### PR TITLE
Add CCache credential

### DIFF
--- a/ssp/credential/ccache.go
+++ b/ssp/credential/ccache.go
@@ -1,0 +1,52 @@
+package credential
+
+import (
+	"github.com/jcmturner/gokrb5/v8/credentials"
+)
+
+type CCache interface {
+	Credential
+	// Keytab.
+	CCache() *credentials.CCache
+}
+
+type ccacheCred struct {
+	userName string
+	realm    string
+	ccache   *credentials.CCache
+}
+
+func (cc *ccacheCred) UserName() string {
+	if cc != nil {
+		return cc.userName
+	}
+	return ""
+}
+
+func (cc *ccacheCred) DomainName() string {
+	if cc != nil {
+		return cc.realm
+	}
+	return ""
+}
+
+func (cc *ccacheCred) Workstation() string {
+	return ""
+}
+
+func (cc *ccacheCred) CCache() *credentials.CCache {
+	if cc != nil && cc.ccache != nil {
+		ccache := *cc.ccache
+		return &ccache
+	}
+	return nil
+}
+
+func NewFromCCache(un string, ccache *credentials.CCache, opts ...Option) CCache {
+	realm, un, _ := parseDomainUserWorkstation(un, opts...)
+	return &ccacheCred{
+		userName: un,
+		realm:    realm,
+		ccache:   ccache,
+	}
+}

--- a/ssp/credential/ccache.go
+++ b/ssp/credential/ccache.go
@@ -6,7 +6,7 @@ import (
 
 type CCache interface {
 	Credential
-	// Keytab.
+	// CCache.
 	CCache() *credentials.CCache
 }
 

--- a/ssp/krb5/authentifier.go
+++ b/ssp/krb5/authentifier.go
@@ -120,6 +120,11 @@ func (a *Authentifier) makeClient(ctx context.Context) (*client.Client, error) {
 		cli.Config.LibDefaults.DefaultTGSEnctypeIDs = []int32{etypeID.RC4_HMAC}
 		cli.Config.LibDefaults.DefaultTktEnctypeIDs = []int32{etypeID.RC4_HMAC}
 		cli.Config.LibDefaults.PermittedEnctypeIDs = []int32{etypeID.RC4_HMAC}
+	} else if ccache, ok := a.Config.Credential.(credential.CCache); ok {
+		cli, err = client.NewFromCCache(ccache.CCache(), a.Config.KRB5Config, a.Config.ClientSettings()...)
+		if err != nil {
+			return nil, fmt.Errorf("client from ccache credential: %w", err)
+		}
 	}
 
 	_, err = cli.IsConfigured()

--- a/ssp/krb5/config.go
+++ b/ssp/krb5/config.go
@@ -164,6 +164,10 @@ func IsValidCredential(cred any) bool {
 		return true
 	}
 
+	if _, ok := cred.(credential.CCache); ok {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
This PR adds a new credential for Kerberos based on an in-memory CCache. This was the easiest way I found to make the library support PKINIT.

Unfortunately, [jcmturner/gokrb5](https://github.com/jcmturner/gokrb5) does not support PKINIT itself and the only way to make it use a TGT I obtained myself is to initialize a client with a CCache but there is no implementation in Go (that I'm aware of) that supports *writing* CCache files, so I have to provide an in-memory CCache.