### PR TITLE
msrpc: wmi: fix wmi parse object array

### DIFF
--- a/examples/wmic.go
+++ b/examples/wmic.go
@@ -192,6 +192,8 @@ func main() {
 		flags |= wmi.QueryFlagType(wmi.GenericFlagTypeForwardOnly)
 	}
 
+	now := time.Now()
+
 	enum, err := svcs.ExecQuery(ctx, &iwbemservices.ExecQueryRequest{
 		This:          &dcom.ORPCThis{Version: srv.COMVersion},
 		QueryLanguage: &oaut.String{Data: "WQL"},
@@ -256,9 +258,7 @@ func main() {
 		return
 	}
 
-	var cls wmio.Class
-
-	now := time.Now()
+	var classes = make(map[string]*wmio.Class)
 
 	if limit > 0 && limit < page {
 		page = limit
@@ -282,7 +282,7 @@ func main() {
 			break
 		}
 
-		oa, err := wmi.UnmarshalObjectArrayWithClass(ret.Buffer, cls)
+		oa, err := wmi.UnmarshalObjectArrayWithClasses(ret.Buffer, classes)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "unmarshal_object_array_with_class", err)
 			return
@@ -292,7 +292,6 @@ func main() {
 			if po.Object.Class != nil {
 				fmt.Println(j(po.Object.Properties()))
 			} else {
-				cls = po.Object.Instance.CurrentClass
 				fmt.Println(j(po.Object.Values()))
 			}
 		}

--- a/msrpc/dcom/wmio/codec.go
+++ b/msrpc/dcom/wmio/codec.go
@@ -157,6 +157,10 @@ func (c *Codec) DecodeWithSize32(sz uint32, data any) error {
 		return nil
 	}
 
+	if sz > uint32(c.buf.Len()) {
+		return c.Errf("decode_with_size32: expected size is greater than actual: %d > %d", sz, c.buf.Len())
+	}
+
 	b := make([]byte, sz)
 	c.ReadData(b)
 

--- a/msrpc/dcom/wmio/wmio.go
+++ b/msrpc/dcom/wmio/wmio.go
@@ -123,7 +123,18 @@ func (o *Object) Values() Values {
 	var values = make(Values)
 
 	for _, prop := range o.Instance.Properties {
-		values[prop.Name] = prop.Value.Value
+		switch value := prop.Value.Value.(type) {
+		case *Object:
+			values[prop.Name] = value.Values()
+		case []*Object:
+			vls := make([]any, len(value))
+			for i := range value {
+				vls[i] = value[i].Values()
+			}
+			values[prop.Name] = vls
+		default:
+			values[prop.Name] = value
+		}
 	}
 
 	return values


### PR DESCRIPTION
fix for smart enum implementation, where classes are preserved across different wco smartenum calls and are allowed to go in any order.
