### PR TITLE
feature: implicit response parameters

### DIFF
--- a/codegen/gen/operation.go
+++ b/codegen/gen/operation.go
@@ -329,13 +329,16 @@ func (p *Generator) GenOperationStruct(ctx context.Context, op *midl.Operation, 
 
 	// generate go structure for the in/out/any parameters.
 	p.Structure(p.OpName(ctx, op, dir), func() {
-		for _, param := range p.GetOutputParamImplicitDependents(ctx, op, dir) {
-			p.P("//", "XXX:", param.Name, "is an implicit input depedency for output parameters")
-			p.NewParamGenerator(ctx, param.Type).GenStructField(ctx, &midl.Field{
-				Name:  param.Name,
-				Attrs: param.Attrs.FieldAttr,
-				Type:  param.Type,
-			})
+		if implicit := p.GetOutputParamImplicitDependents(ctx, op, dir); len(implicit) > 0 {
+			for _, param := range implicit {
+				p.P("//", "XXX:", param.Name, "is an implicit input depedency for output parameters")
+				p.NewParamGenerator(ctx, param.Type).GenStructField(ctx, &midl.Field{
+					Name:  param.Name,
+					Attrs: param.Attrs.FieldAttr,
+					Type:  param.Type,
+				})
+			}
+			p.P()
 		}
 
 		for _, param := range p.OperationParams(ctx, op) {

--- a/msrpc/cmrp/clusapi2/v2/v2.go
+++ b/msrpc/cmrp/clusapi2/v2/v2.go
@@ -9723,7 +9723,8 @@ func (o *QueryValueRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 // QueryValueResponse structure represents the ApiQueryValue operation response
 type QueryValueResponse struct {
 	// XXX: cbData is an implicit input depedency for output parameters
-	DataLength     uint32 `idl:"name:cbData" json:"data_length"`
+	DataLength uint32 `idl:"name:cbData" json:"data_length"`
+
 	ValueType      uint32 `idl:"name:lpValueType" json:"value_type"`
 	Data           []byte `idl:"name:lpData;size_is:(cbData)" json:"data"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -17382,7 +17383,8 @@ func (o *NodeResourceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 // NodeResourceControlResponse structure represents the ApiNodeResourceControl operation response
 type NodeResourceControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -17773,7 +17775,8 @@ func (o *ResourceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 // ResourceControlResponse structure represents the ApiResourceControl operation response
 type ResourceControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -18207,7 +18210,8 @@ func (o *NodeResourceTypeControlRequest) UnmarshalNDR(ctx context.Context, r ndr
 // NodeResourceTypeControlResponse structure represents the ApiNodeResourceTypeControl operation response
 type NodeResourceTypeControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -18616,7 +18620,8 @@ func (o *ResourceTypeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 // ResourceTypeControlResponse structure represents the ApiResourceTypeControl operation response
 type ResourceTypeControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -19032,7 +19037,8 @@ func (o *NodeGroupControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 // NodeGroupControlResponse structure represents the ApiNodeGroupControl operation response
 type NodeGroupControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -19423,7 +19429,8 @@ func (o *GroupControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 // GroupControlResponse structure represents the ApiGroupControl operation response
 type GroupControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -19839,7 +19846,8 @@ func (o *NodeNodeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 // NodeNodeControlResponse structure represents the ApiNodeNodeControl operation response
 type NodeNodeControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -20230,7 +20238,8 @@ func (o *NodeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 // NodeControlResponse structure represents the ApiNodeControl operation response
 type NodeControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -21964,7 +21973,8 @@ func (o *NodeNetworkControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 // NodeNetworkControlResponse structure represents the ApiNodeNetworkControl operation response
 type NodeNetworkControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -22355,7 +22365,8 @@ func (o *NetworkControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 // NetworkControlResponse structure represents the ApiNetworkControl operation response
 type NetworkControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -24132,7 +24143,8 @@ func (o *NodeNetInterfaceControlRequest) UnmarshalNDR(ctx context.Context, r ndr
 // NodeNetInterfaceControlResponse structure represents the ApiNodeNetInterfaceControl operation response
 type NodeNetInterfaceControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -24525,7 +24537,8 @@ func (o *NetInterfaceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 // NetInterfaceControlResponse structure represents the ApiNetInterfaceControl operation response
 type NetInterfaceControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -26280,7 +26293,8 @@ func (o *NodeClusterControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 // NodeClusterControlResponse structure represents the ApiNodeClusterControl operation response
 type NodeClusterControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -26671,7 +26685,8 @@ func (o *ClusterControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 // ClusterControlResponse structure represents the ApiClusterControl operation response
 type ClusterControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -27125,7 +27140,8 @@ func (o *SetServiceAccountPasswordRequest) UnmarshalNDR(ctx context.Context, r n
 // SetServiceAccountPasswordResponse structure represents the ApiSetServiceAccountPassword operation response
 type SetServiceAccountPasswordResponse struct {
 	// XXX: ReturnStatusBufferSize is an implicit input depedency for output parameters
-	ReturnStatusBufferSize    uint32                      `idl:"name:ReturnStatusBufferSize" json:"return_status_buffer_size"`
+	ReturnStatusBufferSize uint32 `idl:"name:ReturnStatusBufferSize" json:"return_status_buffer_size"`
+
 	ReturnStatusBufferPointer []*ClusterSetPasswordStatus `idl:"name:ReturnStatusBufferPtr;size_is:(ReturnStatusBufferSize);length_is:(SizeReturned)" json:"return_status_buffer_pointer"`
 	SizeReturned              uint32                      `idl:"name:SizeReturned" json:"size_returned"`
 	ExpectedBufferSize        uint32                      `idl:"name:ExpectedBufferSize" json:"expected_buffer_size"`

--- a/msrpc/cmrp/clusapi2/v2/v2.go
+++ b/msrpc/cmrp/clusapi2/v2/v2.go
@@ -9722,6 +9722,8 @@ func (o *QueryValueRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 
 // QueryValueResponse structure represents the ApiQueryValue operation response
 type QueryValueResponse struct {
+	// XXX: cbData is an implicit input depedency for output parameters
+	DataLength     uint32 `idl:"name:cbData" json:"data_length"`
 	ValueType      uint32 `idl:"name:lpValueType" json:"value_type"`
 	Data           []byte `idl:"name:lpData;size_is:(cbData)" json:"data"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -9736,6 +9738,11 @@ func (o *QueryValueResponse) xxx_ToOp(ctx context.Context, op *xxx_QueryValueOpe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DataLength == uint32(0) {
+		op.DataLength = o.DataLength
+	}
+
 	op.ValueType = o.ValueType
 	op.Data = o.Data
 	op.RequiredLength = o.RequiredLength
@@ -9747,6 +9754,9 @@ func (o *QueryValueResponse) xxx_FromOp(ctx context.Context, op *xxx_QueryValueO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DataLength = op.DataLength
+
 	o.ValueType = op.ValueType
 	o.Data = op.Data
 	o.RequiredLength = op.RequiredLength
@@ -17371,6 +17381,8 @@ func (o *NodeResourceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // NodeResourceControlResponse structure represents the ApiNodeResourceControl operation response
 type NodeResourceControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -17385,6 +17397,11 @@ func (o *NodeResourceControlResponse) xxx_ToOp(ctx context.Context, op *xxx_Node
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -17396,6 +17413,9 @@ func (o *NodeResourceControlResponse) xxx_FromOp(ctx context.Context, op *xxx_No
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -17752,6 +17772,8 @@ func (o *ResourceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // ResourceControlResponse structure represents the ApiResourceControl operation response
 type ResourceControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -17766,6 +17788,11 @@ func (o *ResourceControlResponse) xxx_ToOp(ctx context.Context, op *xxx_Resource
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -17777,6 +17804,9 @@ func (o *ResourceControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Resour
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -18176,6 +18206,8 @@ func (o *NodeResourceTypeControlRequest) UnmarshalNDR(ctx context.Context, r ndr
 
 // NodeResourceTypeControlResponse structure represents the ApiNodeResourceTypeControl operation response
 type NodeResourceTypeControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -18190,6 +18222,11 @@ func (o *NodeResourceTypeControlResponse) xxx_ToOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -18201,6 +18238,9 @@ func (o *NodeResourceTypeControlResponse) xxx_FromOp(ctx context.Context, op *xx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -18575,6 +18615,8 @@ func (o *ResourceTypeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // ResourceTypeControlResponse structure represents the ApiResourceTypeControl operation response
 type ResourceTypeControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -18589,6 +18631,11 @@ func (o *ResourceTypeControlResponse) xxx_ToOp(ctx context.Context, op *xxx_Reso
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -18600,6 +18647,9 @@ func (o *ResourceTypeControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Re
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -18981,6 +19031,8 @@ func (o *NodeGroupControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // NodeGroupControlResponse structure represents the ApiNodeGroupControl operation response
 type NodeGroupControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -18995,6 +19047,11 @@ func (o *NodeGroupControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeGro
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -19006,6 +19063,9 @@ func (o *NodeGroupControlResponse) xxx_FromOp(ctx context.Context, op *xxx_NodeG
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -19362,6 +19422,8 @@ func (o *GroupControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // GroupControlResponse structure represents the ApiGroupControl operation response
 type GroupControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -19376,6 +19438,11 @@ func (o *GroupControlResponse) xxx_ToOp(ctx context.Context, op *xxx_GroupContro
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -19387,6 +19454,9 @@ func (o *GroupControlResponse) xxx_FromOp(ctx context.Context, op *xxx_GroupCont
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -19768,6 +19838,8 @@ func (o *NodeNodeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // NodeNodeControlResponse structure represents the ApiNodeNodeControl operation response
 type NodeNodeControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -19782,6 +19854,11 @@ func (o *NodeNodeControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeNode
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -19793,6 +19870,9 @@ func (o *NodeNodeControlResponse) xxx_FromOp(ctx context.Context, op *xxx_NodeNo
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -20149,6 +20229,8 @@ func (o *NodeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 
 // NodeControlResponse structure represents the ApiNodeControl operation response
 type NodeControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -20163,6 +20245,11 @@ func (o *NodeControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeControlO
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -20174,6 +20261,9 @@ func (o *NodeControlResponse) xxx_FromOp(ctx context.Context, op *xxx_NodeContro
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -21873,6 +21963,8 @@ func (o *NodeNetworkControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // NodeNetworkControlResponse structure represents the ApiNodeNetworkControl operation response
 type NodeNetworkControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -21887,6 +21979,11 @@ func (o *NodeNetworkControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeN
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -21898,6 +21995,9 @@ func (o *NodeNetworkControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Nod
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -22254,6 +22354,8 @@ func (o *NetworkControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // NetworkControlResponse structure represents the ApiNetworkControl operation response
 type NetworkControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -22268,6 +22370,11 @@ func (o *NetworkControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NetworkCo
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -22279,6 +22386,9 @@ func (o *NetworkControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Network
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -24021,6 +24131,8 @@ func (o *NodeNetInterfaceControlRequest) UnmarshalNDR(ctx context.Context, r ndr
 
 // NodeNetInterfaceControlResponse structure represents the ApiNodeNetInterfaceControl operation response
 type NodeNetInterfaceControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -24035,6 +24147,11 @@ func (o *NodeNetInterfaceControlResponse) xxx_ToOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -24046,6 +24163,9 @@ func (o *NodeNetInterfaceControlResponse) xxx_FromOp(ctx context.Context, op *xx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -24404,6 +24524,8 @@ func (o *NetInterfaceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // NetInterfaceControlResponse structure represents the ApiNetInterfaceControl operation response
 type NetInterfaceControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -24418,6 +24540,11 @@ func (o *NetInterfaceControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NetI
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -24429,6 +24556,9 @@ func (o *NetInterfaceControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Ne
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -26149,6 +26279,8 @@ func (o *NodeClusterControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // NodeClusterControlResponse structure represents the ApiNodeClusterControl operation response
 type NodeClusterControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -26163,6 +26295,11 @@ func (o *NodeClusterControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeC
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -26174,6 +26311,9 @@ func (o *NodeClusterControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Nod
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -26530,6 +26670,8 @@ func (o *ClusterControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // ClusterControlResponse structure represents the ApiClusterControl operation response
 type ClusterControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -26544,6 +26686,11 @@ func (o *ClusterControlResponse) xxx_ToOp(ctx context.Context, op *xxx_ClusterCo
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -26555,6 +26702,9 @@ func (o *ClusterControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Cluster
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -26974,6 +27124,8 @@ func (o *SetServiceAccountPasswordRequest) UnmarshalNDR(ctx context.Context, r n
 
 // SetServiceAccountPasswordResponse structure represents the ApiSetServiceAccountPassword operation response
 type SetServiceAccountPasswordResponse struct {
+	// XXX: ReturnStatusBufferSize is an implicit input depedency for output parameters
+	ReturnStatusBufferSize    uint32                      `idl:"name:ReturnStatusBufferSize" json:"return_status_buffer_size"`
 	ReturnStatusBufferPointer []*ClusterSetPasswordStatus `idl:"name:ReturnStatusBufferPtr;size_is:(ReturnStatusBufferSize);length_is:(SizeReturned)" json:"return_status_buffer_pointer"`
 	SizeReturned              uint32                      `idl:"name:SizeReturned" json:"size_returned"`
 	ExpectedBufferSize        uint32                      `idl:"name:ExpectedBufferSize" json:"expected_buffer_size"`
@@ -26988,6 +27140,11 @@ func (o *SetServiceAccountPasswordResponse) xxx_ToOp(ctx context.Context, op *xx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ReturnStatusBufferSize == uint32(0) {
+		op.ReturnStatusBufferSize = o.ReturnStatusBufferSize
+	}
+
 	op.ReturnStatusBufferPointer = o.ReturnStatusBufferPointer
 	op.SizeReturned = o.SizeReturned
 	op.ExpectedBufferSize = o.ExpectedBufferSize
@@ -26999,6 +27156,9 @@ func (o *SetServiceAccountPasswordResponse) xxx_FromOp(ctx context.Context, op *
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ReturnStatusBufferSize = op.ReturnStatusBufferSize
+
 	o.ReturnStatusBufferPointer = op.ReturnStatusBufferPointer
 	o.SizeReturned = op.SizeReturned
 	o.ExpectedBufferSize = op.ExpectedBufferSize

--- a/msrpc/cmrp/clusapi3/v3/v3.go
+++ b/msrpc/cmrp/clusapi3/v3/v3.go
@@ -13618,7 +13618,8 @@ func (o *QueryValueRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 // QueryValueResponse structure represents the ApiQueryValue operation response
 type QueryValueResponse struct {
 	// XXX: cbData is an implicit input depedency for output parameters
-	DataLength     uint32 `idl:"name:cbData" json:"data_length"`
+	DataLength uint32 `idl:"name:cbData" json:"data_length"`
+
 	ValueType      uint32 `idl:"name:lpValueType" json:"value_type"`
 	Data           []byte `idl:"name:lpData;size_is:(cbData)" json:"data"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -21840,7 +21841,8 @@ func (o *NodeResourceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 // NodeResourceControlResponse structure represents the ApiNodeResourceControl operation response
 type NodeResourceControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -22247,7 +22249,8 @@ func (o *ResourceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 // ResourceControlResponse structure represents the ApiResourceControl operation response
 type ResourceControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -22697,7 +22700,8 @@ func (o *NodeResourceTypeControlRequest) UnmarshalNDR(ctx context.Context, r ndr
 // NodeResourceTypeControlResponse structure represents the ApiNodeResourceTypeControl operation response
 type NodeResourceTypeControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -23122,7 +23126,8 @@ func (o *ResourceTypeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 // ResourceTypeControlResponse structure represents the ApiResourceTypeControl operation response
 type ResourceTypeControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -23554,7 +23559,8 @@ func (o *NodeGroupControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 // NodeGroupControlResponse structure represents the ApiNodeGroupControl operation response
 type NodeGroupControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -23961,7 +23967,8 @@ func (o *GroupControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 // GroupControlResponse structure represents the ApiGroupControl operation response
 type GroupControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -24393,7 +24400,8 @@ func (o *NodeNodeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 // NodeNodeControlResponse structure represents the ApiNodeNodeControl operation response
 type NodeNodeControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -24800,7 +24808,8 @@ func (o *NodeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 // NodeControlResponse structure represents the ApiNodeControl operation response
 type NodeControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -26646,7 +26655,8 @@ func (o *NodeNetworkControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 // NodeNetworkControlResponse structure represents the ApiNodeNetworkControl operation response
 type NodeNetworkControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -27053,7 +27063,8 @@ func (o *NetworkControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 // NetworkControlResponse structure represents the ApiNetworkControl operation response
 type NetworkControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -28942,7 +28953,8 @@ func (o *NodeNetInterfaceControlRequest) UnmarshalNDR(ctx context.Context, r ndr
 // NodeNetInterfaceControlResponse structure represents the ApiNodeNetInterfaceControl operation response
 type NodeNetInterfaceControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -29351,7 +29363,8 @@ func (o *NetInterfaceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 // NetInterfaceControlResponse structure represents the ApiNetInterfaceControl operation response
 type NetInterfaceControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -31218,7 +31231,8 @@ func (o *NodeClusterControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 // NodeClusterControlResponse structure represents the ApiNodeClusterControl operation response
 type NodeClusterControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -31625,7 +31639,8 @@ func (o *ClusterControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 // ClusterControlResponse structure represents the ApiClusterControl operation response
 type ClusterControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -32085,7 +32100,8 @@ func (o *SetServiceAccountPasswordRequest) UnmarshalNDR(ctx context.Context, r n
 // SetServiceAccountPasswordResponse structure represents the ApiSetServiceAccountPassword operation response
 type SetServiceAccountPasswordResponse struct {
 	// XXX: ReturnStatusBufferSize is an implicit input depedency for output parameters
-	ReturnStatusBufferSize    uint32                      `idl:"name:ReturnStatusBufferSize" json:"return_status_buffer_size"`
+	ReturnStatusBufferSize uint32 `idl:"name:ReturnStatusBufferSize" json:"return_status_buffer_size"`
+
 	ReturnStatusBufferPointer []*ClusterSetPasswordStatus `idl:"name:ReturnStatusBufferPtr;size_is:(ReturnStatusBufferSize);length_is:(SizeReturned)" json:"return_status_buffer_pointer"`
 	SizeReturned              uint32                      `idl:"name:SizeReturned" json:"size_returned"`
 	ExpectedBufferSize        uint32                      `idl:"name:ExpectedBufferSize" json:"expected_buffer_size"`
@@ -44699,7 +44715,8 @@ func (o *NodeGroupSetControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 // NodeGroupSetControlResponse structure represents the ApiNodeGroupSetControl operation response
 type NodeGroupSetControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -45109,7 +45126,8 @@ func (o *GroupSetControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 // GroupSetControlResponse structure represents the ApiGroupSetControl operation response
 type GroupSetControlResponse struct {
 	// XXX: nOutBufferSize is an implicit input depedency for output parameters
-	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+	OutBufferSize uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
+
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`

--- a/msrpc/cmrp/clusapi3/v3/v3.go
+++ b/msrpc/cmrp/clusapi3/v3/v3.go
@@ -13617,6 +13617,8 @@ func (o *QueryValueRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 
 // QueryValueResponse structure represents the ApiQueryValue operation response
 type QueryValueResponse struct {
+	// XXX: cbData is an implicit input depedency for output parameters
+	DataLength     uint32 `idl:"name:cbData" json:"data_length"`
 	ValueType      uint32 `idl:"name:lpValueType" json:"value_type"`
 	Data           []byte `idl:"name:lpData;size_is:(cbData)" json:"data"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -13632,6 +13634,11 @@ func (o *QueryValueResponse) xxx_ToOp(ctx context.Context, op *xxx_QueryValueOpe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DataLength == uint32(0) {
+		op.DataLength = o.DataLength
+	}
+
 	op.ValueType = o.ValueType
 	op.Data = o.Data
 	op.RequiredLength = o.RequiredLength
@@ -13644,6 +13651,9 @@ func (o *QueryValueResponse) xxx_FromOp(ctx context.Context, op *xxx_QueryValueO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DataLength = op.DataLength
+
 	o.ValueType = op.ValueType
 	o.Data = op.Data
 	o.RequiredLength = op.RequiredLength
@@ -21829,6 +21839,8 @@ func (o *NodeResourceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // NodeResourceControlResponse structure represents the ApiNodeResourceControl operation response
 type NodeResourceControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -21844,6 +21856,11 @@ func (o *NodeResourceControlResponse) xxx_ToOp(ctx context.Context, op *xxx_Node
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -21856,6 +21873,9 @@ func (o *NodeResourceControlResponse) xxx_FromOp(ctx context.Context, op *xxx_No
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -22226,6 +22246,8 @@ func (o *ResourceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // ResourceControlResponse structure represents the ApiResourceControl operation response
 type ResourceControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -22241,6 +22263,11 @@ func (o *ResourceControlResponse) xxx_ToOp(ctx context.Context, op *xxx_Resource
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -22253,6 +22280,9 @@ func (o *ResourceControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Resour
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -22666,6 +22696,8 @@ func (o *NodeResourceTypeControlRequest) UnmarshalNDR(ctx context.Context, r ndr
 
 // NodeResourceTypeControlResponse structure represents the ApiNodeResourceTypeControl operation response
 type NodeResourceTypeControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -22681,6 +22713,11 @@ func (o *NodeResourceTypeControlResponse) xxx_ToOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -22693,6 +22730,9 @@ func (o *NodeResourceTypeControlResponse) xxx_FromOp(ctx context.Context, op *xx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -23081,6 +23121,8 @@ func (o *ResourceTypeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // ResourceTypeControlResponse structure represents the ApiResourceTypeControl operation response
 type ResourceTypeControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -23096,6 +23138,11 @@ func (o *ResourceTypeControlResponse) xxx_ToOp(ctx context.Context, op *xxx_Reso
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -23108,6 +23155,9 @@ func (o *ResourceTypeControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Re
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -23503,6 +23553,8 @@ func (o *NodeGroupControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // NodeGroupControlResponse structure represents the ApiNodeGroupControl operation response
 type NodeGroupControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -23518,6 +23570,11 @@ func (o *NodeGroupControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeGro
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -23530,6 +23587,9 @@ func (o *NodeGroupControlResponse) xxx_FromOp(ctx context.Context, op *xxx_NodeG
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -23900,6 +23960,8 @@ func (o *GroupControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // GroupControlResponse structure represents the ApiGroupControl operation response
 type GroupControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -23915,6 +23977,11 @@ func (o *GroupControlResponse) xxx_ToOp(ctx context.Context, op *xxx_GroupContro
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -23927,6 +23994,9 @@ func (o *GroupControlResponse) xxx_FromOp(ctx context.Context, op *xxx_GroupCont
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -24322,6 +24392,8 @@ func (o *NodeNodeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // NodeNodeControlResponse structure represents the ApiNodeNodeControl operation response
 type NodeNodeControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -24337,6 +24409,11 @@ func (o *NodeNodeControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeNode
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -24349,6 +24426,9 @@ func (o *NodeNodeControlResponse) xxx_FromOp(ctx context.Context, op *xxx_NodeNo
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -24719,6 +24799,8 @@ func (o *NodeControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 
 // NodeControlResponse structure represents the ApiNodeControl operation response
 type NodeControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -24734,6 +24816,11 @@ func (o *NodeControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeControlO
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -24746,6 +24833,9 @@ func (o *NodeControlResponse) xxx_FromOp(ctx context.Context, op *xxx_NodeContro
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -26555,6 +26645,8 @@ func (o *NodeNetworkControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // NodeNetworkControlResponse structure represents the ApiNodeNetworkControl operation response
 type NodeNetworkControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -26570,6 +26662,11 @@ func (o *NodeNetworkControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeN
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -26582,6 +26679,9 @@ func (o *NodeNetworkControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Nod
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -26952,6 +27052,8 @@ func (o *NetworkControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // NetworkControlResponse structure represents the ApiNetworkControl operation response
 type NetworkControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -26967,6 +27069,11 @@ func (o *NetworkControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NetworkCo
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -26979,6 +27086,9 @@ func (o *NetworkControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Network
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -28831,6 +28941,8 @@ func (o *NodeNetInterfaceControlRequest) UnmarshalNDR(ctx context.Context, r ndr
 
 // NodeNetInterfaceControlResponse structure represents the ApiNodeNetInterfaceControl operation response
 type NodeNetInterfaceControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -28846,6 +28958,11 @@ func (o *NodeNetInterfaceControlResponse) xxx_ToOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -28858,6 +28975,9 @@ func (o *NodeNetInterfaceControlResponse) xxx_FromOp(ctx context.Context, op *xx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -29230,6 +29350,8 @@ func (o *NetInterfaceControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // NetInterfaceControlResponse structure represents the ApiNetInterfaceControl operation response
 type NetInterfaceControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -29245,6 +29367,11 @@ func (o *NetInterfaceControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NetI
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -29257,6 +29384,9 @@ func (o *NetInterfaceControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Ne
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -31087,6 +31217,8 @@ func (o *NodeClusterControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // NodeClusterControlResponse structure represents the ApiNodeClusterControl operation response
 type NodeClusterControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -31102,6 +31234,11 @@ func (o *NodeClusterControlResponse) xxx_ToOp(ctx context.Context, op *xxx_NodeC
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -31114,6 +31251,9 @@ func (o *NodeClusterControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Nod
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -31484,6 +31624,8 @@ func (o *ClusterControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // ClusterControlResponse structure represents the ApiClusterControl operation response
 type ClusterControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -31499,6 +31641,11 @@ func (o *ClusterControlResponse) xxx_ToOp(ctx context.Context, op *xxx_ClusterCo
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -31511,6 +31658,9 @@ func (o *ClusterControlResponse) xxx_FromOp(ctx context.Context, op *xxx_Cluster
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -31934,6 +32084,8 @@ func (o *SetServiceAccountPasswordRequest) UnmarshalNDR(ctx context.Context, r n
 
 // SetServiceAccountPasswordResponse structure represents the ApiSetServiceAccountPassword operation response
 type SetServiceAccountPasswordResponse struct {
+	// XXX: ReturnStatusBufferSize is an implicit input depedency for output parameters
+	ReturnStatusBufferSize    uint32                      `idl:"name:ReturnStatusBufferSize" json:"return_status_buffer_size"`
 	ReturnStatusBufferPointer []*ClusterSetPasswordStatus `idl:"name:ReturnStatusBufferPtr;size_is:(ReturnStatusBufferSize);length_is:(SizeReturned)" json:"return_status_buffer_pointer"`
 	SizeReturned              uint32                      `idl:"name:SizeReturned" json:"size_returned"`
 	ExpectedBufferSize        uint32                      `idl:"name:ExpectedBufferSize" json:"expected_buffer_size"`
@@ -31948,6 +32100,11 @@ func (o *SetServiceAccountPasswordResponse) xxx_ToOp(ctx context.Context, op *xx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ReturnStatusBufferSize == uint32(0) {
+		op.ReturnStatusBufferSize = o.ReturnStatusBufferSize
+	}
+
 	op.ReturnStatusBufferPointer = o.ReturnStatusBufferPointer
 	op.SizeReturned = o.SizeReturned
 	op.ExpectedBufferSize = o.ExpectedBufferSize
@@ -31959,6 +32116,9 @@ func (o *SetServiceAccountPasswordResponse) xxx_FromOp(ctx context.Context, op *
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ReturnStatusBufferSize = op.ReturnStatusBufferSize
+
 	o.ReturnStatusBufferPointer = op.ReturnStatusBufferPointer
 	o.SizeReturned = op.SizeReturned
 	o.ExpectedBufferSize = op.ExpectedBufferSize
@@ -44538,6 +44698,8 @@ func (o *NodeGroupSetControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // NodeGroupSetControlResponse structure represents the ApiNodeGroupSetControl operation response
 type NodeGroupSetControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -44553,6 +44715,11 @@ func (o *NodeGroupSetControlResponse) xxx_ToOp(ctx context.Context, op *xxx_Node
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -44565,6 +44732,9 @@ func (o *NodeGroupSetControlResponse) xxx_FromOp(ctx context.Context, op *xxx_No
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength
@@ -44938,6 +45108,8 @@ func (o *GroupSetControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // GroupSetControlResponse structure represents the ApiGroupSetControl operation response
 type GroupSetControlResponse struct {
+	// XXX: nOutBufferSize is an implicit input depedency for output parameters
+	OutBufferSize  uint32 `idl:"name:nOutBufferSize" json:"out_buffer_size"`
 	OutBuffer      []byte `idl:"name:lpOutBuffer;size_is:(nOutBufferSize);length_is:(lpBytesReturned)" json:"out_buffer"`
 	BytesReturned  uint32 `idl:"name:lpBytesReturned" json:"bytes_returned"`
 	RequiredLength uint32 `idl:"name:lpcbRequired" json:"required_length"`
@@ -44953,6 +45125,11 @@ func (o *GroupSetControlResponse) xxx_ToOp(ctx context.Context, op *xxx_GroupSet
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutBufferSize == uint32(0) {
+		op.OutBufferSize = o.OutBufferSize
+	}
+
 	op.OutBuffer = o.OutBuffer
 	op.BytesReturned = o.BytesReturned
 	op.RequiredLength = o.RequiredLength
@@ -44965,6 +45142,9 @@ func (o *GroupSetControlResponse) xxx_FromOp(ctx context.Context, op *xxx_GroupS
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutBufferSize = op.OutBufferSize
+
 	o.OutBuffer = op.OutBuffer
 	o.BytesReturned = op.BytesReturned
 	o.RequiredLength = op.RequiredLength

--- a/msrpc/dcom/coma/iregister/v0/v0.go
+++ b/msrpc/dcom/coma/iregister/v0/v0.go
@@ -969,6 +969,8 @@ func (o *RegisterModuleRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // RegisterModuleResponse structure represents the RegisterModule operation response
 type RegisterModuleResponse struct {
+	// XXX: cModules is an implicit input depedency for output parameters
+	ModulesCount uint32 `idl:"name:cModules" json:"modules_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppModuleFlags:  A pointer to a variable that, upon successful completion, SHOULD
@@ -1006,6 +1008,11 @@ func (o *RegisterModuleResponse) xxx_ToOp(ctx context.Context, op *xxx_RegisterM
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ModulesCount == uint32(0) {
+		op.ModulesCount = o.ModulesCount
+	}
+
 	op.That = o.That
 	op.ModuleFlags = o.ModuleFlags
 	op.ResultsCount = o.ResultsCount
@@ -1021,6 +1028,9 @@ func (o *RegisterModuleResponse) xxx_FromOp(ctx context.Context, op *xxx_Registe
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ModulesCount = op.ModulesCount
+
 	o.That = op.That
 	o.ModuleFlags = op.ModuleFlags
 	o.ResultsCount = op.ResultsCount

--- a/msrpc/dcom/coma/iregister/v0/v0.go
+++ b/msrpc/dcom/coma/iregister/v0/v0.go
@@ -971,6 +971,7 @@ func (o *RegisterModuleRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 type RegisterModuleResponse struct {
 	// XXX: cModules is an implicit input depedency for output parameters
 	ModulesCount uint32 `idl:"name:cModules" json:"modules_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppModuleFlags:  A pointer to a variable that, upon successful completion, SHOULD

--- a/msrpc/dcom/coma/iregister2/v0/v0.go
+++ b/msrpc/dcom/coma/iregister2/v0/v0.go
@@ -1837,6 +1837,8 @@ func (o *RegisterModule2Request) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // RegisterModule2Response structure represents the RegisterModule2 operation response
 type RegisterModule2Response struct {
+	// XXX: cModules is an implicit input depedency for output parameters
+	ModulesCount uint32 `idl:"name:cModules" json:"modules_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppModuleFlags:  A pointer to a variable that, upon successful completion, SHOULD
@@ -1874,6 +1876,11 @@ func (o *RegisterModule2Response) xxx_ToOp(ctx context.Context, op *xxx_Register
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ModulesCount == uint32(0) {
+		op.ModulesCount = o.ModulesCount
+	}
+
 	op.That = o.That
 	op.ModuleFlags = o.ModuleFlags
 	op.ResultsCount = o.ResultsCount
@@ -1889,6 +1896,9 @@ func (o *RegisterModule2Response) xxx_FromOp(ctx context.Context, op *xxx_Regist
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ModulesCount = op.ModulesCount
+
 	o.That = op.That
 	o.ModuleFlags = op.ModuleFlags
 	o.ResultsCount = op.ResultsCount

--- a/msrpc/dcom/coma/iregister2/v0/v0.go
+++ b/msrpc/dcom/coma/iregister2/v0/v0.go
@@ -1839,6 +1839,7 @@ func (o *RegisterModule2Request) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 type RegisterModule2Response struct {
 	// XXX: cModules is an implicit input depedency for output parameters
 	ModulesCount uint32 `idl:"name:cModules" json:"modules_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppModuleFlags:  A pointer to a variable that, upon successful completion, SHOULD

--- a/msrpc/dcom/comev/ienumeventobject/v0/v0.go
+++ b/msrpc/dcom/comev/ienumeventobject/v0/v0.go
@@ -781,6 +781,7 @@ func (o *NextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type NextResponse struct {
 	// XXX: cReqElem is an implicit input depedency for output parameters
 	RequestElemCount uint32 `idl:"name:cReqElem" json:"request_elem_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppInterface: If the function returns a success HRESULT, this MUST contain an array

--- a/msrpc/dcom/comev/ienumeventobject/v0/v0.go
+++ b/msrpc/dcom/comev/ienumeventobject/v0/v0.go
@@ -779,6 +779,8 @@ func (o *NextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // NextResponse structure represents the Next operation response
 type NextResponse struct {
+	// XXX: cReqElem is an implicit input depedency for output parameters
+	RequestElemCount uint32 `idl:"name:cReqElem" json:"request_elem_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppInterface: If the function returns a success HRESULT, this MUST contain an array
@@ -801,6 +803,11 @@ func (o *NextResponse) xxx_ToOp(ctx context.Context, op *xxx_NextOperation) *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.RequestElemCount == uint32(0) {
+		op.RequestElemCount = o.RequestElemCount
+	}
+
 	op.That = o.That
 	op.Interface = o.Interface
 	op.ReturnElemCount = o.ReturnElemCount
@@ -812,6 +819,9 @@ func (o *NextResponse) xxx_FromOp(ctx context.Context, op *xxx_NextOperation) {
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.RequestElemCount = op.RequestElemCount
+
 	o.That = op.That
 	o.Interface = op.Interface
 	o.ReturnElemCount = op.ReturnElemCount

--- a/msrpc/dcom/csra/icertadmind/v0/v0.go
+++ b/msrpc/dcom/csra/icertadmind/v0/v0.go
@@ -7778,6 +7778,8 @@ func (o *BackupReadFileRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // BackupReadFileResponse structure represents the BackupReadFile operation response
 type BackupReadFileResponse struct {
+	// XXX: cbBuffer is an implicit input depedency for output parameters
+	BufferLength int32 `idl:"name:cbBuffer" json:"buffer_length"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbBuffer: A pointer to the buffer that receives the read data.
@@ -7795,6 +7797,11 @@ func (o *BackupReadFileResponse) xxx_ToOp(ctx context.Context, op *xxx_BackupRea
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == int32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.That = o.That
 	op.Buffer = o.Buffer
 	op.ReadLength = o.ReadLength
@@ -7806,6 +7813,9 @@ func (o *BackupReadFileResponse) xxx_FromOp(ctx context.Context, op *xxx_BackupR
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.That = op.That
 	o.Buffer = op.Buffer
 	o.ReadLength = op.ReadLength

--- a/msrpc/dcom/csra/icertadmind/v0/v0.go
+++ b/msrpc/dcom/csra/icertadmind/v0/v0.go
@@ -7780,6 +7780,7 @@ func (o *BackupReadFileRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 type BackupReadFileResponse struct {
 	// XXX: cbBuffer is an implicit input depedency for output parameters
 	BufferLength int32 `idl:"name:cbBuffer" json:"buffer_length"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbBuffer: A pointer to the buffer that receives the read data.

--- a/msrpc/dcom/csvp/iclusterstorage2/v0/v0.go
+++ b/msrpc/dcom/csvp/iclusterstorage2/v0/v0.go
@@ -1871,6 +1871,7 @@ func (o *RawReadRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type RawReadResponse struct {
 	// XXX: cbData is an implicit input depedency for output parameters
 	DataLength uint32 `idl:"name:cbData" json:"data_length"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbData: The data to read from the disk.
@@ -5083,6 +5084,7 @@ func (o *GetUniqueIDsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 type GetUniqueIDsResponse struct {
 	// XXX: cbData is an implicit input depedency for output parameters
 	DataLength uint32 `idl:"name:cbData" json:"data_length"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbData: The output buffer for the device ID data.
@@ -8812,6 +8814,7 @@ func (o *GetDSMsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type GetDSMsResponse struct {
 	// XXX: Size is an implicit input depedency for output parameters
 	Size uint32 `idl:"name:Size" json:"size"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That            *dcom.ORPCThat `idl:"name:That" json:"that"`
 	ResgisteredDSMs uint32         `idl:"name:pResgisteredDsms" json:"resgistered_dsms"`

--- a/msrpc/dcom/csvp/iclusterstorage2/v0/v0.go
+++ b/msrpc/dcom/csvp/iclusterstorage2/v0/v0.go
@@ -1869,6 +1869,8 @@ func (o *RawReadRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // RawReadResponse structure represents the CprepDiskRawRead operation response
 type RawReadResponse struct {
+	// XXX: cbData is an implicit input depedency for output parameters
+	DataLength uint32 `idl:"name:cbData" json:"data_length"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbData: The data to read from the disk.
@@ -1889,6 +1891,11 @@ func (o *RawReadResponse) xxx_ToOp(ctx context.Context, op *xxx_RawReadOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DataLength == uint32(0) {
+		op.DataLength = o.DataLength
+	}
+
 	op.That = o.That
 	op.Data = o.Data
 	op.DataReadLength = o.DataReadLength
@@ -1901,6 +1908,9 @@ func (o *RawReadResponse) xxx_FromOp(ctx context.Context, op *xxx_RawReadOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DataLength = op.DataLength
+
 	o.That = op.That
 	o.Data = op.Data
 	o.DataReadLength = op.DataReadLength
@@ -5071,6 +5081,8 @@ func (o *GetUniqueIDsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // GetUniqueIDsResponse structure represents the CprepDiskGetUniqueIds operation response
 type GetUniqueIDsResponse struct {
+	// XXX: cbData is an implicit input depedency for output parameters
+	DataLength uint32 `idl:"name:cbData" json:"data_length"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbData: The output buffer for the device ID data.
@@ -5092,6 +5104,11 @@ func (o *GetUniqueIDsResponse) xxx_ToOp(ctx context.Context, op *xxx_GetUniqueID
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DataLength == uint32(0) {
+		op.DataLength = o.DataLength
+	}
+
 	op.That = o.That
 	op.Data = o.Data
 	op.DataOutLength = o.DataOutLength
@@ -5104,6 +5121,9 @@ func (o *GetUniqueIDsResponse) xxx_FromOp(ctx context.Context, op *xxx_GetUnique
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DataLength = op.DataLength
+
 	o.That = op.That
 	o.Data = op.Data
 	o.DataOutLength = op.DataOutLength
@@ -8790,6 +8810,8 @@ func (o *GetDSMsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // GetDSMsResponse structure represents the CprepDiskGetDsms operation response
 type GetDSMsResponse struct {
+	// XXX: Size is an implicit input depedency for output parameters
+	Size uint32 `idl:"name:Size" json:"size"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That            *dcom.ORPCThat `idl:"name:That" json:"that"`
 	ResgisteredDSMs uint32         `idl:"name:pResgisteredDsms" json:"resgistered_dsms"`
@@ -8807,6 +8829,11 @@ func (o *GetDSMsResponse) xxx_ToOp(ctx context.Context, op *xxx_GetDSMsOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Size == uint32(0) {
+		op.Size = o.Size
+	}
+
 	op.That = o.That
 	op.ResgisteredDSMs = o.ResgisteredDSMs
 	op.RegisteredDSMs = o.RegisteredDSMs
@@ -8818,6 +8845,9 @@ func (o *GetDSMsResponse) xxx_FromOp(ctx context.Context, op *xxx_GetDSMsOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Size = op.Size
+
 	o.That = op.That
 	o.ResgisteredDSMs = op.ResgisteredDSMs
 	o.RegisteredDSMs = op.RegisteredDSMs

--- a/msrpc/dcom/iactivation/v0/v0.go
+++ b/msrpc/dcom/iactivation/v0/v0.go
@@ -848,6 +848,7 @@ func (o *RemoteActivationRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type RemoteActivationResponse struct {
 	// XXX: Interfaces is an implicit input depedency for output parameters
 	Interfaces uint32 `idl:"name:Interfaces" json:"interfaces"`
+
 	// ORPCthat:  This MUST contain an ORPCTHAT. The extensions field MUST be set to NULL.
 	ORPCThat *dcom.ORPCThat `idl:"name:ORPCthat" json:"orpc_that"`
 	// pOxid: This MUST contain an OXID value identifying the object exporter containing

--- a/msrpc/dcom/iactivation/v0/v0.go
+++ b/msrpc/dcom/iactivation/v0/v0.go
@@ -846,6 +846,8 @@ func (o *RemoteActivationRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // RemoteActivationResponse structure represents the RemoteActivation operation response
 type RemoteActivationResponse struct {
+	// XXX: Interfaces is an implicit input depedency for output parameters
+	Interfaces uint32 `idl:"name:Interfaces" json:"interfaces"`
 	// ORPCthat:  This MUST contain an ORPCTHAT. The extensions field MUST be set to NULL.
 	ORPCThat *dcom.ORPCThat `idl:"name:ORPCthat" json:"orpc_that"`
 	// pOxid: This MUST contain an OXID value identifying the object exporter containing
@@ -888,6 +890,11 @@ func (o *RemoteActivationResponse) xxx_ToOp(ctx context.Context, op *xxx_RemoteA
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Interfaces == uint32(0) {
+		op.Interfaces = o.Interfaces
+	}
+
 	op.ORPCThat = o.ORPCThat
 	op.OXID = o.OXID
 	op.OXIDBindings = o.OXIDBindings
@@ -905,6 +912,9 @@ func (o *RemoteActivationResponse) xxx_FromOp(ctx context.Context, op *xxx_Remot
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Interfaces = op.Interfaces
+
 	o.ORPCThat = op.ORPCThat
 	o.OXID = op.OXID
 	o.OXIDBindings = op.OXIDBindings

--- a/msrpc/dcom/iiss/iiisservicecontrol/v0/v0.go
+++ b/msrpc/dcom/iiss/iiisservicecontrol/v0/v0.go
@@ -1363,6 +1363,7 @@ func (o *StatusRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type StatusResponse struct {
 	// XXX: dwBufferSize is an implicit input depedency for output parameters
 	BufferSize uint32 `idl:"name:dwBufferSize" json:"buffer_size"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbBuffer: An array of unsigned chars that will be filled with information about the

--- a/msrpc/dcom/iiss/iiisservicecontrol/v0/v0.go
+++ b/msrpc/dcom/iiss/iiisservicecontrol/v0/v0.go
@@ -1361,6 +1361,8 @@ func (o *StatusRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // StatusResponse structure represents the Status operation response
 type StatusResponse struct {
+	// XXX: dwBufferSize is an implicit input depedency for output parameters
+	BufferSize uint32 `idl:"name:dwBufferSize" json:"buffer_size"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbBuffer: An array of unsigned chars that will be filled with information about the
@@ -1384,6 +1386,11 @@ func (o *StatusResponse) xxx_ToOp(ctx context.Context, op *xxx_StatusOperation) 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferSize == uint32(0) {
+		op.BufferSize = o.BufferSize
+	}
+
 	op.That = o.That
 	op.Buffer = o.Buffer
 	op.RequiredBufferSize = o.RequiredBufferSize
@@ -1396,6 +1403,9 @@ func (o *StatusResponse) xxx_FromOp(ctx context.Context, op *xxx_StatusOperation
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferSize = op.BufferSize
+
 	o.That = op.That
 	o.Buffer = op.Buffer
 	o.RequiredBufferSize = op.RequiredBufferSize

--- a/msrpc/dcom/imsa/imsadminbase3w/v0/v0.go
+++ b/msrpc/dcom/imsa/imsadminbase3w/v0/v0.go
@@ -638,6 +638,7 @@ func (o *GetChildPathsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 type GetChildPathsResponse struct {
 	// XXX: cchMDBufferSize is an implicit input depedency for output parameters
 	BufferSize uint32 `idl:"name:cchMDBufferSize" json:"buffer_size"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pszBuffer: A pointer to a Unicode character buffer passed in by the caller to store

--- a/msrpc/dcom/imsa/imsadminbase3w/v0/v0.go
+++ b/msrpc/dcom/imsa/imsadminbase3w/v0/v0.go
@@ -636,6 +636,8 @@ func (o *GetChildPathsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 
 // GetChildPathsResponse structure represents the GetChildPaths operation response
 type GetChildPathsResponse struct {
+	// XXX: cchMDBufferSize is an implicit input depedency for output parameters
+	BufferSize uint32 `idl:"name:cchMDBufferSize" json:"buffer_size"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pszBuffer: A pointer to a Unicode character buffer passed in by the caller to store
@@ -657,6 +659,11 @@ func (o *GetChildPathsResponse) xxx_ToOp(ctx context.Context, op *xxx_GetChildPa
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferSize == uint32(0) {
+		op.BufferSize = o.BufferSize
+	}
+
 	op.That = o.That
 	op.Buffer = o.Buffer
 	op.RequiredBufferSize = o.RequiredBufferSize
@@ -668,6 +675,9 @@ func (o *GetChildPathsResponse) xxx_FromOp(ctx context.Context, op *xxx_GetChild
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferSize = op.BufferSize
+
 	o.That = op.That
 	o.Buffer = op.Buffer
 	o.RequiredBufferSize = op.RequiredBufferSize

--- a/msrpc/dcom/imsa/imsadminbasew/v0/v0.go
+++ b/msrpc/dcom/imsa/imsadminbasew/v0/v0.go
@@ -6338,6 +6338,8 @@ func (o *GetDataPathsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // GetDataPathsResponse structure represents the GetDataPaths operation response
 type GetDataPathsResponse struct {
+	// XXX: dwMDBufferSize is an implicit input depedency for output parameters
+	BufferSize uint32 `idl:"name:dwMDBufferSize" json:"buffer_size"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pszBuffer: A pointer to a buffer that contains the retrieved data. If the method
@@ -6359,6 +6361,11 @@ func (o *GetDataPathsResponse) xxx_ToOp(ctx context.Context, op *xxx_GetDataPath
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferSize == uint32(0) {
+		op.BufferSize = o.BufferSize
+	}
+
 	op.That = o.That
 	op.Buffer = o.Buffer
 	op.RequiredBufferSize = o.RequiredBufferSize
@@ -6370,6 +6377,9 @@ func (o *GetDataPathsResponse) xxx_FromOp(ctx context.Context, op *xxx_GetDataPa
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferSize = op.BufferSize
+
 	o.That = op.That
 	o.Buffer = op.Buffer
 	o.RequiredBufferSize = op.RequiredBufferSize

--- a/msrpc/dcom/imsa/imsadminbasew/v0/v0.go
+++ b/msrpc/dcom/imsa/imsadminbasew/v0/v0.go
@@ -6340,6 +6340,7 @@ func (o *GetDataPathsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 type GetDataPathsResponse struct {
 	// XXX: dwMDBufferSize is an implicit input depedency for output parameters
 	BufferSize uint32 `idl:"name:dwMDBufferSize" json:"buffer_size"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pszBuffer: A pointer to a buffer that contains the retrieved data. If the method

--- a/msrpc/dcom/iremunknown/v0/v0.go
+++ b/msrpc/dcom/iremunknown/v0/v0.go
@@ -544,6 +544,8 @@ func (o *RemoteQueryInterfaceRequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 
 // RemoteQueryInterfaceResponse structure represents the RemQueryInterface operation response
 type RemoteQueryInterfaceResponse struct {
+	// XXX: cIids is an implicit input depedency for output parameters
+	IIDsCount uint16 `idl:"name:cIids" json:"iids_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppQIResults: This MUST contain an array of REMQIRESULT structures containing the
@@ -560,6 +562,11 @@ func (o *RemoteQueryInterfaceResponse) xxx_ToOp(ctx context.Context, op *xxx_Rem
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.IIDsCount == uint16(0) {
+		op.IIDsCount = o.IIDsCount
+	}
+
 	op.That = o.That
 	op.QueryInterfaceResults = o.QueryInterfaceResults
 	op.Return = o.Return
@@ -570,6 +577,9 @@ func (o *RemoteQueryInterfaceResponse) xxx_FromOp(ctx context.Context, op *xxx_R
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.IIDsCount = op.IIDsCount
+
 	o.That = op.That
 	o.QueryInterfaceResults = op.QueryInterfaceResults
 	o.Return = op.Return
@@ -868,6 +878,8 @@ func (o *RemoteAddReferenceRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // RemoteAddReferenceResponse structure represents the RemAddRef operation response
 type RemoteAddReferenceResponse struct {
+	// XXX: cInterfaceRefs is an implicit input depedency for output parameters
+	InterfaceReferencesCount uint16 `idl:"name:cInterfaceRefs" json:"interface_references_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pResults:  This MUST contain an array of HRESULTs specifying the respective success
@@ -884,6 +896,11 @@ func (o *RemoteAddReferenceResponse) xxx_ToOp(ctx context.Context, op *xxx_Remot
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InterfaceReferencesCount == uint16(0) {
+		op.InterfaceReferencesCount = o.InterfaceReferencesCount
+	}
+
 	op.That = o.That
 	op.Results = o.Results
 	op.Return = o.Return
@@ -894,6 +911,9 @@ func (o *RemoteAddReferenceResponse) xxx_FromOp(ctx context.Context, op *xxx_Rem
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InterfaceReferencesCount = op.InterfaceReferencesCount
+
 	o.That = op.That
 	o.Results = op.Results
 	o.Return = op.Return

--- a/msrpc/dcom/iremunknown/v0/v0.go
+++ b/msrpc/dcom/iremunknown/v0/v0.go
@@ -546,6 +546,7 @@ func (o *RemoteQueryInterfaceRequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 type RemoteQueryInterfaceResponse struct {
 	// XXX: cIids is an implicit input depedency for output parameters
 	IIDsCount uint16 `idl:"name:cIids" json:"iids_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppQIResults: This MUST contain an array of REMQIRESULT structures containing the
@@ -880,6 +881,7 @@ func (o *RemoteAddReferenceRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 type RemoteAddReferenceResponse struct {
 	// XXX: cInterfaceRefs is an implicit input depedency for output parameters
 	InterfaceReferencesCount uint16 `idl:"name:cInterfaceRefs" json:"interface_references_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pResults:  This MUST contain an array of HRESULTs specifying the respective success

--- a/msrpc/dcom/iremunknown2/v0/v0.go
+++ b/msrpc/dcom/iremunknown2/v0/v0.go
@@ -524,6 +524,8 @@ func (o *RemoteQueryInterface2Request) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // RemoteQueryInterface2Response structure represents the RemQueryInterface2 operation response
 type RemoteQueryInterface2Response struct {
+	// XXX: cIids is an implicit input depedency for output parameters
+	IIDsCount uint16 `idl:"name:cIids" json:"iids_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// phr:  This MUST contain an array of HRESULTs specifying the respective success or
@@ -543,6 +545,11 @@ func (o *RemoteQueryInterface2Response) xxx_ToOp(ctx context.Context, op *xxx_Re
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.IIDsCount == uint16(0) {
+		op.IIDsCount = o.IIDsCount
+	}
+
 	op.That = o.That
 	op.HResult = o.HResult
 	op.Interface = o.Interface
@@ -554,6 +561,9 @@ func (o *RemoteQueryInterface2Response) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.IIDsCount = op.IIDsCount
+
 	o.That = op.That
 	o.HResult = op.HResult
 	o.Interface = op.Interface

--- a/msrpc/dcom/iremunknown2/v0/v0.go
+++ b/msrpc/dcom/iremunknown2/v0/v0.go
@@ -526,6 +526,7 @@ func (o *RemoteQueryInterface2Request) UnmarshalNDR(ctx context.Context, r ndr.R
 type RemoteQueryInterface2Response struct {
 	// XXX: cIids is an implicit input depedency for output parameters
 	IIDsCount uint16 `idl:"name:cIids" json:"iids_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// phr:  This MUST contain an array of HRESULTs specifying the respective success or

--- a/msrpc/dcom/oaut/idispatch/v0/v0.go
+++ b/msrpc/dcom/oaut/idispatch/v0/v0.go
@@ -1255,6 +1255,8 @@ func (o *GetIDsOfNamesRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 
 // GetIDsOfNamesResponse structure represents the GetIDsOfNames operation response
 type GetIDsOfNamesResponse struct {
+	// XXX: cNames is an implicit input depedency for output parameters
+	NamesCount uint32 `idl:"name:cNames" json:"names_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// rgDispId: MUST be an array of DISPIDs that are filled in by the server. Each DISPID
@@ -1271,6 +1273,11 @@ func (o *GetIDsOfNamesResponse) xxx_ToOp(ctx context.Context, op *xxx_GetIDsOfNa
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.NamesCount == uint32(0) {
+		op.NamesCount = o.NamesCount
+	}
+
 	op.That = o.That
 	op.DispatchID = o.DispatchID
 	op.Return = o.Return
@@ -1281,6 +1288,9 @@ func (o *GetIDsOfNamesResponse) xxx_FromOp(ctx context.Context, op *xxx_GetIDsOf
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.NamesCount = op.NamesCount
+
 	o.That = op.That
 	o.DispatchID = op.DispatchID
 	o.Return = op.Return
@@ -1926,6 +1936,8 @@ func (o *InvokeRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // InvokeResponse structure represents the Invoke operation response
 type InvokeResponse struct {
+	// XXX: cVarRef is an implicit input depedency for output parameters
+	VarReferenceCount uint32 `idl:"name:cVarRef" json:"var_reference_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pVarResult: MUST point to a VARIANT that will be filled with the result of the method
@@ -1955,6 +1967,11 @@ func (o *InvokeResponse) xxx_ToOp(ctx context.Context, op *xxx_InvokeOperation) 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.VarReferenceCount == uint32(0) {
+		op.VarReferenceCount = o.VarReferenceCount
+	}
+
 	op.That = o.That
 	op.VarResult = o.VarResult
 	op.ExceptionInfo = o.ExceptionInfo
@@ -1968,6 +1985,9 @@ func (o *InvokeResponse) xxx_FromOp(ctx context.Context, op *xxx_InvokeOperation
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.VarReferenceCount = op.VarReferenceCount
+
 	o.That = op.That
 	o.VarResult = op.VarResult
 	o.ExceptionInfo = op.ExceptionInfo

--- a/msrpc/dcom/oaut/idispatch/v0/v0.go
+++ b/msrpc/dcom/oaut/idispatch/v0/v0.go
@@ -1257,6 +1257,7 @@ func (o *GetIDsOfNamesRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 type GetIDsOfNamesResponse struct {
 	// XXX: cNames is an implicit input depedency for output parameters
 	NamesCount uint32 `idl:"name:cNames" json:"names_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// rgDispId: MUST be an array of DISPIDs that are filled in by the server. Each DISPID
@@ -1938,6 +1939,7 @@ func (o *InvokeRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type InvokeResponse struct {
 	// XXX: cVarRef is an implicit input depedency for output parameters
 	VarReferenceCount uint32 `idl:"name:cVarRef" json:"var_reference_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pVarResult: MUST point to a VARIANT that will be filled with the result of the method

--- a/msrpc/dcom/oaut/ienumvariant/v0/v0.go
+++ b/msrpc/dcom/oaut/ienumvariant/v0/v0.go
@@ -559,6 +559,7 @@ func (o *NextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type NextResponse struct {
 	// XXX: celt is an implicit input depedency for output parameters
 	Count uint32 `idl:"name:celt" json:"count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// rgVar: MUST be set to an array of elements that are returned from the enumeration

--- a/msrpc/dcom/oaut/ienumvariant/v0/v0.go
+++ b/msrpc/dcom/oaut/ienumvariant/v0/v0.go
@@ -557,6 +557,8 @@ func (o *NextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // NextResponse structure represents the Next operation response
 type NextResponse struct {
+	// XXX: celt is an implicit input depedency for output parameters
+	Count uint32 `idl:"name:celt" json:"count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// rgVar: MUST be set to an array of elements that are returned from the enumeration
@@ -577,6 +579,11 @@ func (o *NextResponse) xxx_ToOp(ctx context.Context, op *xxx_NextOperation) *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Count == uint32(0) {
+		op.Count = o.Count
+	}
+
 	op.That = o.That
 	op.Var = o.Var
 	op.CountFetched = o.CountFetched
@@ -588,6 +595,9 @@ func (o *NextResponse) xxx_FromOp(ctx context.Context, op *xxx_NextOperation) {
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Count = op.Count
+
 	o.That = op.That
 	o.Var = op.Var
 	o.CountFetched = op.CountFetched

--- a/msrpc/dcom/oaut/itypeinfo/v0/v0.go
+++ b/msrpc/dcom/oaut/itypeinfo/v0/v0.go
@@ -2073,6 +2073,8 @@ func (o *GetNamesRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 
 // GetNamesResponse structure represents the GetNames operation response
 type GetNamesResponse struct {
+	// XXX: cMaxNames is an implicit input depedency for output parameters
+	MaxNamesCount uint32 `idl:"name:cMaxNames" json:"max_names_count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// rgBstrNames: MUST be set to an array of BSTR. If pcNames is 0, rgBstrNames MUST be
@@ -2091,6 +2093,11 @@ func (o *GetNamesResponse) xxx_ToOp(ctx context.Context, op *xxx_GetNamesOperati
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.MaxNamesCount == uint32(0) {
+		op.MaxNamesCount = o.MaxNamesCount
+	}
+
 	op.That = o.That
 	op.Names = o.Names
 	op.NamesCount = o.NamesCount
@@ -2102,6 +2109,9 @@ func (o *GetNamesResponse) xxx_FromOp(ctx context.Context, op *xxx_GetNamesOpera
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.MaxNamesCount = op.MaxNamesCount
+
 	o.That = op.That
 	o.Names = op.Names
 	o.NamesCount = op.NamesCount

--- a/msrpc/dcom/oaut/itypeinfo/v0/v0.go
+++ b/msrpc/dcom/oaut/itypeinfo/v0/v0.go
@@ -2075,6 +2075,7 @@ func (o *GetNamesRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 type GetNamesResponse struct {
 	// XXX: cMaxNames is an implicit input depedency for output parameters
 	MaxNamesCount uint32 `idl:"name:cMaxNames" json:"max_names_count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// rgBstrNames: MUST be set to an array of BSTR. If pcNames is 0, rgBstrNames MUST be

--- a/msrpc/dcom/vds/ienumvdsobject/v0/v0.go
+++ b/msrpc/dcom/vds/ienumvdsobject/v0/v0.go
@@ -516,6 +516,7 @@ func (o *NextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type NextResponse struct {
 	// XXX: celt is an implicit input depedency for output parameters
 	Count uint32 `idl:"name:celt" json:"count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppObjectArray: A pointer to an array of IUnknown interfaces. The size of this array

--- a/msrpc/dcom/vds/ienumvdsobject/v0/v0.go
+++ b/msrpc/dcom/vds/ienumvdsobject/v0/v0.go
@@ -514,6 +514,8 @@ func (o *NextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // NextResponse structure represents the Next operation response
 type NextResponse struct {
+	// XXX: celt is an implicit input depedency for output parameters
+	Count uint32 `idl:"name:celt" json:"count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// ppObjectArray: A pointer to an array of IUnknown interfaces. The size of this array
@@ -536,6 +538,11 @@ func (o *NextResponse) xxx_ToOp(ctx context.Context, op *xxx_NextOperation) *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Count == uint32(0) {
+		op.Count = o.Count
+	}
+
 	op.That = o.That
 	op.ObjectArray = o.ObjectArray
 	op.FetchedCount = o.FetchedCount
@@ -547,6 +554,9 @@ func (o *NextResponse) xxx_FromOp(ctx context.Context, op *xxx_NextOperation) {
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Count = op.Count
+
 	o.That = op.That
 	o.ObjectArray = op.ObjectArray
 	o.FetchedCount = op.FetchedCount

--- a/msrpc/dcom/vds/ivdspack/v0/v0.go
+++ b/msrpc/dcom/vds/ivdspack/v0/v0.go
@@ -2300,6 +2300,7 @@ func (o *MigrateDisksRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 type MigrateDisksResponse struct {
 	// XXX: lNumberOfDisks is an implicit input depedency for output parameters
 	NumberOfDisks int32 `idl:"name:lNumberOfDisks" json:"number_of_disks"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pResults: A pointer to an array of HRESULT values that, if the operation is successfully

--- a/msrpc/dcom/vds/ivdspack/v0/v0.go
+++ b/msrpc/dcom/vds/ivdspack/v0/v0.go
@@ -2298,6 +2298,8 @@ func (o *MigrateDisksRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // MigrateDisksResponse structure represents the MigrateDisks operation response
 type MigrateDisksResponse struct {
+	// XXX: lNumberOfDisks is an implicit input depedency for output parameters
+	NumberOfDisks int32 `idl:"name:lNumberOfDisks" json:"number_of_disks"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pResults: A pointer to an array of HRESULT values that, if the operation is successfully
@@ -2321,6 +2323,11 @@ func (o *MigrateDisksResponse) xxx_ToOp(ctx context.Context, op *xxx_MigrateDisk
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.NumberOfDisks == int32(0) {
+		op.NumberOfDisks = o.NumberOfDisks
+	}
+
 	op.That = o.That
 	op.Results = o.Results
 	op.RebootNeeded = o.RebootNeeded
@@ -2332,6 +2339,9 @@ func (o *MigrateDisksResponse) xxx_FromOp(ctx context.Context, op *xxx_MigrateDi
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.NumberOfDisks = op.NumberOfDisks
+
 	o.That = op.That
 	o.Results = op.Results
 	o.RebootNeeded = op.RebootNeeded

--- a/msrpc/dcom/vds/ivdsservice/v0/v0.go
+++ b/msrpc/dcom/vds/ivdsservice/v0/v0.go
@@ -2219,6 +2219,7 @@ func (o *QueryDriveLettersRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type QueryDriveLettersResponse struct {
 	// XXX: count is an implicit input depedency for output parameters
 	Count uint32 `idl:"name:count" json:"count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pDriveLetterPropArray: An array of VDS_DRIVE_LETTER_PROP structures that, if the

--- a/msrpc/dcom/vds/ivdsservice/v0/v0.go
+++ b/msrpc/dcom/vds/ivdsservice/v0/v0.go
@@ -2217,6 +2217,8 @@ func (o *QueryDriveLettersRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // QueryDriveLettersResponse structure represents the QueryDriveLetters operation response
 type QueryDriveLettersResponse struct {
+	// XXX: count is an implicit input depedency for output parameters
+	Count uint32 `idl:"name:count" json:"count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pDriveLetterPropArray: An array of VDS_DRIVE_LETTER_PROP structures that, if the
@@ -2233,6 +2235,11 @@ func (o *QueryDriveLettersResponse) xxx_ToOp(ctx context.Context, op *xxx_QueryD
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Count == uint32(0) {
+		op.Count = o.Count
+	}
+
 	op.That = o.That
 	op.DriveLetterPropertyArray = o.DriveLetterPropertyArray
 	op.Return = o.Return
@@ -2243,6 +2250,9 @@ func (o *QueryDriveLettersResponse) xxx_FromOp(ctx context.Context, op *xxx_Quer
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Count = op.Count
+
 	o.That = op.That
 	o.DriveLetterPropertyArray = op.DriveLetterPropertyArray
 	o.Return = op.Return

--- a/msrpc/dcom/vds/ivdsserviceuninstalldisk/v0/v0.go
+++ b/msrpc/dcom/vds/ivdsserviceuninstalldisk/v0/v0.go
@@ -736,6 +736,8 @@ func (o *UninstallDisksRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // UninstallDisksResponse structure represents the UninstallDisks operation response
 type UninstallDisksResponse struct {
+	// XXX: ulCount is an implicit input depedency for output parameters
+	Count uint32 `idl:"name:ulCount" json:"count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbReboot: A pointer to a Boolean that, if the operation is successfully completed,
@@ -759,6 +761,11 @@ func (o *UninstallDisksResponse) xxx_ToOp(ctx context.Context, op *xxx_Uninstall
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Count == uint32(0) {
+		op.Count = o.Count
+	}
+
 	op.That = o.That
 	op.Reboot = o.Reboot
 	op.Results = o.Results
@@ -770,6 +777,9 @@ func (o *UninstallDisksResponse) xxx_FromOp(ctx context.Context, op *xxx_Uninsta
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Count = op.Count
+
 	o.That = op.That
 	o.Reboot = op.Reboot
 	o.Results = op.Results

--- a/msrpc/dcom/vds/ivdsserviceuninstalldisk/v0/v0.go
+++ b/msrpc/dcom/vds/ivdsserviceuninstalldisk/v0/v0.go
@@ -738,6 +738,7 @@ func (o *UninstallDisksRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 type UninstallDisksResponse struct {
 	// XXX: ulCount is an implicit input depedency for output parameters
 	Count uint32 `idl:"name:ulCount" json:"count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// pbReboot: A pointer to a Boolean that, if the operation is successfully completed,

--- a/msrpc/dcom/wmi/ienumwbemclassobject/v0/v0.go
+++ b/msrpc/dcom/wmi/ienumwbemclassobject/v0/v0.go
@@ -752,6 +752,7 @@ func (o *NextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type NextResponse struct {
 	// XXX: uCount is an implicit input depedency for output parameters
 	Count uint32 `idl:"name:uCount" json:"count"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That     *dcom.ORPCThat     `idl:"name:That" json:"that"`
 	Objects  []*wmi.ClassObject `idl:"name:apObjects;size_is:(uCount);length_is:(puReturned)" json:"objects"`

--- a/msrpc/dcom/wmi/ienumwbemclassobject/v0/v0.go
+++ b/msrpc/dcom/wmi/ienumwbemclassobject/v0/v0.go
@@ -750,6 +750,8 @@ func (o *NextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // NextResponse structure represents the Next operation response
 type NextResponse struct {
+	// XXX: uCount is an implicit input depedency for output parameters
+	Count uint32 `idl:"name:uCount" json:"count"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That     *dcom.ORPCThat     `idl:"name:That" json:"that"`
 	Objects  []*wmi.ClassObject `idl:"name:apObjects;size_is:(uCount);length_is:(puReturned)" json:"objects"`
@@ -765,6 +767,11 @@ func (o *NextResponse) xxx_ToOp(ctx context.Context, op *xxx_NextOperation) *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Count == uint32(0) {
+		op.Count = o.Count
+	}
+
 	op.That = o.That
 	op.Objects = o.Objects
 	op.Returned = o.Returned
@@ -776,6 +783,9 @@ func (o *NextResponse) xxx_FromOp(ctx context.Context, op *xxx_NextOperation) {
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Count = op.Count
+
 	o.That = op.That
 	o.Objects = op.Objects
 	o.Returned = op.Returned

--- a/msrpc/dcom/wmi/iwbemrefreshingservices/v0/v0.go
+++ b/msrpc/dcom/wmi/iwbemrefreshingservices/v0/v0.go
@@ -2581,6 +2581,7 @@ func (o *ReconnectRemoteRefresherRequest) UnmarshalNDR(ctx context.Context, r nd
 type ReconnectRemoteRefresherResponse struct {
 	// XXX: lNumObjects is an implicit input depedency for output parameters
 	ObjectsLength int32 `idl:"name:lNumObjects" json:"objects_length"`
+
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// apReconnectResults: MUST be a pointer to the _WBEM_RECONNECT_RESULTS structure array,

--- a/msrpc/dcom/wmi/iwbemrefreshingservices/v0/v0.go
+++ b/msrpc/dcom/wmi/iwbemrefreshingservices/v0/v0.go
@@ -2579,6 +2579,8 @@ func (o *ReconnectRemoteRefresherRequest) UnmarshalNDR(ctx context.Context, r nd
 
 // ReconnectRemoteRefresherResponse structure represents the ReconnectRemoteRefresher operation response
 type ReconnectRemoteRefresherResponse struct {
+	// XXX: lNumObjects is an implicit input depedency for output parameters
+	ObjectsLength int32 `idl:"name:lNumObjects" json:"objects_length"`
 	// That: ORPCTHAT structure that is used to return ORPC extension data to the client.
 	That *dcom.ORPCThat `idl:"name:That" json:"that"`
 	// apReconnectResults: MUST be a pointer to the _WBEM_RECONNECT_RESULTS structure array,
@@ -2599,6 +2601,11 @@ func (o *ReconnectRemoteRefresherResponse) xxx_ToOp(ctx context.Context, op *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ObjectsLength == int32(0) {
+		op.ObjectsLength = o.ObjectsLength
+	}
+
 	op.That = o.That
 	op.ReconnectResults = o.ReconnectResults
 	op.ServerRefresherVersion = o.ServerRefresherVersion
@@ -2610,6 +2617,9 @@ func (o *ReconnectRemoteRefresherResponse) xxx_FromOp(ctx context.Context, op *x
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ObjectsLength = op.ObjectsLength
+
 	o.That = op.That
 	o.ReconnectResults = op.ReconnectResults
 	o.ServerRefresherVersion = op.ServerRefresherVersion

--- a/msrpc/dfsnm/netdfs/v3/v3.go
+++ b/msrpc/dfsnm/netdfs/v3/v3.go
@@ -9277,6 +9277,7 @@ func (o *GetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type GetInfoResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// DfsInfo: The pointer to a DFS_INFO_STRUCT union to receive the returned information.
 	// The case of the union is selected by the value of the Level parameter.
 	Info *Info `idl:"name:DfsInfo;switch_is:Level" json:"info"`

--- a/msrpc/dfsnm/netdfs/v3/v3.go
+++ b/msrpc/dfsnm/netdfs/v3/v3.go
@@ -9275,6 +9275,8 @@ func (o *GetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // GetInfoResponse structure represents the NetrDfsGetInfo operation response
 type GetInfoResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// DfsInfo: The pointer to a DFS_INFO_STRUCT union to receive the returned information.
 	// The case of the union is selected by the value of the Level parameter.
 	Info *Info `idl:"name:DfsInfo;switch_is:Level" json:"info"`
@@ -9289,6 +9291,11 @@ func (o *GetInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_GetInfoOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.Info = o.Info
 	op.Return = o.Return
 	return op
@@ -9298,6 +9305,9 @@ func (o *GetInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_GetInfoOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.Info = op.Info
 	o.Return = op.Return
 }

--- a/msrpc/dhcpm/dhcpsrv2/v1/v1.go
+++ b/msrpc/dhcpm/dhcpsrv2/v1/v1.go
@@ -18294,6 +18294,7 @@ type QueryDNSRegCredentialsResponse struct {
 	UserNameSize uint32 `idl:"name:UnameSize" json:"user_name_size"`
 	// XXX: DomainSize is an implicit input depedency for output parameters
 	DomainSize uint32 `idl:"name:DomainSize" json:"domain_size"`
+
 	// Uname:  A pointer to a null-terminated Unicode string in which the DHCP server returns
 	// the user name for the DNS. The memory is allocated at the RPC client and passed to
 	// the RPC server.

--- a/msrpc/dhcpm/dhcpsrv2/v1/v1.go
+++ b/msrpc/dhcpm/dhcpsrv2/v1/v1.go
@@ -18290,6 +18290,10 @@ func (o *QueryDNSRegCredentialsRequest) UnmarshalNDR(ctx context.Context, r ndr.
 
 // QueryDNSRegCredentialsResponse structure represents the R_DhcpQueryDnsRegCredentials operation response
 type QueryDNSRegCredentialsResponse struct {
+	// XXX: UnameSize is an implicit input depedency for output parameters
+	UserNameSize uint32 `idl:"name:UnameSize" json:"user_name_size"`
+	// XXX: DomainSize is an implicit input depedency for output parameters
+	DomainSize uint32 `idl:"name:DomainSize" json:"domain_size"`
 	// Uname:  A pointer to a null-terminated Unicode string in which the DHCP server returns
 	// the user name for the DNS. The memory is allocated at the RPC client and passed to
 	// the RPC server.
@@ -18309,6 +18313,14 @@ func (o *QueryDNSRegCredentialsResponse) xxx_ToOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.UserNameSize == uint32(0) {
+		op.UserNameSize = o.UserNameSize
+	}
+	if op.DomainSize == uint32(0) {
+		op.DomainSize = o.DomainSize
+	}
+
 	op.UserName = o.UserName
 	op.Domain = o.Domain
 	op.Return = o.Return
@@ -18319,6 +18331,10 @@ func (o *QueryDNSRegCredentialsResponse) xxx_FromOp(ctx context.Context, op *xxx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.UserNameSize = op.UserNameSize
+	o.DomainSize = op.DomainSize
+
 	o.UserName = op.UserName
 	o.Domain = op.Domain
 	o.Return = op.Return

--- a/msrpc/dssp/dssetup/v0/v0.go
+++ b/msrpc/dssp/dssetup/v0/v0.go
@@ -931,6 +931,7 @@ func (o *GetPrimaryDomainInformationRequest) UnmarshalNDR(ctx context.Context, r
 type GetPrimaryDomainInformationResponse struct {
 	// XXX: InfoLevel is an implicit input depedency for output parameters
 	InfoLevel PrimaryDomainInfoLevel `idl:"name:InfoLevel" json:"info_level"`
+
 	// DomainInfo: The requested information that the server provides to the client. The
 	// value of the InfoLevel parameter indicates the type of information that is requested;
 	// information is returned in the corresponding member of the DSROLER_PRIMARY_DOMAIN_INFORMATION

--- a/msrpc/dssp/dssetup/v0/v0.go
+++ b/msrpc/dssp/dssetup/v0/v0.go
@@ -929,6 +929,8 @@ func (o *GetPrimaryDomainInformationRequest) UnmarshalNDR(ctx context.Context, r
 
 // GetPrimaryDomainInformationResponse structure represents the DsRolerGetPrimaryDomainInformation operation response
 type GetPrimaryDomainInformationResponse struct {
+	// XXX: InfoLevel is an implicit input depedency for output parameters
+	InfoLevel PrimaryDomainInfoLevel `idl:"name:InfoLevel" json:"info_level"`
 	// DomainInfo: The requested information that the server provides to the client. The
 	// value of the InfoLevel parameter indicates the type of information that is requested;
 	// information is returned in the corresponding member of the DSROLER_PRIMARY_DOMAIN_INFORMATION
@@ -945,6 +947,11 @@ func (o *GetPrimaryDomainInformationResponse) xxx_ToOp(ctx context.Context, op *
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InfoLevel == PrimaryDomainInfoLevel(0) {
+		op.InfoLevel = o.InfoLevel
+	}
+
 	op.DomainInfo = o.DomainInfo
 	op.Return = o.Return
 	return op
@@ -954,6 +961,9 @@ func (o *GetPrimaryDomainInformationResponse) xxx_FromOp(ctx context.Context, op
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InfoLevel = op.InfoLevel
+
 	o.DomainInfo = op.DomainInfo
 	o.Return = op.Return
 }

--- a/msrpc/epm/epm/v3/v3.go
+++ b/msrpc/epm/epm/v3/v3.go
@@ -1171,7 +1171,8 @@ func (o *LookupRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 // LookupResponse structure represents the ept_lookup operation response
 type LookupResponse struct {
 	// XXX: max_ents is an implicit input depedency for output parameters
-	MaxEntries    uint32        `idl:"name:max_ents" json:"max_entries"`
+	MaxEntries uint32 `idl:"name:max_ents" json:"max_entries"`
+
 	EntryHandle   *LookupHandle `idl:"name:entry_handle" json:"entry_handle"`
 	EntriesLength uint32        `idl:"name:num_ents" json:"entries_length"`
 	Entries       []*Entry      `idl:"name:entries;size_is:(max_ents);length_is:(num_ents)" json:"entries"`
@@ -1594,7 +1595,8 @@ func (o *MapRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 // MapResponse structure represents the ept_map operation response
 type MapResponse struct {
 	// XXX: max_towers is an implicit input depedency for output parameters
-	MaxTowers    uint32            `idl:"name:max_towers" json:"max_towers"`
+	MaxTowers uint32 `idl:"name:max_towers" json:"max_towers"`
+
 	EntryHandle  *LookupHandle     `idl:"name:entry_handle" json:"entry_handle"`
 	TowersLength uint32            `idl:"name:num_towers" json:"towers_length"`
 	Towers       []*dcetypes.Tower `idl:"name:towers;size_is:(max_towers);length_is:(num_towers)" json:"towers"`

--- a/msrpc/epm/epm/v3/v3.go
+++ b/msrpc/epm/epm/v3/v3.go
@@ -1170,6 +1170,8 @@ func (o *LookupRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // LookupResponse structure represents the ept_lookup operation response
 type LookupResponse struct {
+	// XXX: max_ents is an implicit input depedency for output parameters
+	MaxEntries    uint32        `idl:"name:max_ents" json:"max_entries"`
 	EntryHandle   *LookupHandle `idl:"name:entry_handle" json:"entry_handle"`
 	EntriesLength uint32        `idl:"name:num_ents" json:"entries_length"`
 	Entries       []*Entry      `idl:"name:entries;size_is:(max_ents);length_is:(num_ents)" json:"entries"`
@@ -1183,6 +1185,11 @@ func (o *LookupResponse) xxx_ToOp(ctx context.Context, op *xxx_LookupOperation) 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.MaxEntries == uint32(0) {
+		op.MaxEntries = o.MaxEntries
+	}
+
 	op.EntryHandle = o.EntryHandle
 	op.EntriesLength = o.EntriesLength
 	op.Entries = o.Entries
@@ -1194,6 +1201,9 @@ func (o *LookupResponse) xxx_FromOp(ctx context.Context, op *xxx_LookupOperation
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.MaxEntries = op.MaxEntries
+
 	o.EntryHandle = op.EntryHandle
 	o.EntriesLength = op.EntriesLength
 	o.Entries = op.Entries
@@ -1583,6 +1593,8 @@ func (o *MapRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // MapResponse structure represents the ept_map operation response
 type MapResponse struct {
+	// XXX: max_towers is an implicit input depedency for output parameters
+	MaxTowers    uint32            `idl:"name:max_towers" json:"max_towers"`
 	EntryHandle  *LookupHandle     `idl:"name:entry_handle" json:"entry_handle"`
 	TowersLength uint32            `idl:"name:num_towers" json:"towers_length"`
 	Towers       []*dcetypes.Tower `idl:"name:towers;size_is:(max_towers);length_is:(num_towers)" json:"towers"`
@@ -1596,6 +1608,11 @@ func (o *MapResponse) xxx_ToOp(ctx context.Context, op *xxx_MapOperation) *xxx_M
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.MaxTowers == uint32(0) {
+		op.MaxTowers = o.MaxTowers
+	}
+
 	op.EntryHandle = o.EntryHandle
 	op.TowersLength = o.TowersLength
 	op.Towers = o.Towers
@@ -1607,6 +1624,9 @@ func (o *MapResponse) xxx_FromOp(ctx context.Context, op *xxx_MapOperation) {
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.MaxTowers = op.MaxTowers
+
 	o.EntryHandle = op.EntryHandle
 	o.TowersLength = op.TowersLength
 	o.Towers = op.Towers

--- a/msrpc/even/eventlog/v0/v0.go
+++ b/msrpc/even/eventlog/v0/v0.go
@@ -3298,6 +3298,8 @@ func (o *ReadEventLogWRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 
 // ReadEventLogWResponse structure represents the ElfrReadELW operation response
 type ReadEventLogWResponse struct {
+	// XXX: NumberOfBytesToRead is an implicit input depedency for output parameters
+	NumberOfBytesToRead uint32 `idl:"name:NumberOfBytesToRead" json:"number_of_bytes_to_read"`
 	// Buffer: The buffer in which to place data read from the event log.
 	Buffer []byte `idl:"name:Buffer;size_is:(NumberOfBytesToRead)" json:"buffer"`
 	// NumberOfBytesRead: Pointer to a variable that receives the number of bytes actually
@@ -3318,6 +3320,11 @@ func (o *ReadEventLogWResponse) xxx_ToOp(ctx context.Context, op *xxx_ReadEventL
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.NumberOfBytesToRead == uint32(0) {
+		op.NumberOfBytesToRead = o.NumberOfBytesToRead
+	}
+
 	op.Buffer = o.Buffer
 	op.NumberOfBytesRead = o.NumberOfBytesRead
 	op.MinNumberOfBytesNeeded = o.MinNumberOfBytesNeeded
@@ -3329,6 +3336,9 @@ func (o *ReadEventLogWResponse) xxx_FromOp(ctx context.Context, op *xxx_ReadEven
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.NumberOfBytesToRead = op.NumberOfBytesToRead
+
 	o.Buffer = op.Buffer
 	o.NumberOfBytesRead = op.NumberOfBytesRead
 	o.MinNumberOfBytesNeeded = op.MinNumberOfBytesNeeded
@@ -5590,6 +5600,8 @@ func (o *ReadEventLogARequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 
 // ReadEventLogAResponse structure represents the ElfrReadELA operation response
 type ReadEventLogAResponse struct {
+	// XXX: NumberOfBytesToRead is an implicit input depedency for output parameters
+	NumberOfBytesToRead uint32 `idl:"name:NumberOfBytesToRead" json:"number_of_bytes_to_read"`
 	// Buffer: Data read from the event log.
 	Buffer []byte `idl:"name:Buffer;size_is:(NumberOfBytesToRead)" json:"buffer"`
 	// NumberOfBytesRead: Number of bytes read by the method.
@@ -5609,6 +5621,11 @@ func (o *ReadEventLogAResponse) xxx_ToOp(ctx context.Context, op *xxx_ReadEventL
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.NumberOfBytesToRead == uint32(0) {
+		op.NumberOfBytesToRead = o.NumberOfBytesToRead
+	}
+
 	op.Buffer = o.Buffer
 	op.NumberOfBytesRead = o.NumberOfBytesRead
 	op.MinNumberOfBytesNeeded = o.MinNumberOfBytesNeeded
@@ -5620,6 +5637,9 @@ func (o *ReadEventLogAResponse) xxx_FromOp(ctx context.Context, op *xxx_ReadEven
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.NumberOfBytesToRead = op.NumberOfBytesToRead
+
 	o.Buffer = op.Buffer
 	o.NumberOfBytesRead = op.NumberOfBytesRead
 	o.MinNumberOfBytesNeeded = op.MinNumberOfBytesNeeded
@@ -6540,6 +6560,8 @@ func (o *GetLogInformationRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // GetLogInformationResponse structure represents the ElfrGetLogInformation operation response
 type GetLogInformationResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: The event log information. This MUST point to either an EVENTLOG_FULL_INFORMATION
 	// (section 2.2.4) structure or be NULL.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -6557,6 +6579,11 @@ func (o *GetLogInformationResponse) xxx_ToOp(ctx context.Context, op *xxx_GetLog
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.Return = o.Return
@@ -6567,6 +6594,9 @@ func (o *GetLogInformationResponse) xxx_FromOp(ctx context.Context, op *xxx_GetL
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.Return = op.Return

--- a/msrpc/even/eventlog/v0/v0.go
+++ b/msrpc/even/eventlog/v0/v0.go
@@ -3300,6 +3300,7 @@ func (o *ReadEventLogWRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 type ReadEventLogWResponse struct {
 	// XXX: NumberOfBytesToRead is an implicit input depedency for output parameters
 	NumberOfBytesToRead uint32 `idl:"name:NumberOfBytesToRead" json:"number_of_bytes_to_read"`
+
 	// Buffer: The buffer in which to place data read from the event log.
 	Buffer []byte `idl:"name:Buffer;size_is:(NumberOfBytesToRead)" json:"buffer"`
 	// NumberOfBytesRead: Pointer to a variable that receives the number of bytes actually
@@ -5602,6 +5603,7 @@ func (o *ReadEventLogARequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 type ReadEventLogAResponse struct {
 	// XXX: NumberOfBytesToRead is an implicit input depedency for output parameters
 	NumberOfBytesToRead uint32 `idl:"name:NumberOfBytesToRead" json:"number_of_bytes_to_read"`
+
 	// Buffer: Data read from the event log.
 	Buffer []byte `idl:"name:Buffer;size_is:(NumberOfBytesToRead)" json:"buffer"`
 	// NumberOfBytesRead: Number of bytes read by the method.
@@ -6562,6 +6564,7 @@ func (o *GetLogInformationRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type GetLogInformationResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: The event log information. This MUST point to either an EVENTLOG_FULL_INFORMATION
 	// (section 2.2.4) structure or be NULL.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`

--- a/msrpc/even6/ieventservice/v1/v1.go
+++ b/msrpc/even6/ieventservice/v1/v1.go
@@ -8688,6 +8688,8 @@ func (o *GetLogFileInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // GetLogFileInfoResponse structure represents the EvtRpcGetLogFileInfo operation response
 type GetLogFileInfoResponse struct {
+	// XXX: propertyValueBufferSize is an implicit input depedency for output parameters
+	PropertyValueBufferSize uint32 `idl:"name:propertyValueBufferSize" json:"property_value_buffer_size"`
 	// propertyValueBuffer: A byte-array that contains the buffer for returned data.
 	PropertyValueBuffer []byte `idl:"name:propertyValueBuffer;size_is:(propertyValueBufferSize)" json:"property_value_buffer"`
 	// propertyValueBufferLength: A pointer to a 32-bit unsigned integer that contains the
@@ -8704,6 +8706,11 @@ func (o *GetLogFileInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_GetLogFil
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.PropertyValueBufferSize == uint32(0) {
+		op.PropertyValueBufferSize = o.PropertyValueBufferSize
+	}
+
 	op.PropertyValueBuffer = o.PropertyValueBuffer
 	op.PropertyValueBufferLength = o.PropertyValueBufferLength
 	op.Return = o.Return
@@ -8714,6 +8721,9 @@ func (o *GetLogFileInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_GetLogF
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.PropertyValueBufferSize = op.PropertyValueBufferSize
+
 	o.PropertyValueBuffer = op.PropertyValueBuffer
 	o.PropertyValueBufferLength = op.PropertyValueBufferLength
 	o.Return = op.Return

--- a/msrpc/even6/ieventservice/v1/v1.go
+++ b/msrpc/even6/ieventservice/v1/v1.go
@@ -8690,6 +8690,7 @@ func (o *GetLogFileInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 type GetLogFileInfoResponse struct {
 	// XXX: propertyValueBufferSize is an implicit input depedency for output parameters
 	PropertyValueBufferSize uint32 `idl:"name:propertyValueBufferSize" json:"property_value_buffer_size"`
+
 	// propertyValueBuffer: A byte-array that contains the buffer for returned data.
 	PropertyValueBuffer []byte `idl:"name:propertyValueBuffer;size_is:(propertyValueBufferSize)" json:"property_value_buffer"`
 	// propertyValueBufferLength: A pointer to a 32-bit unsigned integer that contains the

--- a/msrpc/fasp/remotefw/v1/v1.go
+++ b/msrpc/fasp/remotefw/v1/v1.go
@@ -5288,6 +5288,8 @@ func (o *GetGlobalConfigRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // GetGlobalConfigResponse structure represents the RRPC_FWGetGlobalConfig operation response
 type GetGlobalConfigResponse struct {
+	// XXX: cbData is an implicit input depedency for output parameters
+	DataLength uint32 `idl:"name:cbData" json:"data_length"`
 	// pBuffer: This is an input/output parameter. This parameter is a pointer to the buffer
 	// that the client provides to contain the value of the profile configuration option
 	// being requested.
@@ -5311,6 +5313,11 @@ func (o *GetGlobalConfigResponse) xxx_ToOp(ctx context.Context, op *xxx_GetGloba
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DataLength == uint32(0) {
+		op.DataLength = o.DataLength
+	}
+
 	op.Buffer = o.Buffer
 	op.TransmittedLength = o.TransmittedLength
 	op.RequiredLength = o.RequiredLength
@@ -5322,6 +5329,9 @@ func (o *GetGlobalConfigResponse) xxx_FromOp(ctx context.Context, op *xxx_GetGlo
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DataLength = op.DataLength
+
 	o.Buffer = op.Buffer
 	o.TransmittedLength = op.TransmittedLength
 	o.RequiredLength = op.RequiredLength
@@ -7060,6 +7070,8 @@ func (o *GetConfigRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 
 // GetConfigResponse structure represents the RRPC_FWGetConfig operation response
 type GetConfigResponse struct {
+	// XXX: cbData is an implicit input depedency for output parameters
+	DataLength uint32 `idl:"name:cbData" json:"data_length"`
 	// pBuffer: This is an input/output parameter. This parameter is a pointer to the buffer
 	// that the client provides to contain the value of the profile configuration option
 	// being requested.
@@ -7083,6 +7095,11 @@ func (o *GetConfigResponse) xxx_ToOp(ctx context.Context, op *xxx_GetConfigOpera
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DataLength == uint32(0) {
+		op.DataLength = o.DataLength
+	}
+
 	op.Buffer = o.Buffer
 	op.TransmittedLength = o.TransmittedLength
 	op.RequiredLength = o.RequiredLength
@@ -7094,6 +7111,9 @@ func (o *GetConfigResponse) xxx_FromOp(ctx context.Context, op *xxx_GetConfigOpe
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DataLength = op.DataLength
+
 	o.Buffer = op.Buffer
 	o.TransmittedLength = op.TransmittedLength
 	o.RequiredLength = op.RequiredLength
@@ -15079,6 +15099,8 @@ func (o *GetGlobalConfig210Request) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // GetGlobalConfig210Response structure represents the RRPC_FWGetGlobalConfig2_10 operation response
 type GetGlobalConfig210Response struct {
+	// XXX: cbData is an implicit input depedency for output parameters
+	DataLength uint32 `idl:"name:cbData" json:"data_length"`
 	// pBuffer: This is an input/output parameter. This parameter is a pointer to the buffer
 	// that the client provides to contain the value of the profile configuration option
 	// that is being requested.
@@ -15105,6 +15127,11 @@ func (o *GetGlobalConfig210Response) xxx_ToOp(ctx context.Context, op *xxx_GetGl
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DataLength == uint32(0) {
+		op.DataLength = o.DataLength
+	}
+
 	op.Buffer = o.Buffer
 	op.TransmittedLength = o.TransmittedLength
 	op.RequiredLength = o.RequiredLength
@@ -15117,6 +15144,9 @@ func (o *GetGlobalConfig210Response) xxx_FromOp(ctx context.Context, op *xxx_Get
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DataLength = op.DataLength
+
 	o.Buffer = op.Buffer
 	o.TransmittedLength = op.TransmittedLength
 	o.RequiredLength = op.RequiredLength
@@ -15584,6 +15614,8 @@ func (o *GetConfig210Request) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // GetConfig210Response structure represents the RRPC_FWGetConfig2_10 operation response
 type GetConfig210Response struct {
+	// XXX: cbData is an implicit input depedency for output parameters
+	DataLength uint32 `idl:"name:cbData" json:"data_length"`
 	// pBuffer: This is an input/output parameter. This parameter is a pointer to the buffer
 	// that the client provides to contain the value of the profile configuration option
 	// being requested.
@@ -15610,6 +15642,11 @@ func (o *GetConfig210Response) xxx_ToOp(ctx context.Context, op *xxx_GetConfig21
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DataLength == uint32(0) {
+		op.DataLength = o.DataLength
+	}
+
 	op.Buffer = o.Buffer
 	op.TransmittedLength = o.TransmittedLength
 	op.RequiredLength = o.RequiredLength
@@ -15622,6 +15659,9 @@ func (o *GetConfig210Response) xxx_FromOp(ctx context.Context, op *xxx_GetConfig
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DataLength = op.DataLength
+
 	o.Buffer = op.Buffer
 	o.TransmittedLength = op.TransmittedLength
 	o.RequiredLength = op.RequiredLength

--- a/msrpc/fasp/remotefw/v1/v1.go
+++ b/msrpc/fasp/remotefw/v1/v1.go
@@ -5290,6 +5290,7 @@ func (o *GetGlobalConfigRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 type GetGlobalConfigResponse struct {
 	// XXX: cbData is an implicit input depedency for output parameters
 	DataLength uint32 `idl:"name:cbData" json:"data_length"`
+
 	// pBuffer: This is an input/output parameter. This parameter is a pointer to the buffer
 	// that the client provides to contain the value of the profile configuration option
 	// being requested.
@@ -7072,6 +7073,7 @@ func (o *GetConfigRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 type GetConfigResponse struct {
 	// XXX: cbData is an implicit input depedency for output parameters
 	DataLength uint32 `idl:"name:cbData" json:"data_length"`
+
 	// pBuffer: This is an input/output parameter. This parameter is a pointer to the buffer
 	// that the client provides to contain the value of the profile configuration option
 	// being requested.
@@ -15101,6 +15103,7 @@ func (o *GetGlobalConfig210Request) UnmarshalNDR(ctx context.Context, r ndr.Read
 type GetGlobalConfig210Response struct {
 	// XXX: cbData is an implicit input depedency for output parameters
 	DataLength uint32 `idl:"name:cbData" json:"data_length"`
+
 	// pBuffer: This is an input/output parameter. This parameter is a pointer to the buffer
 	// that the client provides to contain the value of the profile configuration option
 	// that is being requested.
@@ -15616,6 +15619,7 @@ func (o *GetConfig210Request) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 type GetConfig210Response struct {
 	// XXX: cbData is an implicit input depedency for output parameters
 	DataLength uint32 `idl:"name:cbData" json:"data_length"`
+
 	// pBuffer: This is an input/output parameter. This parameter is a pointer to the buffer
 	// that the client provides to contain the value of the profile configuration option
 	// being requested.

--- a/msrpc/fax/fax/v4/v4.go
+++ b/msrpc/fax/fax/v4/v4.go
@@ -12396,6 +12396,8 @@ func (o *SendDocumentExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // SendDocumentExResponse structure represents the FAX_SendDocumentEx operation response
 type SendDocumentExResponse struct {
+	// XXX: dwNumRecipients is an implicit input depedency for output parameters
+	RecipientsLength uint32 `idl:"name:dwNumRecipients" json:"recipients_length"`
 	// lpdwJobId: An optional pointer to a DWORD to return the job identifier. This parameter
 	// is used for backward compatibility with FaxObs_SendDocument (section 3.1.4.2.7).
 	// The fax server MUST ignore this argument if the fax client submits a NULL pointer
@@ -12421,6 +12423,11 @@ func (o *SendDocumentExResponse) xxx_ToOp(ctx context.Context, op *xxx_SendDocum
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.RecipientsLength == uint32(0) {
+		op.RecipientsLength = o.RecipientsLength
+	}
+
 	op.JobID = o.JobID
 	op.MessageID = o.MessageID
 	op.RecipientMessageIDs = o.RecipientMessageIDs
@@ -12432,6 +12439,9 @@ func (o *SendDocumentExResponse) xxx_FromOp(ctx context.Context, op *xxx_SendDoc
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.RecipientsLength = op.RecipientsLength
+
 	o.JobID = op.JobID
 	o.MessageID = op.MessageID
 	o.RecipientMessageIDs = op.RecipientMessageIDs

--- a/msrpc/fax/fax/v4/v4.go
+++ b/msrpc/fax/fax/v4/v4.go
@@ -12398,6 +12398,7 @@ func (o *SendDocumentExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 type SendDocumentExResponse struct {
 	// XXX: dwNumRecipients is an implicit input depedency for output parameters
 	RecipientsLength uint32 `idl:"name:dwNumRecipients" json:"recipients_length"`
+
 	// lpdwJobId: An optional pointer to a DWORD to return the job identifier. This parameter
 	// is used for backward compatibility with FaxObs_SendDocument (section 3.1.4.2.7).
 	// The fax server MUST ignore this argument if the fax client submits a NULL pointer

--- a/msrpc/fax/faxobs/v4/v4.go
+++ b/msrpc/fax/faxobs/v4/v4.go
@@ -3028,6 +3028,7 @@ func (o *GetQueueFileNameRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type GetQueueFileNameResponse struct {
 	// XXX: FileNameSize is an implicit input depedency for output parameters
 	FileNameSize uint32 `idl:"name:FileNameSize" json:"file_name_size"`
+
 	// FileName: A buffer that MUST be allocated by the client to hold FileNameSize characters.
 	// On successful return from this call the server MUST write to this buffer a null-terminated
 	// character string containing the path name, including file name and extension, for

--- a/msrpc/fax/faxobs/v4/v4.go
+++ b/msrpc/fax/faxobs/v4/v4.go
@@ -3026,6 +3026,8 @@ func (o *GetQueueFileNameRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // GetQueueFileNameResponse structure represents the FaxObs_GetQueueFileName operation response
 type GetQueueFileNameResponse struct {
+	// XXX: FileNameSize is an implicit input depedency for output parameters
+	FileNameSize uint32 `idl:"name:FileNameSize" json:"file_name_size"`
 	// FileName: A buffer that MUST be allocated by the client to hold FileNameSize characters.
 	// On successful return from this call the server MUST write to this buffer a null-terminated
 	// character string containing the path name, including file name and extension, for
@@ -3042,6 +3044,11 @@ func (o *GetQueueFileNameResponse) xxx_ToOp(ctx context.Context, op *xxx_GetQueu
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.FileNameSize == uint32(0) {
+		op.FileNameSize = o.FileNameSize
+	}
+
 	op.FileName = o.FileName
 	op.Return = o.Return
 	return op
@@ -3051,6 +3058,9 @@ func (o *GetQueueFileNameResponse) xxx_FromOp(ctx context.Context, op *xxx_GetQu
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.FileNameSize = op.FileNameSize
+
 	o.FileName = op.FileName
 	o.Return = op.Return
 }

--- a/msrpc/fsrvp/fileservervssagent/v1/v1.go
+++ b/msrpc/fsrvp/fileservervssagent/v1/v1.go
@@ -2802,6 +2802,8 @@ func (o *GetShareMappingRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // GetShareMappingResponse structure represents the GetShareMapping operation response
 type GetShareMappingResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// ShareMapping: A pointer to an FSSAGENT_SHARE_MAPPING structure, as specified in section
 	// 2.2.3.1.
 	ShareMapping *ShareMapping `idl:"name:ShareMapping;switch_is:Level" json:"share_mapping"`
@@ -2816,6 +2818,11 @@ func (o *GetShareMappingResponse) xxx_ToOp(ctx context.Context, op *xxx_GetShare
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.ShareMapping = o.ShareMapping
 	op.Return = o.Return
 	return op
@@ -2825,6 +2832,9 @@ func (o *GetShareMappingResponse) xxx_FromOp(ctx context.Context, op *xxx_GetSha
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.ShareMapping = op.ShareMapping
 	o.Return = op.Return
 }

--- a/msrpc/fsrvp/fileservervssagent/v1/v1.go
+++ b/msrpc/fsrvp/fileservervssagent/v1/v1.go
@@ -2804,6 +2804,7 @@ func (o *GetShareMappingRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 type GetShareMappingResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// ShareMapping: A pointer to an FSSAGENT_SHARE_MAPPING structure, as specified in section
 	// 2.2.3.1.
 	ShareMapping *ShareMapping `idl:"name:ShareMapping;switch_is:Level" json:"share_mapping"`

--- a/msrpc/irp/inetinfo/v2/v2.go
+++ b/msrpc/irp/inetinfo/v2/v2.go
@@ -5913,6 +5913,7 @@ func (o *QueryStatisticsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 type QueryStatisticsResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// StatsInfo: The pointer to an INET_INFO_STATISTICS_INFO union that contains the data
 	// to be returned.
 	StatsInfo *StatisticsInfo `idl:"name:StatsInfo;switch_is:Level" json:"stats_info"`
@@ -6811,6 +6812,7 @@ func (o *W3QueryStatistics2Request) UnmarshalNDR(ctx context.Context, r ndr.Read
 type W3QueryStatistics2Response struct {
 	// XXX: dwLevel is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:dwLevel" json:"level"`
+
 	// InfoStruct: The pointer to a W3_STATISTICS_STRUCT union to contain the retrieved
 	// statistics data.
 	Info *W3Statistics `idl:"name:InfoStruct;switch_is:dwLevel" json:"info"`
@@ -7279,6 +7281,7 @@ func (o *FTPQueryStatistics2Request) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type FTPQueryStatistics2Response struct {
 	// XXX: dwLevel is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:dwLevel" json:"level"`
+
 	// InfoStruct: The pointer to an FTP_STATISTICS_STRUCT union to contain the retrieved
 	// statistics data.
 	Info *FTPStatistics `idl:"name:InfoStruct;switch_is:dwLevel" json:"info"`

--- a/msrpc/irp/inetinfo/v2/v2.go
+++ b/msrpc/irp/inetinfo/v2/v2.go
@@ -5911,6 +5911,8 @@ func (o *QueryStatisticsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // QueryStatisticsResponse structure represents the R_InetInfoQueryStatistics operation response
 type QueryStatisticsResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// StatsInfo: The pointer to an INET_INFO_STATISTICS_INFO union that contains the data
 	// to be returned.
 	StatsInfo *StatisticsInfo `idl:"name:StatsInfo;switch_is:Level" json:"stats_info"`
@@ -5925,6 +5927,11 @@ func (o *QueryStatisticsResponse) xxx_ToOp(ctx context.Context, op *xxx_QuerySta
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.StatsInfo = o.StatsInfo
 	op.Return = o.Return
 	return op
@@ -5934,6 +5941,9 @@ func (o *QueryStatisticsResponse) xxx_FromOp(ctx context.Context, op *xxx_QueryS
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.StatsInfo = op.StatsInfo
 	o.Return = op.Return
 }
@@ -6799,6 +6809,8 @@ func (o *W3QueryStatistics2Request) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // W3QueryStatistics2Response structure represents the R_W3QueryStatistics2 operation response
 type W3QueryStatistics2Response struct {
+	// XXX: dwLevel is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:dwLevel" json:"level"`
 	// InfoStruct: The pointer to a W3_STATISTICS_STRUCT union to contain the retrieved
 	// statistics data.
 	Info *W3Statistics `idl:"name:InfoStruct;switch_is:dwLevel" json:"info"`
@@ -6813,6 +6825,11 @@ func (o *W3QueryStatistics2Response) xxx_ToOp(ctx context.Context, op *xxx_W3Que
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.Info = o.Info
 	op.Return = o.Return
 	return op
@@ -6822,6 +6839,9 @@ func (o *W3QueryStatistics2Response) xxx_FromOp(ctx context.Context, op *xxx_W3Q
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.Info = op.Info
 	o.Return = op.Return
 }
@@ -7257,6 +7277,8 @@ func (o *FTPQueryStatistics2Request) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // FTPQueryStatistics2Response structure represents the R_FtpQueryStatistics2 operation response
 type FTPQueryStatistics2Response struct {
+	// XXX: dwLevel is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:dwLevel" json:"level"`
 	// InfoStruct: The pointer to an FTP_STATISTICS_STRUCT union to contain the retrieved
 	// statistics data.
 	Info *FTPStatistics `idl:"name:InfoStruct;switch_is:dwLevel" json:"info"`
@@ -7271,6 +7293,11 @@ func (o *FTPQueryStatistics2Response) xxx_ToOp(ctx context.Context, op *xxx_FTPQ
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.Info = o.Info
 	op.Return = o.Return
 	return op
@@ -7280,6 +7307,9 @@ func (o *FTPQueryStatistics2Response) xxx_FromOp(ctx context.Context, op *xxx_FT
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.Info = op.Info
 	o.Return = op.Return
 }

--- a/msrpc/lsad/lsarpc/v0/v0.go
+++ b/msrpc/lsad/lsarpc/v0/v0.go
@@ -11648,6 +11648,8 @@ func (o *QueryInformationPolicyRequest) UnmarshalNDR(ctx context.Context, r ndr.
 
 // QueryInformationPolicyResponse structure represents the LsarQueryInformationPolicy operation response
 type QueryInformationPolicyResponse struct {
+	// XXX: InformationClass is an implicit input depedency for output parameters
+	InformationClass PolicyInformationClass `idl:"name:InformationClass" json:"information_class"`
 	// PolicyInformation: A parameter that references policy information structure on return.
 	PolicyInformation *PolicyInformation `idl:"name:PolicyInformation;switch_is:InformationClass" json:"policy_information"`
 	// Return: The LsarQueryInformationPolicy return value.
@@ -11661,6 +11663,11 @@ func (o *QueryInformationPolicyResponse) xxx_ToOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InformationClass == PolicyInformationClass(0) {
+		op.InformationClass = o.InformationClass
+	}
+
 	op.PolicyInformation = o.PolicyInformation
 	op.Return = o.Return
 	return op
@@ -11670,6 +11677,9 @@ func (o *QueryInformationPolicyResponse) xxx_FromOp(ctx context.Context, op *xxx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InformationClass = op.InformationClass
+
 	o.PolicyInformation = op.PolicyInformation
 	o.Return = op.Return
 }
@@ -14650,6 +14660,8 @@ func (o *QueryInfoTrustedDomainRequest) UnmarshalNDR(ctx context.Context, r ndr.
 
 // QueryInfoTrustedDomainResponse structure represents the LsarQueryInfoTrustedDomain operation response
 type QueryInfoTrustedDomainResponse struct {
+	// XXX: InformationClass is an implicit input depedency for output parameters
+	InformationClass TrustedInformationClass `idl:"name:InformationClass" json:"information_class"`
 	// TrustedDomainInformation: Used to return requested information about the trusted
 	// domain object.
 	TrustedDomainInformation *TrustedDomainInfo `idl:"name:TrustedDomainInformation;switch_is:InformationClass" json:"trusted_domain_information"`
@@ -14664,6 +14676,11 @@ func (o *QueryInfoTrustedDomainResponse) xxx_ToOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InformationClass == TrustedInformationClass(0) {
+		op.InformationClass = o.InformationClass
+	}
+
 	op.TrustedDomainInformation = o.TrustedDomainInformation
 	op.Return = o.Return
 	return op
@@ -14673,6 +14690,9 @@ func (o *QueryInfoTrustedDomainResponse) xxx_FromOp(ctx context.Context, op *xxx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InformationClass = op.InformationClass
+
 	o.TrustedDomainInformation = op.TrustedDomainInformation
 	o.Return = op.Return
 }
@@ -18040,6 +18060,8 @@ func (o *QueryTrustedDomainInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.
 
 // QueryTrustedDomainInfoResponse structure represents the LsarQueryTrustedDomainInfo operation response
 type QueryTrustedDomainInfoResponse struct {
+	// XXX: InformationClass is an implicit input depedency for output parameters
+	InformationClass TrustedInformationClass `idl:"name:InformationClass" json:"information_class"`
 	// TrustedDomainInformation: Used to return the information on the trusted domain object
 	// to the caller.
 	TrustedDomainInformation *TrustedDomainInfo `idl:"name:TrustedDomainInformation;switch_is:InformationClass" json:"trusted_domain_information"`
@@ -18054,6 +18076,11 @@ func (o *QueryTrustedDomainInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InformationClass == TrustedInformationClass(0) {
+		op.InformationClass = o.InformationClass
+	}
+
 	op.TrustedDomainInformation = o.TrustedDomainInformation
 	op.Return = o.Return
 	return op
@@ -18063,6 +18090,9 @@ func (o *QueryTrustedDomainInfoResponse) xxx_FromOp(ctx context.Context, op *xxx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InformationClass = op.InformationClass
+
 	o.TrustedDomainInformation = op.TrustedDomainInformation
 	o.Return = op.Return
 }
@@ -19455,6 +19485,8 @@ func (o *QueryInformationPolicy2Request) UnmarshalNDR(ctx context.Context, r ndr
 
 // QueryInformationPolicy2Response structure represents the LsarQueryInformationPolicy2 operation response
 type QueryInformationPolicy2Response struct {
+	// XXX: InformationClass is an implicit input depedency for output parameters
+	InformationClass PolicyInformationClass `idl:"name:InformationClass" json:"information_class"`
 	// PolicyInformation: A parameter that references policy information structure on return.
 	PolicyInformation *PolicyInformation `idl:"name:PolicyInformation;switch_is:InformationClass" json:"policy_information"`
 	// Return: The LsarQueryInformationPolicy2 return value.
@@ -19468,6 +19500,11 @@ func (o *QueryInformationPolicy2Response) xxx_ToOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InformationClass == PolicyInformationClass(0) {
+		op.InformationClass = o.InformationClass
+	}
+
 	op.PolicyInformation = o.PolicyInformation
 	op.Return = o.Return
 	return op
@@ -19477,6 +19514,9 @@ func (o *QueryInformationPolicy2Response) xxx_FromOp(ctx context.Context, op *xx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InformationClass = op.InformationClass
+
 	o.PolicyInformation = op.PolicyInformation
 	o.Return = op.Return
 }
@@ -19920,6 +19960,8 @@ func (o *QueryTrustedDomainInfoByNameRequest) UnmarshalNDR(ctx context.Context, 
 
 // QueryTrustedDomainInfoByNameResponse structure represents the LsarQueryTrustedDomainInfoByName operation response
 type QueryTrustedDomainInfoByNameResponse struct {
+	// XXX: InformationClass is an implicit input depedency for output parameters
+	InformationClass TrustedInformationClass `idl:"name:InformationClass" json:"information_class"`
 	// TrustedDomainInformation: Used to return the information requested by the caller.
 	TrustedDomainInformation *TrustedDomainInfo `idl:"name:TrustedDomainInformation;switch_is:InformationClass" json:"trusted_domain_information"`
 	// Return: The LsarQueryTrustedDomainInfoByName return value.
@@ -19933,6 +19975,11 @@ func (o *QueryTrustedDomainInfoByNameResponse) xxx_ToOp(ctx context.Context, op 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InformationClass == TrustedInformationClass(0) {
+		op.InformationClass = o.InformationClass
+	}
+
 	op.TrustedDomainInformation = o.TrustedDomainInformation
 	op.Return = o.Return
 	return op
@@ -19942,6 +19989,9 @@ func (o *QueryTrustedDomainInfoByNameResponse) xxx_FromOp(ctx context.Context, o
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InformationClass = op.InformationClass
+
 	o.TrustedDomainInformation = op.TrustedDomainInformation
 	o.Return = op.Return
 }
@@ -20887,6 +20937,8 @@ func (o *QueryDomainInformationPolicyRequest) UnmarshalNDR(ctx context.Context, 
 
 // QueryDomainInformationPolicyResponse structure represents the LsarQueryDomainInformationPolicy operation response
 type QueryDomainInformationPolicyResponse struct {
+	// XXX: InformationClass is an implicit input depedency for output parameters
+	InformationClass PolicyDomainInformationClass `idl:"name:InformationClass" json:"information_class"`
 	// PolicyDomainInformation: A parameter that references policy information structure
 	// on return.
 	PolicyDomainInformation *PolicyDomainInformation `idl:"name:PolicyDomainInformation;switch_is:InformationClass" json:"policy_domain_information"`
@@ -20901,6 +20953,11 @@ func (o *QueryDomainInformationPolicyResponse) xxx_ToOp(ctx context.Context, op 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InformationClass == PolicyDomainInformationClass(0) {
+		op.InformationClass = o.InformationClass
+	}
+
 	op.PolicyDomainInformation = o.PolicyDomainInformation
 	op.Return = o.Return
 	return op
@@ -20910,6 +20967,9 @@ func (o *QueryDomainInformationPolicyResponse) xxx_FromOp(ctx context.Context, o
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InformationClass = op.InformationClass
+
 	o.PolicyDomainInformation = op.PolicyDomainInformation
 	o.Return = op.Return
 }

--- a/msrpc/lsad/lsarpc/v0/v0.go
+++ b/msrpc/lsad/lsarpc/v0/v0.go
@@ -11650,6 +11650,7 @@ func (o *QueryInformationPolicyRequest) UnmarshalNDR(ctx context.Context, r ndr.
 type QueryInformationPolicyResponse struct {
 	// XXX: InformationClass is an implicit input depedency for output parameters
 	InformationClass PolicyInformationClass `idl:"name:InformationClass" json:"information_class"`
+
 	// PolicyInformation: A parameter that references policy information structure on return.
 	PolicyInformation *PolicyInformation `idl:"name:PolicyInformation;switch_is:InformationClass" json:"policy_information"`
 	// Return: The LsarQueryInformationPolicy return value.
@@ -14662,6 +14663,7 @@ func (o *QueryInfoTrustedDomainRequest) UnmarshalNDR(ctx context.Context, r ndr.
 type QueryInfoTrustedDomainResponse struct {
 	// XXX: InformationClass is an implicit input depedency for output parameters
 	InformationClass TrustedInformationClass `idl:"name:InformationClass" json:"information_class"`
+
 	// TrustedDomainInformation: Used to return requested information about the trusted
 	// domain object.
 	TrustedDomainInformation *TrustedDomainInfo `idl:"name:TrustedDomainInformation;switch_is:InformationClass" json:"trusted_domain_information"`
@@ -18062,6 +18064,7 @@ func (o *QueryTrustedDomainInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.
 type QueryTrustedDomainInfoResponse struct {
 	// XXX: InformationClass is an implicit input depedency for output parameters
 	InformationClass TrustedInformationClass `idl:"name:InformationClass" json:"information_class"`
+
 	// TrustedDomainInformation: Used to return the information on the trusted domain object
 	// to the caller.
 	TrustedDomainInformation *TrustedDomainInfo `idl:"name:TrustedDomainInformation;switch_is:InformationClass" json:"trusted_domain_information"`
@@ -19487,6 +19490,7 @@ func (o *QueryInformationPolicy2Request) UnmarshalNDR(ctx context.Context, r ndr
 type QueryInformationPolicy2Response struct {
 	// XXX: InformationClass is an implicit input depedency for output parameters
 	InformationClass PolicyInformationClass `idl:"name:InformationClass" json:"information_class"`
+
 	// PolicyInformation: A parameter that references policy information structure on return.
 	PolicyInformation *PolicyInformation `idl:"name:PolicyInformation;switch_is:InformationClass" json:"policy_information"`
 	// Return: The LsarQueryInformationPolicy2 return value.
@@ -19962,6 +19966,7 @@ func (o *QueryTrustedDomainInfoByNameRequest) UnmarshalNDR(ctx context.Context, 
 type QueryTrustedDomainInfoByNameResponse struct {
 	// XXX: InformationClass is an implicit input depedency for output parameters
 	InformationClass TrustedInformationClass `idl:"name:InformationClass" json:"information_class"`
+
 	// TrustedDomainInformation: Used to return the information requested by the caller.
 	TrustedDomainInformation *TrustedDomainInfo `idl:"name:TrustedDomainInformation;switch_is:InformationClass" json:"trusted_domain_information"`
 	// Return: The LsarQueryTrustedDomainInfoByName return value.
@@ -20939,6 +20944,7 @@ func (o *QueryDomainInformationPolicyRequest) UnmarshalNDR(ctx context.Context, 
 type QueryDomainInformationPolicyResponse struct {
 	// XXX: InformationClass is an implicit input depedency for output parameters
 	InformationClass PolicyDomainInformationClass `idl:"name:InformationClass" json:"information_class"`
+
 	// PolicyDomainInformation: A parameter that references policy information structure
 	// on return.
 	PolicyDomainInformation *PolicyDomainInformation `idl:"name:PolicyDomainInformation;switch_is:InformationClass" json:"policy_domain_information"`

--- a/msrpc/mqds/dscomm/v1/v1.go
+++ b/msrpc/mqds/dscomm/v1/v1.go
@@ -2205,6 +2205,7 @@ func (o *GetPropertiesRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 type GetPropertiesResponse struct {
 	// XXX: cp is an implicit input depedency for output parameters
 	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
+
 	// apVar: On input, each element MUST be initialized to the appropriate VARTYPE ([MS-MQMQ]
 	// section 2.2.12.1) for the associated property specified by the same element in aProp,
 	// or VT_NULL. On success, the server MUST populate the elements of this array with
@@ -2959,6 +2960,7 @@ func (o *GetObjectSecurityRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type GetObjectSecurityResponse struct {
 	// XXX: nLength is an implicit input depedency for output parameters
 	Length uint32 `idl:"name:nLength" json:"length"`
+
 	// pSecurityDescriptor: If the SecurityInformation parameter is MQDS_SIGN_PUBLIC_KEY
 	// or MQDS_KEYX_PUBLIC_KEY, it SHOULD<55> contain a pointer to a BLOBHEADER (section
 	// 2.2.19) structure followed by an RSAPUBKEY (section 2.2.18) structure. Otherwise,
@@ -4034,6 +4036,7 @@ func (o *LookupNextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 type LookupNextResponse struct {
 	// XXX: dwSize is an implicit input depedency for output parameters
 	Size uint32 `idl:"name:dwSize" json:"size"`
+
 	// dwOutSize: A pointer to an unsigned LONG that the server MUST set to the number of
 	// properties returned in pbBuffer for the set of objects being returned from this invocation
 	// of the S_DSLookupNext method. The server MUST return as many completed sets of properties
@@ -4946,6 +4949,7 @@ func (o *GetPropertiesGUIDRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type GetPropertiesGUIDResponse struct {
 	// XXX: cp is an implicit input depedency for output parameters
 	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
+
 	// apVar: On input, each element MUST be initialized to the appropriate VARTYPE ([MS-MQMQ]
 	// section 2.2.12.1) for the associated property specified by the same element in aProp,
 	// or VT_NULL. On success, the server MUST populate the elements of this array with
@@ -5682,6 +5686,7 @@ func (o *GetObjectSecurityGUIDRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 type GetObjectSecurityGUIDResponse struct {
 	// XXX: nLength is an implicit input depedency for output parameters
 	Length uint32 `idl:"name:nLength" json:"length"`
+
 	// pSecurityDescriptor: If the SecurityInformation parameter is MQDS_SIGN_PUBLIC_KEY
 	// or MQDS_KEYX_PUBLIC_KEY, it SHOULD<59> contain a pointer to a BLOBHEADER structure
 	// followed by an RSAPUBKEY (section 2.2.18) structure. Otherwise, this parameter contains
@@ -7172,6 +7177,7 @@ func (o *QMSetMachinePropertiesSignProcRequest) UnmarshalNDR(ctx context.Context
 type QMSetMachinePropertiesSignProcResponse struct {
 	// XXX: dwSignatureMaxSize is an implicit input depedency for output parameters
 	SignatureMaxSize uint32 `idl:"name:dwSignatureMaxSize" json:"signature_max_size"`
+
 	// abSignature: MUST be set by the caller to a pointer to a buffer to contain the returned
 	// signature. MUST be set by the receiver to a signature over the challenge in abChallenge.
 	// The algorithm for creating this signature is specified by the following pseudocode.
@@ -7598,6 +7604,7 @@ func (o *QMGetObjectSecurityRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type QMGetObjectSecurityResponse struct {
 	// XXX: nLength is an implicit input depedency for output parameters
 	Length uint32 `idl:"name:nLength" json:"length"`
+
 	// pSecurityDescriptor: If the SecurityInformation parameter is MQDS_SIGN_PUBLIC_KEY
 	// or MQDS_KEYX_PUBLIC_KEY, it SHOULD <73> contain a pointer to a BLOBHEADER structure
 	// followed by an RSAPUBKEY (section 2.2.18) structure. Otherwise, this parameter contains
@@ -8057,6 +8064,7 @@ func (o *QMGetObjectSecurityChallengeResponseProcRequest) UnmarshalNDR(ctx conte
 type QMGetObjectSecurityChallengeResponseProcResponse struct {
 	// XXX: dwCallengeResponceMaxSize is an implicit input depedency for output parameters
 	ChallengeResponseMaxSize uint32 `idl:"name:dwCallengeResponceMaxSize" json:"challenge_response_max_size"`
+
 	// abCallengeResponce:  MUST be set by the caller to a pointer to a buffer to contain
 	// the returned signature. MUST be set by the receiver to a signature over the challenge
 	// in abChallenge. The algorithm for creating this signature is specified by the following
@@ -8405,6 +8413,7 @@ func (o *InitSecurityContextRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type InitSecurityContextResponse struct {
 	// XXX: dwClientBuffMaxSize is an implicit input depedency for output parameters
 	ClientBufferMaxSize uint32 `idl:"name:dwClientBuffMaxSize" json:"client_buffer_max_size"`
+
 	// pClientBuff:  MUST be set by the caller to point to a buffer to hold the returned
 	// token. MUST be set by the receiver to the output_token from a call to GSS_Init_sec_context.
 	// The buffer length MUST NOT exceed the value specified by dwClientBuffMaxSize. If

--- a/msrpc/mqds/dscomm/v1/v1.go
+++ b/msrpc/mqds/dscomm/v1/v1.go
@@ -2203,6 +2203,8 @@ func (o *GetPropertiesRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 
 // GetPropertiesResponse structure represents the S_DSGetProps operation response
 type GetPropertiesResponse struct {
+	// XXX: cp is an implicit input depedency for output parameters
+	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
 	// apVar: On input, each element MUST be initialized to the appropriate VARTYPE ([MS-MQMQ]
 	// section 2.2.12.1) for the associated property specified by the same element in aProp,
 	// or VT_NULL. On success, the server MUST populate the elements of this array with
@@ -2225,6 +2227,11 @@ func (o *GetPropertiesResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPropert
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.CreatePartition == uint32(0) {
+		op.CreatePartition = o.CreatePartition
+	}
+
 	op.Var = o.Var
 	op.ServerSignature = o.ServerSignature
 	op.ServerSignatureSize = o.ServerSignatureSize
@@ -2236,6 +2243,9 @@ func (o *GetPropertiesResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPrope
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.CreatePartition = op.CreatePartition
+
 	o.Var = op.Var
 	o.ServerSignature = op.ServerSignature
 	o.ServerSignatureSize = op.ServerSignatureSize
@@ -2947,6 +2957,8 @@ func (o *GetObjectSecurityRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // GetObjectSecurityResponse structure represents the S_DSGetObjectSecurity operation response
 type GetObjectSecurityResponse struct {
+	// XXX: nLength is an implicit input depedency for output parameters
+	Length uint32 `idl:"name:nLength" json:"length"`
 	// pSecurityDescriptor: If the SecurityInformation parameter is MQDS_SIGN_PUBLIC_KEY
 	// or MQDS_KEYX_PUBLIC_KEY, it SHOULD<55> contain a pointer to a BLOBHEADER (section
 	// 2.2.19) structure followed by an RSAPUBKEY (section 2.2.18) structure. Otherwise,
@@ -2972,6 +2984,11 @@ func (o *GetObjectSecurityResponse) xxx_ToOp(ctx context.Context, op *xxx_GetObj
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Length == uint32(0) {
+		op.Length = o.Length
+	}
+
 	op.SecurityDescriptor = o.SecurityDescriptor
 	op.LengthNeeded = o.LengthNeeded
 	op.ServerSignature = o.ServerSignature
@@ -2984,6 +3001,9 @@ func (o *GetObjectSecurityResponse) xxx_FromOp(ctx context.Context, op *xxx_GetO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Length = op.Length
+
 	o.SecurityDescriptor = op.SecurityDescriptor
 	o.LengthNeeded = op.LengthNeeded
 	o.ServerSignature = op.ServerSignature
@@ -4012,6 +4032,8 @@ func (o *LookupNextRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 
 // LookupNextResponse structure represents the S_DSLookupNext operation response
 type LookupNextResponse struct {
+	// XXX: dwSize is an implicit input depedency for output parameters
+	Size uint32 `idl:"name:dwSize" json:"size"`
 	// dwOutSize: A pointer to an unsigned LONG that the server MUST set to the number of
 	// properties returned in pbBuffer for the set of objects being returned from this invocation
 	// of the S_DSLookupNext method. The server MUST return as many completed sets of properties
@@ -4041,6 +4063,11 @@ func (o *LookupNextResponse) xxx_ToOp(ctx context.Context, op *xxx_LookupNextOpe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Size == uint32(0) {
+		op.Size = o.Size
+	}
+
 	op.OutSize = o.OutSize
 	op.Buffer = o.Buffer
 	op.ServerSignature = o.ServerSignature
@@ -4053,6 +4080,9 @@ func (o *LookupNextResponse) xxx_FromOp(ctx context.Context, op *xxx_LookupNextO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Size = op.Size
+
 	o.OutSize = op.OutSize
 	o.Buffer = op.Buffer
 	o.ServerSignature = op.ServerSignature
@@ -4914,6 +4944,8 @@ func (o *GetPropertiesGUIDRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // GetPropertiesGUIDResponse structure represents the S_DSGetPropsGuid operation response
 type GetPropertiesGUIDResponse struct {
+	// XXX: cp is an implicit input depedency for output parameters
+	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
 	// apVar: On input, each element MUST be initialized to the appropriate VARTYPE ([MS-MQMQ]
 	// section 2.2.12.1) for the associated property specified by the same element in aProp,
 	// or VT_NULL. On success, the server MUST populate the elements of this array with
@@ -4937,6 +4969,11 @@ func (o *GetPropertiesGUIDResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPro
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.CreatePartition == uint32(0) {
+		op.CreatePartition = o.CreatePartition
+	}
+
 	op.Var = o.Var
 	op.ServerSignature = o.ServerSignature
 	op.ServerSignatureSize = o.ServerSignatureSize
@@ -4948,6 +4985,9 @@ func (o *GetPropertiesGUIDResponse) xxx_FromOp(ctx context.Context, op *xxx_GetP
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.CreatePartition = op.CreatePartition
+
 	o.Var = op.Var
 	o.ServerSignature = op.ServerSignature
 	o.ServerSignatureSize = op.ServerSignatureSize
@@ -5640,6 +5680,8 @@ func (o *GetObjectSecurityGUIDRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // GetObjectSecurityGUIDResponse structure represents the S_DSGetObjectSecurityGuid operation response
 type GetObjectSecurityGUIDResponse struct {
+	// XXX: nLength is an implicit input depedency for output parameters
+	Length uint32 `idl:"name:nLength" json:"length"`
 	// pSecurityDescriptor: If the SecurityInformation parameter is MQDS_SIGN_PUBLIC_KEY
 	// or MQDS_KEYX_PUBLIC_KEY, it SHOULD<59> contain a pointer to a BLOBHEADER structure
 	// followed by an RSAPUBKEY (section 2.2.18) structure. Otherwise, this parameter contains
@@ -5667,6 +5709,11 @@ func (o *GetObjectSecurityGUIDResponse) xxx_ToOp(ctx context.Context, op *xxx_Ge
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Length == uint32(0) {
+		op.Length = o.Length
+	}
+
 	op.SecurityDescriptor = o.SecurityDescriptor
 	op.LengthNeeded = o.LengthNeeded
 	op.ServerSignature = o.ServerSignature
@@ -5679,6 +5726,9 @@ func (o *GetObjectSecurityGUIDResponse) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Length = op.Length
+
 	o.SecurityDescriptor = op.SecurityDescriptor
 	o.LengthNeeded = op.LengthNeeded
 	o.ServerSignature = op.ServerSignature
@@ -7120,6 +7170,8 @@ func (o *QMSetMachinePropertiesSignProcRequest) UnmarshalNDR(ctx context.Context
 
 // QMSetMachinePropertiesSignProcResponse structure represents the S_DSQMSetMachinePropertiesSignProc operation response
 type QMSetMachinePropertiesSignProcResponse struct {
+	// XXX: dwSignatureMaxSize is an implicit input depedency for output parameters
+	SignatureMaxSize uint32 `idl:"name:dwSignatureMaxSize" json:"signature_max_size"`
 	// abSignature: MUST be set by the caller to a pointer to a buffer to contain the returned
 	// signature. MUST be set by the receiver to a signature over the challenge in abChallenge.
 	// The algorithm for creating this signature is specified by the following pseudocode.
@@ -7139,6 +7191,11 @@ func (o *QMSetMachinePropertiesSignProcResponse) xxx_ToOp(ctx context.Context, o
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.SignatureMaxSize == uint32(0) {
+		op.SignatureMaxSize = o.SignatureMaxSize
+	}
+
 	op.Signature = o.Signature
 	op.SignatureSize = o.SignatureSize
 	op.Return = o.Return
@@ -7149,6 +7206,9 @@ func (o *QMSetMachinePropertiesSignProcResponse) xxx_FromOp(ctx context.Context,
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.SignatureMaxSize = op.SignatureMaxSize
+
 	o.Signature = op.Signature
 	o.SignatureSize = op.SignatureSize
 	o.Return = op.Return
@@ -7536,6 +7596,8 @@ func (o *QMGetObjectSecurityRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // QMGetObjectSecurityResponse structure represents the S_DSQMGetObjectSecurity operation response
 type QMGetObjectSecurityResponse struct {
+	// XXX: nLength is an implicit input depedency for output parameters
+	Length uint32 `idl:"name:nLength" json:"length"`
 	// pSecurityDescriptor: If the SecurityInformation parameter is MQDS_SIGN_PUBLIC_KEY
 	// or MQDS_KEYX_PUBLIC_KEY, it SHOULD <73> contain a pointer to a BLOBHEADER structure
 	// followed by an RSAPUBKEY (section 2.2.18) structure. Otherwise, this parameter contains
@@ -7563,6 +7625,11 @@ func (o *QMGetObjectSecurityResponse) xxx_ToOp(ctx context.Context, op *xxx_QMGe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Length == uint32(0) {
+		op.Length = o.Length
+	}
+
 	op.SecurityDescriptor = o.SecurityDescriptor
 	op.LengthNeeded = o.LengthNeeded
 	op.ServerSignature = o.ServerSignature
@@ -7575,6 +7642,9 @@ func (o *QMGetObjectSecurityResponse) xxx_FromOp(ctx context.Context, op *xxx_QM
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Length = op.Length
+
 	o.SecurityDescriptor = op.SecurityDescriptor
 	o.LengthNeeded = op.LengthNeeded
 	o.ServerSignature = op.ServerSignature
@@ -7985,6 +8055,8 @@ func (o *QMGetObjectSecurityChallengeResponseProcRequest) UnmarshalNDR(ctx conte
 
 // QMGetObjectSecurityChallengeResponseProcResponse structure represents the S_DSQMGetObjectSecurityChallengeResponceProc operation response
 type QMGetObjectSecurityChallengeResponseProcResponse struct {
+	// XXX: dwCallengeResponceMaxSize is an implicit input depedency for output parameters
+	ChallengeResponseMaxSize uint32 `idl:"name:dwCallengeResponceMaxSize" json:"challenge_response_max_size"`
 	// abCallengeResponce:  MUST be set by the caller to a pointer to a buffer to contain
 	// the returned signature. MUST be set by the receiver to a signature over the challenge
 	// in abChallenge. The algorithm for creating this signature is specified by the following
@@ -8005,6 +8077,11 @@ func (o *QMGetObjectSecurityChallengeResponseProcResponse) xxx_ToOp(ctx context.
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ChallengeResponseMaxSize == uint32(0) {
+		op.ChallengeResponseMaxSize = o.ChallengeResponseMaxSize
+	}
+
 	op.ChallengeResponse = o.ChallengeResponse
 	op.ChallengeResponseSize = o.ChallengeResponseSize
 	op.Return = o.Return
@@ -8015,6 +8092,9 @@ func (o *QMGetObjectSecurityChallengeResponseProcResponse) xxx_FromOp(ctx contex
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ChallengeResponseMaxSize = op.ChallengeResponseMaxSize
+
 	o.ChallengeResponse = op.ChallengeResponse
 	o.ChallengeResponseSize = op.ChallengeResponseSize
 	o.Return = op.Return
@@ -8323,6 +8403,8 @@ func (o *InitSecurityContextRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // InitSecurityContextResponse structure represents the S_InitSecCtx operation response
 type InitSecurityContextResponse struct {
+	// XXX: dwClientBuffMaxSize is an implicit input depedency for output parameters
+	ClientBufferMaxSize uint32 `idl:"name:dwClientBuffMaxSize" json:"client_buffer_max_size"`
 	// pClientBuff:  MUST be set by the caller to point to a buffer to hold the returned
 	// token. MUST be set by the receiver to the output_token from a call to GSS_Init_sec_context.
 	// The buffer length MUST NOT exceed the value specified by dwClientBuffMaxSize. If
@@ -8343,6 +8425,11 @@ func (o *InitSecurityContextResponse) xxx_ToOp(ctx context.Context, op *xxx_Init
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ClientBufferMaxSize == uint32(0) {
+		op.ClientBufferMaxSize = o.ClientBufferMaxSize
+	}
+
 	op.ClientBuffer = o.ClientBuffer
 	op.ClientBufferSize = o.ClientBufferSize
 	op.Return = o.Return
@@ -8353,6 +8440,9 @@ func (o *InitSecurityContextResponse) xxx_FromOp(ctx context.Context, op *xxx_In
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ClientBufferMaxSize = op.ClientBufferMaxSize
+
 	o.ClientBuffer = op.ClientBuffer
 	o.ClientBufferSize = op.ClientBufferSize
 	o.Return = op.Return

--- a/msrpc/mqds/dscomm2/v1/v1.go
+++ b/msrpc/mqds/dscomm2/v1/v1.go
@@ -1146,6 +1146,8 @@ func (o *GetPropertiesExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // GetPropertiesExResponse structure represents the S_DSGetPropsEx operation response
 type GetPropertiesExResponse struct {
+	// XXX: cp is an implicit input depedency for output parameters
+	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
 	// apVar:  MUST be set by the client to an array that holds the property values retrieved
 	// from the object. Each element MUST be set by the server to the property value for
 	// the corresponding property identifier at the same element index in aProp. The array
@@ -1168,6 +1170,11 @@ func (o *GetPropertiesExResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrope
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.CreatePartition == uint32(0) {
+		op.CreatePartition = o.CreatePartition
+	}
+
 	op.Var = o.Var
 	op.ServerSignature = o.ServerSignature
 	op.ServerSignatureSize = o.ServerSignatureSize
@@ -1179,6 +1186,9 @@ func (o *GetPropertiesExResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPro
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.CreatePartition = op.CreatePartition
+
 	o.Var = op.Var
 	o.ServerSignature = op.ServerSignature
 	o.ServerSignatureSize = op.ServerSignatureSize
@@ -1681,6 +1691,8 @@ func (o *GetPropertiesGUIDExRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // GetPropertiesGUIDExResponse structure represents the S_DSGetPropsGuidEx operation response
 type GetPropertiesGUIDExResponse struct {
+	// XXX: cp is an implicit input depedency for output parameters
+	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
 	// apVar:  MUST be set by the client to an array that holds the property values retrieved
 	// from the object. Each element MUST be set by the server to the property value for
 	// the corresponding property identifier at the same element index in aProp. The array
@@ -1703,6 +1715,11 @@ func (o *GetPropertiesGUIDExResponse) xxx_ToOp(ctx context.Context, op *xxx_GetP
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.CreatePartition == uint32(0) {
+		op.CreatePartition = o.CreatePartition
+	}
+
 	op.Var = o.Var
 	op.ServerSignature = o.ServerSignature
 	op.ServerSignatureSize = o.ServerSignatureSize
@@ -1714,6 +1731,9 @@ func (o *GetPropertiesGUIDExResponse) xxx_FromOp(ctx context.Context, op *xxx_Ge
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.CreatePartition = op.CreatePartition
+
 	o.Var = op.Var
 	o.ServerSignature = op.ServerSignature
 	o.ServerSignatureSize = op.ServerSignatureSize

--- a/msrpc/mqds/dscomm2/v1/v1.go
+++ b/msrpc/mqds/dscomm2/v1/v1.go
@@ -1148,6 +1148,7 @@ func (o *GetPropertiesExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 type GetPropertiesExResponse struct {
 	// XXX: cp is an implicit input depedency for output parameters
 	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
+
 	// apVar:  MUST be set by the client to an array that holds the property values retrieved
 	// from the object. Each element MUST be set by the server to the property value for
 	// the corresponding property identifier at the same element index in aProp. The array
@@ -1693,6 +1694,7 @@ func (o *GetPropertiesGUIDExRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type GetPropertiesGUIDExResponse struct {
 	// XXX: cp is an implicit input depedency for output parameters
 	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
+
 	// apVar:  MUST be set by the client to an array that holds the property values retrieved
 	// from the object. Each element MUST be set by the server to the property value for
 	// the corresponding property identifier at the same element index in aProp. The array

--- a/msrpc/mqmp/qmcomm/v1/v1.go
+++ b/msrpc/mqmp/qmcomm/v1/v1.go
@@ -6649,6 +6649,8 @@ func (o *GetObjectSecurityInternalRequest) UnmarshalNDR(ctx context.Context, r n
 
 // GetObjectSecurityInternalResponse structure represents the R_QMGetObjectSecurityInternal operation response
 type GetObjectSecurityInternalResponse struct {
+	// XXX: nLength is an implicit input depedency for output parameters
+	Length uint32 `idl:"name:nLength" json:"length"`
 	// pSecurityDescriptor:  MUST be a pointer to an array of bytes into which the server
 	// MUST write a self-relative SECURITY_DESCRIPTOR structure. The server MUST NOT write
 	// more than nLength bytes to the buffer. If the buffer provided by the client is too
@@ -6672,6 +6674,11 @@ func (o *GetObjectSecurityInternalResponse) xxx_ToOp(ctx context.Context, op *xx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Length == uint32(0) {
+		op.Length = o.Length
+	}
+
 	op.SecurityDescriptor = o.SecurityDescriptor
 	op.LengthNeeded = o.LengthNeeded
 	op.Return = o.Return
@@ -6682,6 +6689,9 @@ func (o *GetObjectSecurityInternalResponse) xxx_FromOp(ctx context.Context, op *
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Length = op.Length
+
 	o.SecurityDescriptor = op.SecurityDescriptor
 	o.LengthNeeded = op.LengthNeeded
 	o.Return = op.Return
@@ -7201,6 +7211,8 @@ func (o *GetObjectPropertiesRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // GetObjectPropertiesResponse structure represents the R_QMGetObjectProperties operation response
 type GetObjectPropertiesResponse struct {
+	// XXX: cp is an implicit input depedency for output parameters
+	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
 	// apVar: MUST contain at least one element. On input, each element MUST be initialized
 	// to the appropriate VARTYPE for the associated property specified by the same element
 	// in aProp, or VT_NULL. Otherwise, the server SHOULD return the failure HRESULT MQ_ERROR_PROPERTY
@@ -7219,6 +7231,11 @@ func (o *GetObjectPropertiesResponse) xxx_ToOp(ctx context.Context, op *xxx_GetO
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.CreatePartition == uint32(0) {
+		op.CreatePartition = o.CreatePartition
+	}
+
 	op.Var = o.Var
 	op.Return = o.Return
 	return op
@@ -7228,6 +7245,9 @@ func (o *GetObjectPropertiesResponse) xxx_FromOp(ctx context.Context, op *xxx_Ge
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.CreatePartition = op.CreatePartition
+
 	o.Var = op.Var
 	o.Return = op.Return
 }
@@ -7952,6 +7972,8 @@ func (o *GetTMWhereaboutsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // GetTMWhereaboutsResponse structure represents the R_QMGetTmWhereabouts operation response
 type GetTMWhereaboutsResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// pbWhereabouts:  On success, points to an array of bytes containing a Distributed
 	// Transaction Coordinator (DTC) SWhereabouts structure, as specified in [MS-DTCO] section
 	// 2.2.5.11.
@@ -7971,6 +7993,11 @@ func (o *GetTMWhereaboutsResponse) xxx_ToOp(ctx context.Context, op *xxx_GetTMWh
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Whereabouts = o.Whereabouts
 	op.WhereaboutsLength = o.WhereaboutsLength
 	op.Return = o.Return
@@ -7981,6 +8008,9 @@ func (o *GetTMWhereaboutsResponse) xxx_FromOp(ctx context.Context, op *xxx_GetTM
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Whereabouts = op.Whereabouts
 	o.WhereaboutsLength = op.WhereaboutsLength
 	o.Return = op.Return
@@ -10270,6 +10300,8 @@ func (o *HandleToFormatNameRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // HandleToFormatNameResponse structure represents the rpc_ACHandleToFormatName operation response
 type HandleToFormatNameResponse struct {
+	// XXX: dwFormatNameRPCBufferLen is an implicit input depedency for output parameters
+	FormatNameRPCBufferLength uint32 `idl:"name:dwFormatNameRPCBufferLen" json:"format_name_rpc_buffer_length"`
 	// lpwcsFormatName:  Pointer to a Unicode character buffer into which the server writes
 	// the format name (as specified in [MS-MQMQ]) for the queue identified by the hQueue
 	// parameter. The character buffer MUST be null-terminated by the server prior to returning,
@@ -10294,6 +10326,11 @@ func (o *HandleToFormatNameResponse) xxx_ToOp(ctx context.Context, op *xxx_Handl
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.FormatNameRPCBufferLength == uint32(0) {
+		op.FormatNameRPCBufferLength = o.FormatNameRPCBufferLength
+	}
+
 	op.FormatName = o.FormatName
 	op.Length = o.Length
 	op.Return = o.Return
@@ -10304,6 +10341,9 @@ func (o *HandleToFormatNameResponse) xxx_FromOp(ctx context.Context, op *xxx_Han
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.FormatNameRPCBufferLength = op.FormatNameRPCBufferLength
+
 	o.FormatName = op.FormatName
 	o.Length = op.Length
 	o.Return = op.Return

--- a/msrpc/mqmp/qmcomm/v1/v1.go
+++ b/msrpc/mqmp/qmcomm/v1/v1.go
@@ -6651,6 +6651,7 @@ func (o *GetObjectSecurityInternalRequest) UnmarshalNDR(ctx context.Context, r n
 type GetObjectSecurityInternalResponse struct {
 	// XXX: nLength is an implicit input depedency for output parameters
 	Length uint32 `idl:"name:nLength" json:"length"`
+
 	// pSecurityDescriptor:  MUST be a pointer to an array of bytes into which the server
 	// MUST write a self-relative SECURITY_DESCRIPTOR structure. The server MUST NOT write
 	// more than nLength bytes to the buffer. If the buffer provided by the client is too
@@ -7213,6 +7214,7 @@ func (o *GetObjectPropertiesRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type GetObjectPropertiesResponse struct {
 	// XXX: cp is an implicit input depedency for output parameters
 	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
+
 	// apVar: MUST contain at least one element. On input, each element MUST be initialized
 	// to the appropriate VARTYPE for the associated property specified by the same element
 	// in aProp, or VT_NULL. Otherwise, the server SHOULD return the failure HRESULT MQ_ERROR_PROPERTY
@@ -7974,6 +7976,7 @@ func (o *GetTMWhereaboutsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type GetTMWhereaboutsResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// pbWhereabouts:  On success, points to an array of bytes containing a Distributed
 	// Transaction Coordinator (DTC) SWhereabouts structure, as specified in [MS-DTCO] section
 	// 2.2.5.11.
@@ -10302,6 +10305,7 @@ func (o *HandleToFormatNameRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 type HandleToFormatNameResponse struct {
 	// XXX: dwFormatNameRPCBufferLen is an implicit input depedency for output parameters
 	FormatNameRPCBufferLength uint32 `idl:"name:dwFormatNameRPCBufferLen" json:"format_name_rpc_buffer_length"`
+
 	// lpwcsFormatName:  Pointer to a Unicode character buffer into which the server writes
 	// the format name (as specified in [MS-MQMQ]) for the queue identified by the hQueue
 	// parameter. The character buffer MUST be null-terminated by the server prior to returning,

--- a/msrpc/mqmr/qmmgmt/v1/v1.go
+++ b/msrpc/mqmr/qmmgmt/v1/v1.go
@@ -825,6 +825,7 @@ func (o *ManagementGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type ManagementGetInfoResponse struct {
 	// XXX: cp is an implicit input depedency for output parameters
 	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
+
 	// apVar: Points to an array that specifies the property values associated with the
 	// array of property identifiers. Each element in this array specifies the property
 	// value for the corresponding property identifier at the same element index in the

--- a/msrpc/mqmr/qmmgmt/v1/v1.go
+++ b/msrpc/mqmr/qmmgmt/v1/v1.go
@@ -823,6 +823,8 @@ func (o *ManagementGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // ManagementGetInfoResponse structure represents the R_QMMgmtGetInfo operation response
 type ManagementGetInfoResponse struct {
+	// XXX: cp is an implicit input depedency for output parameters
+	CreatePartition uint32 `idl:"name:cp" json:"create_partition"`
 	// apVar: Points to an array that specifies the property values associated with the
 	// array of property identifiers. Each element in this array specifies the property
 	// value for the corresponding property identifier at the same element index in the
@@ -843,6 +845,11 @@ func (o *ManagementGetInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_Manage
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.CreatePartition == uint32(0) {
+		op.CreatePartition = o.CreatePartition
+	}
+
 	op.Var = o.Var
 	op.Return = o.Return
 	return op
@@ -852,6 +859,9 @@ func (o *ManagementGetInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_Mana
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.CreatePartition = op.CreatePartition
+
 	o.Var = op.Var
 	o.Return = op.Return
 }

--- a/msrpc/msrp/msgsvc/v1/v1.go
+++ b/msrpc/msrp/msgsvc/v1/v1.go
@@ -1936,6 +1936,7 @@ func (o *MessageNameGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 type MessageNameGetInfoResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// InfoStruct:  A pointer to a structure of type MSG_INFO.
 	Info *MessageInfo `idl:"name:InfoStruct;switch_is:Level" json:"info"`
 	// Return: The NetrMessageNameGetInfo return value.

--- a/msrpc/msrp/msgsvc/v1/v1.go
+++ b/msrpc/msrp/msgsvc/v1/v1.go
@@ -1934,6 +1934,8 @@ func (o *MessageNameGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // MessageNameGetInfoResponse structure represents the NetrMessageNameGetInfo operation response
 type MessageNameGetInfoResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// InfoStruct:  A pointer to a structure of type MSG_INFO.
 	Info *MessageInfo `idl:"name:InfoStruct;switch_is:Level" json:"info"`
 	// Return: The NetrMessageNameGetInfo return value.
@@ -1947,6 +1949,11 @@ func (o *MessageNameGetInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_Messa
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.Info = o.Info
 	op.Return = o.Return
 	return op
@@ -1956,6 +1963,9 @@ func (o *MessageNameGetInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_Mes
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.Info = op.Info
 	o.Return = op.Return
 }

--- a/msrpc/nrpc/logon/v1/v1.go
+++ b/msrpc/nrpc/logon/v1/v1.go
@@ -20250,9 +20250,11 @@ func (o *SAMLogonRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 
 // SAMLogonResponse structure represents the NetrLogonSamLogon operation response
 type SAMLogonResponse struct {
-	ReturnAuthenticator   *Authenticator `idl:"name:ReturnAuthenticator;pointer:unique" json:"return_authenticator"`
-	ValidationInformation *Validation    `idl:"name:ValidationInformation;switch_is:ValidationLevel" json:"validation_information"`
-	Authoritative         uint8          `idl:"name:Authoritative" json:"authoritative"`
+	// XXX: ValidationLevel is an implicit input depedency for output parameters
+	ValidationLevel       ValidationInfoClass `idl:"name:ValidationLevel" json:"validation_level"`
+	ReturnAuthenticator   *Authenticator      `idl:"name:ReturnAuthenticator;pointer:unique" json:"return_authenticator"`
+	ValidationInformation *Validation         `idl:"name:ValidationInformation;switch_is:ValidationLevel" json:"validation_information"`
+	Authoritative         uint8               `idl:"name:Authoritative" json:"authoritative"`
 	// Return: The NetrLogonSamLogon return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -20264,6 +20266,11 @@ func (o *SAMLogonResponse) xxx_ToOp(ctx context.Context, op *xxx_SAMLogonOperati
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ValidationLevel == ValidationInfoClass(0) {
+		op.ValidationLevel = o.ValidationLevel
+	}
+
 	op.ReturnAuthenticator = o.ReturnAuthenticator
 	op.ValidationInformation = o.ValidationInformation
 	op.Authoritative = o.Authoritative
@@ -20275,6 +20282,9 @@ func (o *SAMLogonResponse) xxx_FromOp(ctx context.Context, op *xxx_SAMLogonOpera
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ValidationLevel = op.ValidationLevel
+
 	o.ReturnAuthenticator = op.ReturnAuthenticator
 	o.ValidationInformation = op.ValidationInformation
 	o.Authoritative = op.Authoritative
@@ -22667,6 +22677,8 @@ func (o *AccountDeltasRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 
 // AccountDeltasResponse structure represents the NetrAccountDeltas operation response
 type AccountDeltasResponse struct {
+	// XXX: BufferSize is an implicit input depedency for output parameters
+	BufferSize          uint32         `idl:"name:BufferSize" json:"buffer_size"`
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator" json:"return_authenticator"`
 	Buffer              []byte         `idl:"name:Buffer;size_is:(BufferSize)" json:"buffer"`
 	CountReturned       uint32         `idl:"name:CountReturned" json:"count_returned"`
@@ -22683,6 +22695,11 @@ func (o *AccountDeltasResponse) xxx_ToOp(ctx context.Context, op *xxx_AccountDel
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferSize == uint32(0) {
+		op.BufferSize = o.BufferSize
+	}
+
 	op.ReturnAuthenticator = o.ReturnAuthenticator
 	op.Buffer = o.Buffer
 	op.CountReturned = o.CountReturned
@@ -22696,6 +22713,9 @@ func (o *AccountDeltasResponse) xxx_FromOp(ctx context.Context, op *xxx_AccountD
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferSize = op.BufferSize
+
 	o.ReturnAuthenticator = op.ReturnAuthenticator
 	o.Buffer = op.Buffer
 	o.CountReturned = op.CountReturned
@@ -23092,6 +23112,8 @@ func (o *AccountSyncRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 
 // AccountSyncResponse structure represents the NetrAccountSync operation response
 type AccountSyncResponse struct {
+	// XXX: BufferSize is an implicit input depedency for output parameters
+	BufferSize          uint32         `idl:"name:BufferSize" json:"buffer_size"`
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator" json:"return_authenticator"`
 	Buffer              []byte         `idl:"name:Buffer;size_is:(BufferSize)" json:"buffer"`
 	CountReturned       uint32         `idl:"name:CountReturned" json:"count_returned"`
@@ -23109,6 +23131,11 @@ func (o *AccountSyncResponse) xxx_ToOp(ctx context.Context, op *xxx_AccountSyncO
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferSize == uint32(0) {
+		op.BufferSize = o.BufferSize
+	}
+
 	op.ReturnAuthenticator = o.ReturnAuthenticator
 	op.Buffer = o.Buffer
 	op.CountReturned = o.CountReturned
@@ -23123,6 +23150,9 @@ func (o *AccountSyncResponse) xxx_FromOp(ctx context.Context, op *xxx_AccountSyn
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferSize = op.BufferSize
+
 	o.ReturnAuthenticator = op.ReturnAuthenticator
 	o.Buffer = op.Buffer
 	o.CountReturned = op.CountReturned
@@ -23572,7 +23602,9 @@ func (o *ControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // ControlResponse structure represents the NetrLogonControl operation response
 type ControlResponse struct {
-	Buffer *ControlQueryInformation `idl:"name:Buffer;switch_is:QueryLevel" json:"buffer"`
+	// XXX: QueryLevel is an implicit input depedency for output parameters
+	QueryLevel uint32                   `idl:"name:QueryLevel" json:"query_level"`
+	Buffer     *ControlQueryInformation `idl:"name:Buffer;switch_is:QueryLevel" json:"buffer"`
 	// Return: The NetrLogonControl return value.
 	Return uint32 `idl:"name:Return" json:"return"`
 }
@@ -23584,6 +23616,11 @@ func (o *ControlResponse) xxx_ToOp(ctx context.Context, op *xxx_ControlOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.QueryLevel == uint32(0) {
+		op.QueryLevel = o.QueryLevel
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -23593,6 +23630,9 @@ func (o *ControlResponse) xxx_FromOp(ctx context.Context, op *xxx_ControlOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.QueryLevel = op.QueryLevel
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -24095,7 +24135,9 @@ func (o *Control2Request) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 
 // Control2Response structure represents the NetrLogonControl2 operation response
 type Control2Response struct {
-	Buffer *ControlQueryInformation `idl:"name:Buffer;switch_is:QueryLevel" json:"buffer"`
+	// XXX: QueryLevel is an implicit input depedency for output parameters
+	QueryLevel uint32                   `idl:"name:QueryLevel" json:"query_level"`
+	Buffer     *ControlQueryInformation `idl:"name:Buffer;switch_is:QueryLevel" json:"buffer"`
 	// Return: The NetrLogonControl2 return value.
 	Return uint32 `idl:"name:Return" json:"return"`
 }
@@ -24107,6 +24149,11 @@ func (o *Control2Response) xxx_ToOp(ctx context.Context, op *xxx_Control2Operati
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.QueryLevel == uint32(0) {
+		op.QueryLevel = o.QueryLevel
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -24116,6 +24163,9 @@ func (o *Control2Response) xxx_FromOp(ctx context.Context, op *xxx_Control2Opera
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.QueryLevel = op.QueryLevel
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -25563,6 +25613,8 @@ func (o *Control2ExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 
 // Control2ExResponse structure represents the NetrLogonControl2Ex operation response
 type Control2ExResponse struct {
+	// XXX: QueryLevel is an implicit input depedency for output parameters
+	QueryLevel uint32 `idl:"name:QueryLevel" json:"query_level"`
 	// Buffer: A NETLOGON_CONTROL_QUERY_INFORMATION structure, as specified in section 2.2.1.7.6,
 	// that contains the specific query results, with a level of verbosity as specified
 	// in QueryLevel.
@@ -25578,6 +25630,11 @@ func (o *Control2ExResponse) xxx_ToOp(ctx context.Context, op *xxx_Control2ExOpe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.QueryLevel == uint32(0) {
+		op.QueryLevel = o.QueryLevel
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -25587,6 +25644,9 @@ func (o *Control2ExResponse) xxx_FromOp(ctx context.Context, op *xxx_Control2ExO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.QueryLevel = op.QueryLevel
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -26459,6 +26519,8 @@ func (o *GetCapabilitiesRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // GetCapabilitiesResponse structure represents the NetrLogonGetCapabilities operation response
 type GetCapabilitiesResponse struct {
+	// XXX: QueryLevel is an implicit input depedency for output parameters
+	QueryLevel uint32 `idl:"name:QueryLevel" json:"query_level"`
 	// ReturnAuthenticator: A pointer to a NETLOGON_AUTHENTICATOR structure that contains
 	// the server return authenticator.
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator" json:"return_authenticator"`
@@ -26474,6 +26536,11 @@ func (o *GetCapabilitiesResponse) xxx_ToOp(ctx context.Context, op *xxx_GetCapab
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.QueryLevel == uint32(0) {
+		op.QueryLevel = o.QueryLevel
+	}
+
 	op.ReturnAuthenticator = o.ReturnAuthenticator
 	op.ServerCapabilities = o.ServerCapabilities
 	op.Return = o.Return
@@ -26484,6 +26551,9 @@ func (o *GetCapabilitiesResponse) xxx_FromOp(ctx context.Context, op *xxx_GetCap
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.QueryLevel = op.QueryLevel
+
 	o.ReturnAuthenticator = op.ReturnAuthenticator
 	o.ServerCapabilities = op.ServerCapabilities
 	o.Return = op.Return
@@ -28911,6 +28981,8 @@ func (o *GetDomainInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 
 // GetDomainInfoResponse structure represents the NetrLogonGetDomainInfo operation response
 type GetDomainInfoResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// ReturnAuthenticator: A pointer to a NETLOGON_AUTHENTICATOR structure, as specified
 	// in section 2.2.1.1.5, that contains the server return authenticator.
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator" json:"return_authenticator"`
@@ -28928,6 +29000,11 @@ func (o *GetDomainInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_GetDomainI
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.ReturnAuthenticator = o.ReturnAuthenticator
 	op.DomBuffer = o.DomBuffer
 	op.Return = o.Return
@@ -28938,6 +29015,9 @@ func (o *GetDomainInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_GetDomai
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.ReturnAuthenticator = op.ReturnAuthenticator
 	o.DomBuffer = op.DomBuffer
 	o.Return = op.Return
@@ -32090,6 +32170,8 @@ func (o *SAMLogonExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 
 // SAMLogonExResponse structure represents the NetrLogonSamLogonEx operation response
 type SAMLogonExResponse struct {
+	// XXX: ValidationLevel is an implicit input depedency for output parameters
+	ValidationLevel ValidationInfoClass `idl:"name:ValidationLevel" json:"validation_level"`
 	// ValidationInformation: A pointer to a NETLOGON_VALIDATION structure, as specified
 	// in section 2.2.1.4.14, that describes the user validation information returned to
 	// the client. The type of the NETLOGON_VALIDATION used is determined by the value of
@@ -32140,6 +32222,11 @@ func (o *SAMLogonExResponse) xxx_ToOp(ctx context.Context, op *xxx_SAMLogonExOpe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ValidationLevel == ValidationInfoClass(0) {
+		op.ValidationLevel = o.ValidationLevel
+	}
+
 	op.ValidationInformation = o.ValidationInformation
 	op.Authoritative = o.Authoritative
 	op.ExtraFlags = o.ExtraFlags
@@ -32151,6 +32238,9 @@ func (o *SAMLogonExResponse) xxx_FromOp(ctx context.Context, op *xxx_SAMLogonExO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ValidationLevel = op.ValidationLevel
+
 	o.ValidationInformation = op.ValidationInformation
 	o.Authoritative = op.Authoritative
 	o.ExtraFlags = op.ExtraFlags
@@ -34221,6 +34311,8 @@ func (o *SAMLogonWithFlagsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // SAMLogonWithFlagsResponse structure represents the NetrLogonSamLogonWithFlags operation response
 type SAMLogonWithFlagsResponse struct {
+	// XXX: ValidationLevel is an implicit input depedency for output parameters
+	ValidationLevel ValidationInfoClass `idl:"name:ValidationLevel" json:"validation_level"`
 	// ReturnAuthenticator: A pointer to a NETLOGON_AUTHENTICATOR structure, as specified
 	// in section 2.2.1.1.5, that contains the server return authenticator.
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator;pointer:unique" json:"return_authenticator"`
@@ -34274,6 +34366,11 @@ func (o *SAMLogonWithFlagsResponse) xxx_ToOp(ctx context.Context, op *xxx_SAMLog
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ValidationLevel == ValidationInfoClass(0) {
+		op.ValidationLevel = o.ValidationLevel
+	}
+
 	op.ReturnAuthenticator = o.ReturnAuthenticator
 	op.ValidationInformation = o.ValidationInformation
 	op.Authoritative = o.Authoritative
@@ -34286,6 +34383,9 @@ func (o *SAMLogonWithFlagsResponse) xxx_FromOp(ctx context.Context, op *xxx_SAML
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ValidationLevel = op.ValidationLevel
+
 	o.ReturnAuthenticator = op.ReturnAuthenticator
 	o.ValidationInformation = op.ValidationInformation
 	o.Authoritative = op.Authoritative

--- a/msrpc/nrpc/logon/v1/v1.go
+++ b/msrpc/nrpc/logon/v1/v1.go
@@ -20251,10 +20251,11 @@ func (o *SAMLogonRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 // SAMLogonResponse structure represents the NetrLogonSamLogon operation response
 type SAMLogonResponse struct {
 	// XXX: ValidationLevel is an implicit input depedency for output parameters
-	ValidationLevel       ValidationInfoClass `idl:"name:ValidationLevel" json:"validation_level"`
-	ReturnAuthenticator   *Authenticator      `idl:"name:ReturnAuthenticator;pointer:unique" json:"return_authenticator"`
-	ValidationInformation *Validation         `idl:"name:ValidationInformation;switch_is:ValidationLevel" json:"validation_information"`
-	Authoritative         uint8               `idl:"name:Authoritative" json:"authoritative"`
+	ValidationLevel ValidationInfoClass `idl:"name:ValidationLevel" json:"validation_level"`
+
+	ReturnAuthenticator   *Authenticator `idl:"name:ReturnAuthenticator;pointer:unique" json:"return_authenticator"`
+	ValidationInformation *Validation    `idl:"name:ValidationInformation;switch_is:ValidationLevel" json:"validation_information"`
+	Authoritative         uint8          `idl:"name:Authoritative" json:"authoritative"`
 	// Return: The NetrLogonSamLogon return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -22678,7 +22679,8 @@ func (o *AccountDeltasRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 // AccountDeltasResponse structure represents the NetrAccountDeltas operation response
 type AccountDeltasResponse struct {
 	// XXX: BufferSize is an implicit input depedency for output parameters
-	BufferSize          uint32         `idl:"name:BufferSize" json:"buffer_size"`
+	BufferSize uint32 `idl:"name:BufferSize" json:"buffer_size"`
+
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator" json:"return_authenticator"`
 	Buffer              []byte         `idl:"name:Buffer;size_is:(BufferSize)" json:"buffer"`
 	CountReturned       uint32         `idl:"name:CountReturned" json:"count_returned"`
@@ -23113,7 +23115,8 @@ func (o *AccountSyncRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 // AccountSyncResponse structure represents the NetrAccountSync operation response
 type AccountSyncResponse struct {
 	// XXX: BufferSize is an implicit input depedency for output parameters
-	BufferSize          uint32         `idl:"name:BufferSize" json:"buffer_size"`
+	BufferSize uint32 `idl:"name:BufferSize" json:"buffer_size"`
+
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator" json:"return_authenticator"`
 	Buffer              []byte         `idl:"name:Buffer;size_is:(BufferSize)" json:"buffer"`
 	CountReturned       uint32         `idl:"name:CountReturned" json:"count_returned"`
@@ -23603,8 +23606,9 @@ func (o *ControlRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 // ControlResponse structure represents the NetrLogonControl operation response
 type ControlResponse struct {
 	// XXX: QueryLevel is an implicit input depedency for output parameters
-	QueryLevel uint32                   `idl:"name:QueryLevel" json:"query_level"`
-	Buffer     *ControlQueryInformation `idl:"name:Buffer;switch_is:QueryLevel" json:"buffer"`
+	QueryLevel uint32 `idl:"name:QueryLevel" json:"query_level"`
+
+	Buffer *ControlQueryInformation `idl:"name:Buffer;switch_is:QueryLevel" json:"buffer"`
 	// Return: The NetrLogonControl return value.
 	Return uint32 `idl:"name:Return" json:"return"`
 }
@@ -24136,8 +24140,9 @@ func (o *Control2Request) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 // Control2Response structure represents the NetrLogonControl2 operation response
 type Control2Response struct {
 	// XXX: QueryLevel is an implicit input depedency for output parameters
-	QueryLevel uint32                   `idl:"name:QueryLevel" json:"query_level"`
-	Buffer     *ControlQueryInformation `idl:"name:Buffer;switch_is:QueryLevel" json:"buffer"`
+	QueryLevel uint32 `idl:"name:QueryLevel" json:"query_level"`
+
+	Buffer *ControlQueryInformation `idl:"name:Buffer;switch_is:QueryLevel" json:"buffer"`
 	// Return: The NetrLogonControl2 return value.
 	Return uint32 `idl:"name:Return" json:"return"`
 }
@@ -25615,6 +25620,7 @@ func (o *Control2ExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 type Control2ExResponse struct {
 	// XXX: QueryLevel is an implicit input depedency for output parameters
 	QueryLevel uint32 `idl:"name:QueryLevel" json:"query_level"`
+
 	// Buffer: A NETLOGON_CONTROL_QUERY_INFORMATION structure, as specified in section 2.2.1.7.6,
 	// that contains the specific query results, with a level of verbosity as specified
 	// in QueryLevel.
@@ -26521,6 +26527,7 @@ func (o *GetCapabilitiesRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 type GetCapabilitiesResponse struct {
 	// XXX: QueryLevel is an implicit input depedency for output parameters
 	QueryLevel uint32 `idl:"name:QueryLevel" json:"query_level"`
+
 	// ReturnAuthenticator: A pointer to a NETLOGON_AUTHENTICATOR structure that contains
 	// the server return authenticator.
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator" json:"return_authenticator"`
@@ -28983,6 +28990,7 @@ func (o *GetDomainInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 type GetDomainInfoResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// ReturnAuthenticator: A pointer to a NETLOGON_AUTHENTICATOR structure, as specified
 	// in section 2.2.1.1.5, that contains the server return authenticator.
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator" json:"return_authenticator"`
@@ -32172,6 +32180,7 @@ func (o *SAMLogonExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 type SAMLogonExResponse struct {
 	// XXX: ValidationLevel is an implicit input depedency for output parameters
 	ValidationLevel ValidationInfoClass `idl:"name:ValidationLevel" json:"validation_level"`
+
 	// ValidationInformation: A pointer to a NETLOGON_VALIDATION structure, as specified
 	// in section 2.2.1.4.14, that describes the user validation information returned to
 	// the client. The type of the NETLOGON_VALIDATION used is determined by the value of
@@ -34313,6 +34322,7 @@ func (o *SAMLogonWithFlagsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type SAMLogonWithFlagsResponse struct {
 	// XXX: ValidationLevel is an implicit input depedency for output parameters
 	ValidationLevel ValidationInfoClass `idl:"name:ValidationLevel" json:"validation_level"`
+
 	// ReturnAuthenticator: A pointer to a NETLOGON_AUTHENTICATOR structure, as specified
 	// in section 2.2.1.1.5, that contains the server return authenticator.
 	ReturnAuthenticator *Authenticator `idl:"name:ReturnAuthenticator;pointer:unique" json:"return_authenticator"`

--- a/msrpc/par/iremotewinspool/v1/v1.go
+++ b/msrpc/par/iremotewinspool/v1/v1.go
@@ -18791,6 +18791,8 @@ func (o *GetJobRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // GetJobResponse structure represents the RpcAsyncGetJob operation response
 type GetJobResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Job          []byte `idl:"name:pJob;size_is:(cbBuf);pointer:unique" json:"job"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetJob return value.
@@ -18804,6 +18806,11 @@ func (o *GetJobResponse) xxx_ToOp(ctx context.Context, op *xxx_GetJobOperation) 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Job = o.Job
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -18814,6 +18821,9 @@ func (o *GetJobResponse) xxx_FromOp(ctx context.Context, op *xxx_GetJobOperation
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Job = op.Job
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -19188,6 +19198,8 @@ func (o *EnumJobsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 
 // EnumJobsResponse structure represents the RpcAsyncEnumJobs operation response
 type EnumJobsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Job           []byte `idl:"name:pJob;size_is:(cbBuf);pointer:unique" json:"job"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -19202,6 +19214,11 @@ func (o *EnumJobsResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumJobsOperati
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Job = o.Job
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -19213,6 +19230,9 @@ func (o *EnumJobsResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumJobsOpera
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Job = op.Job
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -19543,6 +19563,8 @@ func (o *AddJobRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // AddJobResponse structure represents the RpcAsyncAddJob operation response
 type AddJobResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	AddJob       []byte `idl:"name:pAddJob;size_is:(cbBuf);pointer:unique" json:"add_job"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncAddJob return value.
@@ -19556,6 +19578,11 @@ func (o *AddJobResponse) xxx_ToOp(ctx context.Context, op *xxx_AddJobOperation) 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.AddJob = o.AddJob
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -19566,6 +19593,9 @@ func (o *AddJobResponse) xxx_FromOp(ctx context.Context, op *xxx_AddJobOperation
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.AddJob = op.AddJob
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -20484,6 +20514,8 @@ func (o *GetPrinterRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 
 // GetPrinterResponse structure represents the RpcAsyncGetPrinter operation response
 type GetPrinterResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	PrinterBuffer []byte `idl:"name:pPrinter;size_is:(cbBuf);pointer:unique" json:"printer_buffer"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetPrinter return value.
@@ -20497,6 +20529,11 @@ func (o *GetPrinterResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrinterOpe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrinterBuffer = o.PrinterBuffer
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -20507,6 +20544,9 @@ func (o *GetPrinterResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPrinterO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrinterBuffer = op.PrinterBuffer
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -21817,6 +21857,8 @@ func (o *GetPrinterDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // GetPrinterDataResponse structure represents the RpcAsyncGetPrinterData operation response
 type GetPrinterDataResponse struct {
+	// XXX: nSize is an implicit input depedency for output parameters
+	Size         uint32 `idl:"name:nSize" json:"size"`
 	Type         uint32 `idl:"name:pType" json:"type"`
 	Data         []byte `idl:"name:pData;size_is:(nSize)" json:"data"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
@@ -21831,6 +21873,11 @@ func (o *GetPrinterDataResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrinte
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Size == uint32(0) {
+		op.Size = o.Size
+	}
+
 	op.Type = o.Type
 	op.Data = o.Data
 	op.NeededLength = o.NeededLength
@@ -21842,6 +21889,9 @@ func (o *GetPrinterDataResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPrin
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Size = op.Size
+
 	o.Type = op.Type
 	o.Data = op.Data
 	o.NeededLength = op.NeededLength
@@ -22102,6 +22152,8 @@ func (o *GetPrinterDataExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // GetPrinterDataExResponse structure represents the RpcAsyncGetPrinterDataEx operation response
 type GetPrinterDataExResponse struct {
+	// XXX: nSize is an implicit input depedency for output parameters
+	Size         uint32 `idl:"name:nSize" json:"size"`
 	Type         uint32 `idl:"name:pType" json:"type"`
 	Data         []byte `idl:"name:pData;size_is:(nSize)" json:"data"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
@@ -22116,6 +22168,11 @@ func (o *GetPrinterDataExResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrin
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Size == uint32(0) {
+		op.Size = o.Size
+	}
+
 	op.Type = o.Type
 	op.Data = o.Data
 	op.NeededLength = o.NeededLength
@@ -22127,6 +22184,9 @@ func (o *GetPrinterDataExResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPr
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Size = op.Size
+
 	o.Type = op.Type
 	o.Data = op.Data
 	o.NeededLength = op.NeededLength
@@ -23538,6 +23598,8 @@ func (o *GetFormRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // GetFormResponse structure represents the RpcAsyncGetForm operation response
 type GetFormResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Form         []byte `idl:"name:pForm;size_is:(cbBuf);pointer:unique" json:"form"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetForm return value.
@@ -23551,6 +23613,11 @@ func (o *GetFormResponse) xxx_ToOp(ctx context.Context, op *xxx_GetFormOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Form = o.Form
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -23561,6 +23628,9 @@ func (o *GetFormResponse) xxx_FromOp(ctx context.Context, op *xxx_GetFormOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Form = op.Form
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -24104,6 +24174,8 @@ func (o *EnumFormsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 
 // EnumFormsResponse structure represents the RpcAsyncEnumForms operation response
 type EnumFormsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Form          []byte `idl:"name:pForm;size_is:(cbBuf);pointer:unique" json:"form"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -24118,6 +24190,11 @@ func (o *EnumFormsResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumFormsOpera
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Form = o.Form
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -24129,6 +24206,9 @@ func (o *EnumFormsResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumFormsOpe
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Form = op.Form
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -24560,6 +24640,8 @@ func (o *GetPrinterDriverRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // GetPrinterDriverResponse structure represents the RpcAsyncGetPrinterDriver operation response
 type GetPrinterDriverResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength     uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Driver           []byte `idl:"name:pDriver;size_is:(cbBuf);pointer:unique" json:"driver"`
 	NeededLength     uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ServerMaxVersion uint32 `idl:"name:pdwServerMaxVersion" json:"server_max_version"`
@@ -24575,6 +24657,11 @@ func (o *GetPrinterDriverResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrin
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Driver = o.Driver
 	op.NeededLength = o.NeededLength
 	op.ServerMaxVersion = o.ServerMaxVersion
@@ -24587,6 +24674,9 @@ func (o *GetPrinterDriverResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPr
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Driver = op.Driver
 	o.NeededLength = op.NeededLength
 	o.ServerMaxVersion = op.ServerMaxVersion
@@ -24913,6 +25003,10 @@ func (o *EnumPrinterDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // EnumPrinterDataResponse structure represents the RpcAsyncEnumPrinterData operation response
 type EnumPrinterDataResponse struct {
+	// XXX: cbValueNameIn is an implicit input depedency for output parameters
+	ValueNameInLength uint32 `idl:"name:cbValueNameIn" json:"value_name_in_length"`
+	// XXX: cbDataIn is an implicit input depedency for output parameters
+	DataInLength       uint32 `idl:"name:cbDataIn" json:"data_in_length"`
 	ValueName          string `idl:"name:pValueName;size_is:((cbValueNameIn/2))" json:"value_name"`
 	ValueNameOutLength uint32 `idl:"name:pcbValueNameOut" json:"value_name_out_length"`
 	Type               uint32 `idl:"name:pType" json:"type"`
@@ -24929,6 +25023,14 @@ func (o *EnumPrinterDataResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPrin
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ValueNameInLength == uint32(0) {
+		op.ValueNameInLength = o.ValueNameInLength
+	}
+	if op.DataInLength == uint32(0) {
+		op.DataInLength = o.DataInLength
+	}
+
 	op.ValueName = o.ValueName
 	op.ValueNameOutLength = o.ValueNameOutLength
 	op.Type = o.Type
@@ -24942,6 +25044,10 @@ func (o *EnumPrinterDataResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumPr
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ValueNameInLength = op.ValueNameInLength
+	o.DataInLength = op.DataInLength
+
 	o.ValueName = op.ValueName
 	o.ValueNameOutLength = op.ValueNameOutLength
 	o.Type = op.Type
@@ -25188,6 +25294,8 @@ func (o *EnumPrinterDataExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // EnumPrinterDataExResponse structure represents the RpcAsyncEnumPrinterDataEx operation response
 type EnumPrinterDataExResponse struct {
+	// XXX: cbEnumValuesIn is an implicit input depedency for output parameters
+	EnumValuesInLength  uint32 `idl:"name:cbEnumValuesIn" json:"enum_values_in_length"`
 	EnumValues          []byte `idl:"name:pEnumValues;size_is:(cbEnumValuesIn)" json:"enum_values"`
 	EnumValuesOutLength uint32 `idl:"name:pcbEnumValuesOut" json:"enum_values_out_length"`
 	EnumValuesLength    uint32 `idl:"name:numEnumValues" json:"enum_values_length"`
@@ -25202,6 +25310,11 @@ func (o *EnumPrinterDataExResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPr
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.EnumValuesInLength == uint32(0) {
+		op.EnumValuesInLength = o.EnumValuesInLength
+	}
+
 	op.EnumValues = o.EnumValues
 	op.EnumValuesOutLength = o.EnumValuesOutLength
 	op.EnumValuesLength = o.EnumValuesLength
@@ -25213,6 +25326,9 @@ func (o *EnumPrinterDataExResponse) xxx_FromOp(ctx context.Context, op *xxx_Enum
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.EnumValuesInLength = op.EnumValuesInLength
+
 	o.EnumValues = op.EnumValues
 	o.EnumValuesOutLength = op.EnumValuesOutLength
 	o.EnumValuesLength = op.EnumValuesLength
@@ -25450,6 +25566,8 @@ func (o *EnumPrinterKeyRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // EnumPrinterKeyResponse structure represents the RpcAsyncEnumPrinterKey operation response
 type EnumPrinterKeyResponse struct {
+	// XXX: cbSubkeyIn is an implicit input depedency for output parameters
+	SubkeyInLength  uint32 `idl:"name:cbSubkeyIn" json:"subkey_in_length"`
 	Subkey          string `idl:"name:pSubkey;size_is:((cbSubkeyIn/2))" json:"subkey"`
 	SubkeyOutLength uint32 `idl:"name:pcbSubkeyOut" json:"subkey_out_length"`
 	// Return: The RpcAsyncEnumPrinterKey return value.
@@ -25463,6 +25581,11 @@ func (o *EnumPrinterKeyResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPrint
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.SubkeyInLength == uint32(0) {
+		op.SubkeyInLength = o.SubkeyInLength
+	}
+
 	op.Subkey = o.Subkey
 	op.SubkeyOutLength = o.SubkeyOutLength
 	op.Return = o.Return
@@ -25473,6 +25596,9 @@ func (o *EnumPrinterKeyResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumPri
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.SubkeyInLength = op.SubkeyInLength
+
 	o.Subkey = op.Subkey
 	o.SubkeyOutLength = op.SubkeyOutLength
 	o.Return = op.Return
@@ -26329,6 +26455,8 @@ func (o *XcvDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // XcvDataResponse structure represents the RpcAsyncXcvData operation response
 type XcvDataResponse struct {
+	// XXX: cbOutputData is an implicit input depedency for output parameters
+	OutputDataLength   uint32 `idl:"name:cbOutputData" json:"output_data_length"`
 	OutputData         []byte `idl:"name:pOutputData;size_is:(cbOutputData)" json:"output_data"`
 	OutputNeededLength uint32 `idl:"name:pcbOutputNeeded" json:"output_needed_length"`
 	Status             uint32 `idl:"name:pdwStatus" json:"status"`
@@ -26343,6 +26471,11 @@ func (o *XcvDataResponse) xxx_ToOp(ctx context.Context, op *xxx_XcvDataOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutputDataLength == uint32(0) {
+		op.OutputDataLength = o.OutputDataLength
+	}
+
 	op.OutputData = o.OutputData
 	op.OutputNeededLength = o.OutputNeededLength
 	op.Status = o.Status
@@ -26354,6 +26487,9 @@ func (o *XcvDataResponse) xxx_FromOp(ctx context.Context, op *xxx_XcvDataOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutputDataLength = op.OutputDataLength
+
 	o.OutputData = op.OutputData
 	o.OutputNeededLength = op.OutputNeededLength
 	o.Status = op.Status
@@ -27131,7 +27267,9 @@ func (o *PlayGDIScriptOnPrinterICRequest) UnmarshalNDR(ctx context.Context, r nd
 
 // PlayGDIScriptOnPrinterICResponse structure represents the RpcAsyncPlayGdiScriptOnPrinterIC operation response
 type PlayGDIScriptOnPrinterICResponse struct {
-	Out []byte `idl:"name:pOut;size_is:(cOut)" json:"out"`
+	// XXX: cOut is an implicit input depedency for output parameters
+	OutCount uint32 `idl:"name:cOut" json:"out_count"`
+	Out      []byte `idl:"name:pOut;size_is:(cOut)" json:"out"`
 	// Return: The RpcAsyncPlayGdiScriptOnPrinterIC return value.
 	Return uint32 `idl:"name:Return" json:"return"`
 }
@@ -27143,6 +27281,11 @@ func (o *PlayGDIScriptOnPrinterICResponse) xxx_ToOp(ctx context.Context, op *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutCount == uint32(0) {
+		op.OutCount = o.OutCount
+	}
+
 	op.Out = o.Out
 	op.Return = o.Return
 	return op
@@ -27152,6 +27295,9 @@ func (o *PlayGDIScriptOnPrinterICResponse) xxx_FromOp(ctx context.Context, op *x
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutCount = op.OutCount
+
 	o.Out = op.Out
 	o.Return = op.Return
 }
@@ -27707,6 +27853,8 @@ func (o *EnumPrintersRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // EnumPrintersResponse structure represents the RpcAsyncEnumPrinters operation response
 type EnumPrintersResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	PrinterEnum   []byte `idl:"name:pPrinterEnum;size_is:(cbBuf);pointer:unique" json:"printer_enum"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -27721,6 +27869,11 @@ func (o *EnumPrintersResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPrinter
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrinterEnum = o.PrinterEnum
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -27732,6 +27885,9 @@ func (o *EnumPrintersResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumPrint
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrinterEnum = op.PrinterEnum
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -28349,6 +28505,8 @@ func (o *EnumPrinterDriversRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // EnumPrinterDriversResponse structure represents the RpcAsyncEnumPrinterDrivers operation response
 type EnumPrinterDriversResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Drivers       []byte `idl:"name:pDrivers;size_is:(cbBuf);pointer:unique" json:"drivers"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -28363,6 +28521,11 @@ func (o *EnumPrinterDriversResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumP
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Drivers = o.Drivers
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -28374,6 +28537,9 @@ func (o *EnumPrinterDriversResponse) xxx_FromOp(ctx context.Context, op *xxx_Enu
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Drivers = op.Drivers
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -28761,6 +28927,8 @@ func (o *GetPrinterDriverDirectoryRequest) UnmarshalNDR(ctx context.Context, r n
 
 // GetPrinterDriverDirectoryResponse structure represents the RpcAsyncGetPrinterDriverDirectory operation response
 type GetPrinterDriverDirectoryResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength    uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	DriverDirectory []byte `idl:"name:pDriverDirectory;size_is:(cbBuf);pointer:unique" json:"driver_directory"`
 	NeededLength    uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetPrinterDriverDirectory return value.
@@ -28774,6 +28942,11 @@ func (o *GetPrinterDriverDirectoryResponse) xxx_ToOp(ctx context.Context, op *xx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.DriverDirectory = o.DriverDirectory
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -28784,6 +28957,9 @@ func (o *GetPrinterDriverDirectoryResponse) xxx_FromOp(ctx context.Context, op *
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.DriverDirectory = op.DriverDirectory
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -29837,6 +30013,8 @@ func (o *EnumPrintProcessorsRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // EnumPrintProcessorsResponse structure represents the RpcAsyncEnumPrintProcessors operation response
 type EnumPrintProcessorsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength       uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	PrintProcessorInfo []byte `idl:"name:pPrintProcessorInfo;size_is:(cbBuf);pointer:unique" json:"print_processor_info"`
 	NeededLength       uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount      uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -29851,6 +30029,11 @@ func (o *EnumPrintProcessorsResponse) xxx_ToOp(ctx context.Context, op *xxx_Enum
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrintProcessorInfo = o.PrintProcessorInfo
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -29862,6 +30045,9 @@ func (o *EnumPrintProcessorsResponse) xxx_FromOp(ctx context.Context, op *xxx_En
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrintProcessorInfo = op.PrintProcessorInfo
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -30249,6 +30435,8 @@ func (o *GetPrintProcessorDirectoryRequest) UnmarshalNDR(ctx context.Context, r 
 
 // GetPrintProcessorDirectoryResponse structure represents the RpcAsyncGetPrintProcessorDirectory operation response
 type GetPrintProcessorDirectoryResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength            uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	PrintProcessorDirectory []byte `idl:"name:pPrintProcessorDirectory;size_is:(cbBuf);pointer:unique" json:"print_processor_directory"`
 	NeededLength            uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetPrintProcessorDirectory return value.
@@ -30262,6 +30450,11 @@ func (o *GetPrintProcessorDirectoryResponse) xxx_ToOp(ctx context.Context, op *x
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrintProcessorDirectory = o.PrintProcessorDirectory
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -30272,6 +30465,9 @@ func (o *GetPrintProcessorDirectoryResponse) xxx_FromOp(ctx context.Context, op 
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrintProcessorDirectory = op.PrintProcessorDirectory
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -30628,6 +30824,8 @@ func (o *EnumPortsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 
 // EnumPortsResponse structure represents the RpcAsyncEnumPorts operation response
 type EnumPortsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Port          []byte `idl:"name:pPort;size_is:(cbBuf);pointer:unique" json:"port"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -30642,6 +30840,11 @@ func (o *EnumPortsResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPortsOpera
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Port = o.Port
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -30653,6 +30856,9 @@ func (o *EnumPortsResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumPortsOpe
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Port = op.Port
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -31012,6 +31218,8 @@ func (o *EnumMonitorsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // EnumMonitorsResponse structure represents the RpcAsyncEnumMonitors operation response
 type EnumMonitorsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Monitor       []byte `idl:"name:pMonitor;size_is:(cbBuf);pointer:unique" json:"monitor"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -31026,6 +31234,11 @@ func (o *EnumMonitorsResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumMonitor
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Monitor = o.Monitor
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -31037,6 +31250,9 @@ func (o *EnumMonitorsResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumMonit
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Monitor = op.Monitor
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -32576,6 +32792,8 @@ func (o *EnumPrintProcessorDataTypesRequest) UnmarshalNDR(ctx context.Context, r
 
 // EnumPrintProcessorDataTypesResponse structure represents the RpcAsyncEnumPrintProcessorDatatypes operation response
 type EnumPrintProcessorDataTypesResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	DataTypes     []byte `idl:"name:pDatatypes;size_is:(cbBuf);pointer:unique" json:"data_types"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -32590,6 +32808,11 @@ func (o *EnumPrintProcessorDataTypesResponse) xxx_ToOp(ctx context.Context, op *
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.DataTypes = o.DataTypes
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -32601,6 +32824,9 @@ func (o *EnumPrintProcessorDataTypesResponse) xxx_FromOp(ctx context.Context, op
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.DataTypes = op.DataTypes
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -33348,6 +33574,8 @@ func (o *EnumPerMachineConnectionsRequest) UnmarshalNDR(ctx context.Context, r n
 
 // EnumPerMachineConnectionsResponse structure represents the RpcAsyncEnumPerMachineConnections operation response
 type EnumPerMachineConnectionsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	PrinterEnum   []byte `idl:"name:pPrinterEnum;size_is:(cbBuf);pointer:unique" json:"printer_enum"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -33362,6 +33590,11 @@ func (o *EnumPerMachineConnectionsResponse) xxx_ToOp(ctx context.Context, op *xx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrinterEnum = o.PrinterEnum
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -33373,6 +33606,9 @@ func (o *EnumPerMachineConnectionsResponse) xxx_FromOp(ctx context.Context, op *
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrinterEnum = op.PrinterEnum
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -35304,6 +35540,8 @@ func (o *GetCorePrinterDriversRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // GetCorePrinterDriversResponse structure represents the RpcAsyncGetCorePrinterDrivers operation response
 type GetCorePrinterDriversResponse struct {
+	// XXX: cCorePrinterDrivers is an implicit input depedency for output parameters
+	CorePrinterDriversCount uint32 `idl:"name:cCorePrinterDrivers" json:"core_printer_drivers_count"`
 	// pCorePrinterDrivers: A pointer to a buffer that receives an array of CORE_PRINTER_DRIVER
 	// structures.
 	CorePrinterDrivers []*CorePrinterDriver `idl:"name:pCorePrinterDrivers;size_is:(cCorePrinterDrivers)" json:"core_printer_drivers"`
@@ -35318,6 +35556,11 @@ func (o *GetCorePrinterDriversResponse) xxx_ToOp(ctx context.Context, op *xxx_Ge
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.CorePrinterDriversCount == uint32(0) {
+		op.CorePrinterDriversCount = o.CorePrinterDriversCount
+	}
+
 	op.CorePrinterDrivers = o.CorePrinterDrivers
 	op.Return = o.Return
 	return op
@@ -35327,6 +35570,9 @@ func (o *GetCorePrinterDriversResponse) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.CorePrinterDriversCount = op.CorePrinterDriversCount
+
 	o.CorePrinterDrivers = op.CorePrinterDrivers
 	o.Return = op.Return
 }
@@ -36050,6 +36296,8 @@ func (o *GetPrinterDriverPackagePathRequest) UnmarshalNDR(ctx context.Context, r
 
 // GetPrinterDriverPackagePathResponse structure represents the RpcAsyncGetPrinterDriverPackagePath operation response
 type GetPrinterDriverPackagePathResponse struct {
+	// XXX: cchDriverPackageCab is an implicit input depedency for output parameters
+	DriverPackageCabLength uint32 `idl:"name:cchDriverPackageCab" json:"driver_package_cab_length"`
 	// pszDriverPackageCab: A pointer to a string that contains the path name of the driver
 	// package file.<26> For rules governing path names, see [MS-RPRN] section 2.2.4.9.
 	// The pszDriverPackageCab parameter MUST NOT be NULL unless cchDriverPackageCab is
@@ -36069,6 +36317,11 @@ func (o *GetPrinterDriverPackagePathResponse) xxx_ToOp(ctx context.Context, op *
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DriverPackageCabLength == uint32(0) {
+		op.DriverPackageCabLength = o.DriverPackageCabLength
+	}
+
 	op.DriverPackageCab = o.DriverPackageCab
 	op.RequiredLength = o.RequiredLength
 	op.Return = o.Return
@@ -36079,6 +36332,9 @@ func (o *GetPrinterDriverPackagePathResponse) xxx_FromOp(ctx context.Context, op
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DriverPackageCabLength = op.DriverPackageCabLength
+
 	o.DriverPackageCab = op.DriverPackageCab
 	o.RequiredLength = op.RequiredLength
 	o.Return = op.Return
@@ -36505,6 +36761,8 @@ func (o *ReadPrinterRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 
 // ReadPrinterResponse structure represents the RpcAsyncReadPrinter operation response
 type ReadPrinterResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength     uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	Buffer           []byte `idl:"name:pBuf;size_is:(cbBuf)" json:"buffer"`
 	NoBytesReadCount uint32 `idl:"name:pcNoBytesRead" json:"no_bytes_read_count"`
 	// Return: The RpcAsyncReadPrinter return value.
@@ -36518,6 +36776,11 @@ func (o *ReadPrinterResponse) xxx_ToOp(ctx context.Context, op *xxx_ReadPrinterO
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.NoBytesReadCount = o.NoBytesReadCount
 	op.Return = o.Return
@@ -36528,6 +36791,9 @@ func (o *ReadPrinterResponse) xxx_FromOp(ctx context.Context, op *xxx_ReadPrinte
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.NoBytesReadCount = op.NoBytesReadCount
 	o.Return = op.Return

--- a/msrpc/par/iremotewinspool/v1/v1.go
+++ b/msrpc/par/iremotewinspool/v1/v1.go
@@ -18793,6 +18793,7 @@ func (o *GetJobRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type GetJobResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Job          []byte `idl:"name:pJob;size_is:(cbBuf);pointer:unique" json:"job"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetJob return value.
@@ -19199,7 +19200,8 @@ func (o *EnumJobsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 // EnumJobsResponse structure represents the RpcAsyncEnumJobs operation response
 type EnumJobsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Job           []byte `idl:"name:pJob;size_is:(cbBuf);pointer:unique" json:"job"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -19565,6 +19567,7 @@ func (o *AddJobRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type AddJobResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	AddJob       []byte `idl:"name:pAddJob;size_is:(cbBuf);pointer:unique" json:"add_job"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncAddJob return value.
@@ -20515,7 +20518,8 @@ func (o *GetPrinterRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 // GetPrinterResponse structure represents the RpcAsyncGetPrinter operation response
 type GetPrinterResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	PrinterBuffer []byte `idl:"name:pPrinter;size_is:(cbBuf);pointer:unique" json:"printer_buffer"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetPrinter return value.
@@ -21858,7 +21862,8 @@ func (o *GetPrinterDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 // GetPrinterDataResponse structure represents the RpcAsyncGetPrinterData operation response
 type GetPrinterDataResponse struct {
 	// XXX: nSize is an implicit input depedency for output parameters
-	Size         uint32 `idl:"name:nSize" json:"size"`
+	Size uint32 `idl:"name:nSize" json:"size"`
+
 	Type         uint32 `idl:"name:pType" json:"type"`
 	Data         []byte `idl:"name:pData;size_is:(nSize)" json:"data"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
@@ -22153,7 +22158,8 @@ func (o *GetPrinterDataExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 // GetPrinterDataExResponse structure represents the RpcAsyncGetPrinterDataEx operation response
 type GetPrinterDataExResponse struct {
 	// XXX: nSize is an implicit input depedency for output parameters
-	Size         uint32 `idl:"name:nSize" json:"size"`
+	Size uint32 `idl:"name:nSize" json:"size"`
+
 	Type         uint32 `idl:"name:pType" json:"type"`
 	Data         []byte `idl:"name:pData;size_is:(nSize)" json:"data"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
@@ -23600,6 +23606,7 @@ func (o *GetFormRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type GetFormResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Form         []byte `idl:"name:pForm;size_is:(cbBuf);pointer:unique" json:"form"`
 	NeededLength uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetForm return value.
@@ -24175,7 +24182,8 @@ func (o *EnumFormsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 // EnumFormsResponse structure represents the RpcAsyncEnumForms operation response
 type EnumFormsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Form          []byte `idl:"name:pForm;size_is:(cbBuf);pointer:unique" json:"form"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -24641,7 +24649,8 @@ func (o *GetPrinterDriverRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 // GetPrinterDriverResponse structure represents the RpcAsyncGetPrinterDriver operation response
 type GetPrinterDriverResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength     uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Driver           []byte `idl:"name:pDriver;size_is:(cbBuf);pointer:unique" json:"driver"`
 	NeededLength     uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ServerMaxVersion uint32 `idl:"name:pdwServerMaxVersion" json:"server_max_version"`
@@ -25006,7 +25015,8 @@ type EnumPrinterDataResponse struct {
 	// XXX: cbValueNameIn is an implicit input depedency for output parameters
 	ValueNameInLength uint32 `idl:"name:cbValueNameIn" json:"value_name_in_length"`
 	// XXX: cbDataIn is an implicit input depedency for output parameters
-	DataInLength       uint32 `idl:"name:cbDataIn" json:"data_in_length"`
+	DataInLength uint32 `idl:"name:cbDataIn" json:"data_in_length"`
+
 	ValueName          string `idl:"name:pValueName;size_is:((cbValueNameIn/2))" json:"value_name"`
 	ValueNameOutLength uint32 `idl:"name:pcbValueNameOut" json:"value_name_out_length"`
 	Type               uint32 `idl:"name:pType" json:"type"`
@@ -25295,7 +25305,8 @@ func (o *EnumPrinterDataExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 // EnumPrinterDataExResponse structure represents the RpcAsyncEnumPrinterDataEx operation response
 type EnumPrinterDataExResponse struct {
 	// XXX: cbEnumValuesIn is an implicit input depedency for output parameters
-	EnumValuesInLength  uint32 `idl:"name:cbEnumValuesIn" json:"enum_values_in_length"`
+	EnumValuesInLength uint32 `idl:"name:cbEnumValuesIn" json:"enum_values_in_length"`
+
 	EnumValues          []byte `idl:"name:pEnumValues;size_is:(cbEnumValuesIn)" json:"enum_values"`
 	EnumValuesOutLength uint32 `idl:"name:pcbEnumValuesOut" json:"enum_values_out_length"`
 	EnumValuesLength    uint32 `idl:"name:numEnumValues" json:"enum_values_length"`
@@ -25567,7 +25578,8 @@ func (o *EnumPrinterKeyRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 // EnumPrinterKeyResponse structure represents the RpcAsyncEnumPrinterKey operation response
 type EnumPrinterKeyResponse struct {
 	// XXX: cbSubkeyIn is an implicit input depedency for output parameters
-	SubkeyInLength  uint32 `idl:"name:cbSubkeyIn" json:"subkey_in_length"`
+	SubkeyInLength uint32 `idl:"name:cbSubkeyIn" json:"subkey_in_length"`
+
 	Subkey          string `idl:"name:pSubkey;size_is:((cbSubkeyIn/2))" json:"subkey"`
 	SubkeyOutLength uint32 `idl:"name:pcbSubkeyOut" json:"subkey_out_length"`
 	// Return: The RpcAsyncEnumPrinterKey return value.
@@ -26456,7 +26468,8 @@ func (o *XcvDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 // XcvDataResponse structure represents the RpcAsyncXcvData operation response
 type XcvDataResponse struct {
 	// XXX: cbOutputData is an implicit input depedency for output parameters
-	OutputDataLength   uint32 `idl:"name:cbOutputData" json:"output_data_length"`
+	OutputDataLength uint32 `idl:"name:cbOutputData" json:"output_data_length"`
+
 	OutputData         []byte `idl:"name:pOutputData;size_is:(cbOutputData)" json:"output_data"`
 	OutputNeededLength uint32 `idl:"name:pcbOutputNeeded" json:"output_needed_length"`
 	Status             uint32 `idl:"name:pdwStatus" json:"status"`
@@ -27269,7 +27282,8 @@ func (o *PlayGDIScriptOnPrinterICRequest) UnmarshalNDR(ctx context.Context, r nd
 type PlayGDIScriptOnPrinterICResponse struct {
 	// XXX: cOut is an implicit input depedency for output parameters
 	OutCount uint32 `idl:"name:cOut" json:"out_count"`
-	Out      []byte `idl:"name:pOut;size_is:(cOut)" json:"out"`
+
+	Out []byte `idl:"name:pOut;size_is:(cOut)" json:"out"`
 	// Return: The RpcAsyncPlayGdiScriptOnPrinterIC return value.
 	Return uint32 `idl:"name:Return" json:"return"`
 }
@@ -27854,7 +27868,8 @@ func (o *EnumPrintersRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 // EnumPrintersResponse structure represents the RpcAsyncEnumPrinters operation response
 type EnumPrintersResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	PrinterEnum   []byte `idl:"name:pPrinterEnum;size_is:(cbBuf);pointer:unique" json:"printer_enum"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -28506,7 +28521,8 @@ func (o *EnumPrinterDriversRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 // EnumPrinterDriversResponse structure represents the RpcAsyncEnumPrinterDrivers operation response
 type EnumPrinterDriversResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Drivers       []byte `idl:"name:pDrivers;size_is:(cbBuf);pointer:unique" json:"drivers"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -28928,7 +28944,8 @@ func (o *GetPrinterDriverDirectoryRequest) UnmarshalNDR(ctx context.Context, r n
 // GetPrinterDriverDirectoryResponse structure represents the RpcAsyncGetPrinterDriverDirectory operation response
 type GetPrinterDriverDirectoryResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength    uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	DriverDirectory []byte `idl:"name:pDriverDirectory;size_is:(cbBuf);pointer:unique" json:"driver_directory"`
 	NeededLength    uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetPrinterDriverDirectory return value.
@@ -30014,7 +30031,8 @@ func (o *EnumPrintProcessorsRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 // EnumPrintProcessorsResponse structure represents the RpcAsyncEnumPrintProcessors operation response
 type EnumPrintProcessorsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength       uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	PrintProcessorInfo []byte `idl:"name:pPrintProcessorInfo;size_is:(cbBuf);pointer:unique" json:"print_processor_info"`
 	NeededLength       uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount      uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -30436,7 +30454,8 @@ func (o *GetPrintProcessorDirectoryRequest) UnmarshalNDR(ctx context.Context, r 
 // GetPrintProcessorDirectoryResponse structure represents the RpcAsyncGetPrintProcessorDirectory operation response
 type GetPrintProcessorDirectoryResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength            uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	PrintProcessorDirectory []byte `idl:"name:pPrintProcessorDirectory;size_is:(cbBuf);pointer:unique" json:"print_processor_directory"`
 	NeededLength            uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	// Return: The RpcAsyncGetPrintProcessorDirectory return value.
@@ -30825,7 +30844,8 @@ func (o *EnumPortsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 // EnumPortsResponse structure represents the RpcAsyncEnumPorts operation response
 type EnumPortsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Port          []byte `idl:"name:pPort;size_is:(cbBuf);pointer:unique" json:"port"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -31219,7 +31239,8 @@ func (o *EnumMonitorsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 // EnumMonitorsResponse structure represents the RpcAsyncEnumMonitors operation response
 type EnumMonitorsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Monitor       []byte `idl:"name:pMonitor;size_is:(cbBuf);pointer:unique" json:"monitor"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -32793,7 +32814,8 @@ func (o *EnumPrintProcessorDataTypesRequest) UnmarshalNDR(ctx context.Context, r
 // EnumPrintProcessorDataTypesResponse structure represents the RpcAsyncEnumPrintProcessorDatatypes operation response
 type EnumPrintProcessorDataTypesResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	DataTypes     []byte `idl:"name:pDatatypes;size_is:(cbBuf);pointer:unique" json:"data_types"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -33575,7 +33597,8 @@ func (o *EnumPerMachineConnectionsRequest) UnmarshalNDR(ctx context.Context, r n
 // EnumPerMachineConnectionsResponse structure represents the RpcAsyncEnumPerMachineConnections operation response
 type EnumPerMachineConnectionsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength  uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	PrinterEnum   []byte `idl:"name:pPrinterEnum;size_is:(cbBuf);pointer:unique" json:"printer_enum"`
 	NeededLength  uint32 `idl:"name:pcbNeeded" json:"needed_length"`
 	ReturnedCount uint32 `idl:"name:pcReturned" json:"returned_count"`
@@ -35542,6 +35565,7 @@ func (o *GetCorePrinterDriversRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 type GetCorePrinterDriversResponse struct {
 	// XXX: cCorePrinterDrivers is an implicit input depedency for output parameters
 	CorePrinterDriversCount uint32 `idl:"name:cCorePrinterDrivers" json:"core_printer_drivers_count"`
+
 	// pCorePrinterDrivers: A pointer to a buffer that receives an array of CORE_PRINTER_DRIVER
 	// structures.
 	CorePrinterDrivers []*CorePrinterDriver `idl:"name:pCorePrinterDrivers;size_is:(cCorePrinterDrivers)" json:"core_printer_drivers"`
@@ -36298,6 +36322,7 @@ func (o *GetPrinterDriverPackagePathRequest) UnmarshalNDR(ctx context.Context, r
 type GetPrinterDriverPackagePathResponse struct {
 	// XXX: cchDriverPackageCab is an implicit input depedency for output parameters
 	DriverPackageCabLength uint32 `idl:"name:cchDriverPackageCab" json:"driver_package_cab_length"`
+
 	// pszDriverPackageCab: A pointer to a string that contains the path name of the driver
 	// package file.<26> For rules governing path names, see [MS-RPRN] section 2.2.4.9.
 	// The pszDriverPackageCab parameter MUST NOT be NULL unless cchDriverPackageCab is
@@ -36762,7 +36787,8 @@ func (o *ReadPrinterRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 // ReadPrinterResponse structure represents the RpcAsyncReadPrinter operation response
 type ReadPrinterResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
-	BufferLength     uint32 `idl:"name:cbBuf" json:"buffer_length"`
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	Buffer           []byte `idl:"name:pBuf;size_is:(cbBuf)" json:"buffer"`
 	NoBytesReadCount uint32 `idl:"name:pcNoBytesRead" json:"no_bytes_read_count"`
 	// Return: The RpcAsyncReadPrinter return value.

--- a/msrpc/pcq/perflibv2/v1/v1.go
+++ b/msrpc/pcq/perflibv2/v1/v1.go
@@ -727,6 +727,7 @@ func (o *EnumerateCounterSetRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type EnumerateCounterSetResponse struct {
 	// XXX: dwInSize is an implicit input depedency for output parameters
 	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
+
 	// pdwOutSize: On output, the number of GUIDs that are returned in the array. The server
 	// MUST set this value to zero if the value of dwInSize is less than the total number
 	// of GUIDs on the server.
@@ -1107,6 +1108,7 @@ func (o *QueryCounterSetRegistrationInfoRequest) UnmarshalNDR(ctx context.Contex
 type QueryCounterSetRegistrationInfoResponse struct {
 	// XXX: dwInSize is an implicit input depedency for output parameters
 	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
+
 	// pdwOutSize: The size, in bytes, of the data in the buffer pointed to by lpData.
 	OutSize uint32 `idl:"name:pdwOutSize" json:"out_size"`
 	// pdwRtnSize: The necessary size, in bytes, to retrieve all the requested data.
@@ -1451,6 +1453,7 @@ func (o *EnumerateCounterSetInstancesRequest) UnmarshalNDR(ctx context.Context, 
 type EnumerateCounterSetInstancesResponse struct {
 	// XXX: dwInSize is an implicit input depedency for output parameters
 	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
+
 	// pdwOutSize: The total size, in bytes, of the data that is returned and written to
 	// the buffer.
 	OutSize uint32 `idl:"name:pdwOutSize" json:"out_size"`
@@ -2103,6 +2106,7 @@ func (o *QueryCounterInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type QueryCounterInfoResponse struct {
 	// XXX: dwInSize is an implicit input depedency for output parameters
 	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
+
 	// pdwOutSize: The size, in bytes, of the data that is written to the buffer.
 	OutSize uint32 `idl:"name:pdwOutSize" json:"out_size"`
 	// pdwRtnSize: The necessary size, in bytes, to retrieve all the requested data.
@@ -2397,6 +2401,7 @@ func (o *QueryCounterDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type QueryCounterDataResponse struct {
 	// XXX: dwInSize is an implicit input depedency for output parameters
 	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
+
 	// pdwOutSize: The size, in bytes, of the data that is returned and written to the buffer.
 	OutSize uint32 `idl:"name:pdwOutSize" json:"out_size"`
 	// pdwRtnSize: The necessary size, in bytes, to retrieve all the requested data.
@@ -2716,6 +2721,7 @@ func (o *ValidateCountersRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type ValidateCountersResponse struct {
 	// XXX: dwInSize is an implicit input depedency for output parameters
 	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
+
 	// lpData: The buffer that contains the counter information to add to, or remove from,
 	// the query. The server will return this buffer after it has attempted to add or remove
 	// the specified counters; the Status field of each _PERF_COUNTER_IDENTIFIER structure

--- a/msrpc/pcq/perflibv2/v1/v1.go
+++ b/msrpc/pcq/perflibv2/v1/v1.go
@@ -725,6 +725,8 @@ func (o *EnumerateCounterSetRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // EnumerateCounterSetResponse structure represents the PerflibV2EnumerateCounterSet operation response
 type EnumerateCounterSetResponse struct {
+	// XXX: dwInSize is an implicit input depedency for output parameters
+	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
 	// pdwOutSize: On output, the number of GUIDs that are returned in the array. The server
 	// MUST set this value to zero if the value of dwInSize is less than the total number
 	// of GUIDs on the server.
@@ -744,6 +746,11 @@ func (o *EnumerateCounterSetResponse) xxx_ToOp(ctx context.Context, op *xxx_Enum
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InSize == uint32(0) {
+		op.InSize = o.InSize
+	}
+
 	op.OutSize = o.OutSize
 	op.ReturnSize = o.ReturnSize
 	op.Data = o.Data
@@ -755,6 +762,9 @@ func (o *EnumerateCounterSetResponse) xxx_FromOp(ctx context.Context, op *xxx_En
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InSize = op.InSize
+
 	o.OutSize = op.OutSize
 	o.ReturnSize = op.ReturnSize
 	o.Data = op.Data
@@ -1095,6 +1105,8 @@ func (o *QueryCounterSetRegistrationInfoRequest) UnmarshalNDR(ctx context.Contex
 
 // QueryCounterSetRegistrationInfoResponse structure represents the PerflibV2QueryCounterSetRegistrationInfo operation response
 type QueryCounterSetRegistrationInfoResponse struct {
+	// XXX: dwInSize is an implicit input depedency for output parameters
+	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
 	// pdwOutSize: The size, in bytes, of the data in the buffer pointed to by lpData.
 	OutSize uint32 `idl:"name:pdwOutSize" json:"out_size"`
 	// pdwRtnSize: The necessary size, in bytes, to retrieve all the requested data.
@@ -1112,6 +1124,11 @@ func (o *QueryCounterSetRegistrationInfoResponse) xxx_ToOp(ctx context.Context, 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InSize == uint32(0) {
+		op.InSize = o.InSize
+	}
+
 	op.OutSize = o.OutSize
 	op.ReturnSize = o.ReturnSize
 	op.Data = o.Data
@@ -1123,6 +1140,9 @@ func (o *QueryCounterSetRegistrationInfoResponse) xxx_FromOp(ctx context.Context
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InSize = op.InSize
+
 	o.OutSize = op.OutSize
 	o.ReturnSize = op.ReturnSize
 	o.Data = op.Data
@@ -1429,6 +1449,8 @@ func (o *EnumerateCounterSetInstancesRequest) UnmarshalNDR(ctx context.Context, 
 
 // EnumerateCounterSetInstancesResponse structure represents the PerflibV2EnumerateCounterSetInstances operation response
 type EnumerateCounterSetInstancesResponse struct {
+	// XXX: dwInSize is an implicit input depedency for output parameters
+	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
 	// pdwOutSize: The total size, in bytes, of the data that is returned and written to
 	// the buffer.
 	OutSize uint32 `idl:"name:pdwOutSize" json:"out_size"`
@@ -1447,6 +1469,11 @@ func (o *EnumerateCounterSetInstancesResponse) xxx_ToOp(ctx context.Context, op 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InSize == uint32(0) {
+		op.InSize = o.InSize
+	}
+
 	op.OutSize = o.OutSize
 	op.ReturnSize = o.ReturnSize
 	op.Data = o.Data
@@ -1458,6 +1485,9 @@ func (o *EnumerateCounterSetInstancesResponse) xxx_FromOp(ctx context.Context, o
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InSize = op.InSize
+
 	o.OutSize = op.OutSize
 	o.ReturnSize = op.ReturnSize
 	o.Data = op.Data
@@ -2071,6 +2101,8 @@ func (o *QueryCounterInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // QueryCounterInfoResponse structure represents the PerflibV2QueryCounterInfo operation response
 type QueryCounterInfoResponse struct {
+	// XXX: dwInSize is an implicit input depedency for output parameters
+	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
 	// pdwOutSize: The size, in bytes, of the data that is written to the buffer.
 	OutSize uint32 `idl:"name:pdwOutSize" json:"out_size"`
 	// pdwRtnSize: The necessary size, in bytes, to retrieve all the requested data.
@@ -2088,6 +2120,11 @@ func (o *QueryCounterInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_QueryCo
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InSize == uint32(0) {
+		op.InSize = o.InSize
+	}
+
 	op.OutSize = o.OutSize
 	op.ReturnSize = o.ReturnSize
 	op.Data = o.Data
@@ -2099,6 +2136,9 @@ func (o *QueryCounterInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_Query
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InSize = op.InSize
+
 	o.OutSize = op.OutSize
 	o.ReturnSize = op.ReturnSize
 	o.Data = op.Data
@@ -2355,6 +2395,8 @@ func (o *QueryCounterDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // QueryCounterDataResponse structure represents the PerflibV2QueryCounterData operation response
 type QueryCounterDataResponse struct {
+	// XXX: dwInSize is an implicit input depedency for output parameters
+	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
 	// pdwOutSize: The size, in bytes, of the data that is returned and written to the buffer.
 	OutSize uint32 `idl:"name:pdwOutSize" json:"out_size"`
 	// pdwRtnSize: The necessary size, in bytes, to retrieve all the requested data.
@@ -2372,6 +2414,11 @@ func (o *QueryCounterDataResponse) xxx_ToOp(ctx context.Context, op *xxx_QueryCo
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InSize == uint32(0) {
+		op.InSize = o.InSize
+	}
+
 	op.OutSize = o.OutSize
 	op.ReturnSize = o.ReturnSize
 	op.Data = o.Data
@@ -2383,6 +2430,9 @@ func (o *QueryCounterDataResponse) xxx_FromOp(ctx context.Context, op *xxx_Query
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InSize = op.InSize
+
 	o.OutSize = op.OutSize
 	o.ReturnSize = op.ReturnSize
 	o.Data = op.Data
@@ -2664,6 +2714,8 @@ func (o *ValidateCountersRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // ValidateCountersResponse structure represents the PerflibV2ValidateCounters operation response
 type ValidateCountersResponse struct {
+	// XXX: dwInSize is an implicit input depedency for output parameters
+	InSize uint32 `idl:"name:dwInSize" json:"in_size"`
 	// lpData: The buffer that contains the counter information to add to, or remove from,
 	// the query. The server will return this buffer after it has attempted to add or remove
 	// the specified counters; the Status field of each _PERF_COUNTER_IDENTIFIER structure
@@ -2680,6 +2732,11 @@ func (o *ValidateCountersResponse) xxx_ToOp(ctx context.Context, op *xxx_Validat
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InSize == uint32(0) {
+		op.InSize = o.InSize
+	}
+
 	op.Data = o.Data
 	op.Return = o.Return
 	return op
@@ -2689,6 +2746,9 @@ func (o *ValidateCountersResponse) xxx_FromOp(ctx context.Context, op *xxx_Valid
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InSize = op.InSize
+
 	o.Data = op.Data
 	o.Return = op.Return
 }

--- a/msrpc/rprn/winspool/v1/v1.go
+++ b/msrpc/rprn/winspool/v1/v1.go
@@ -18070,6 +18070,7 @@ func (o *EnumPrintersRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 type EnumPrintersResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pPrinterEnum: A pointer to a BUFFER defined in INFO Structures Query Parameters (section
 	// 3.1.4.1.9).
 	PrinterEnum []byte `idl:"name:pPrinterEnum;size_is:(cbBuf);pointer:unique" json:"printer_enum"`
@@ -19033,6 +19034,7 @@ func (o *GetJobRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type GetJobResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pJob: A pointer to BUFFER as specified in INFO Structures Query Parameters (section
 	// 3.1.4.1.9).
 	Job []byte `idl:"name:pJob;size_is:(cbBuf);pointer:unique" json:"job"`
@@ -19451,6 +19453,7 @@ func (o *EnumJobsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 type EnumJobsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pJob: A pointer to the BUFFER structure specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Job []byte `idl:"name:pJob;size_is:(cbBuf);pointer:unique" json:"job"`
@@ -20590,6 +20593,7 @@ func (o *GetPrinterRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 type GetPrinterResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pPrinter: A pointer to a BUFFER (INFO Structures Query Parameters (section 3.1.4.1.9)).
 	PrinterBuffer []byte `idl:"name:pPrinter;size_is:(cbBuf);pointer:unique" json:"printer_buffer"`
 	// pcbNeeded: A parameter specified in INFO Structures Query Parameters.
@@ -21253,6 +21257,7 @@ func (o *EnumPrinterDriversRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 type EnumPrinterDriversResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pDrivers: A pointer to the BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Drivers []byte `idl:"name:pDrivers;size_is:(cbBuf);pointer:unique" json:"drivers"`
@@ -21688,6 +21693,7 @@ func (o *GetPrinterDriverRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type GetPrinterDriverResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pDriver: An optional pointer to BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Driver []byte `idl:"name:pDriver;size_is:(cbBuf);pointer:unique" json:"driver"`
@@ -22116,6 +22122,7 @@ func (o *GetPrinterDriverDirectoryRequest) UnmarshalNDR(ctx context.Context, r n
 type GetPrinterDriverDirectoryResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pDriverDirectory: An optional pointer to BUFFER, as specified in String Query Parameters
 	// (section 3.1.4.1.7). If cbBuf is zero, this parameter SHOULD be NULL.
 	DriverDirectory []byte `idl:"name:pDriverDirectory;size_is:(cbBuf);pointer:unique" json:"driver_directory"`
@@ -22987,6 +22994,7 @@ func (o *EnumPrintProcessorsRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type EnumPrintProcessorsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pPrintProcessorInfo: A pointer to BUFFER as specified in INFO Structures Query Parameters,
 	// section 3.1.4.1.9
 	PrintProcessorInfo []byte `idl:"name:pPrintProcessorInfo;size_is:(cbBuf);pointer:unique" json:"print_processor_info"`
@@ -23422,6 +23430,7 @@ func (o *GetPrintProcessorDirectoryRequest) UnmarshalNDR(ctx context.Context, r 
 type GetPrintProcessorDirectoryResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pPrintProcessorDirectory: This parameter MAY be NULL if cbBuf equals zero; otherwise,
 	// it is a pointer to BUFFER as specified in String Query Parameters, section 3.1.4.1.7.
 	PrintProcessorDirectory []byte `idl:"name:pPrintProcessorDirectory;size_is:(cbBuf);pointer:unique" json:"print_processor_directory"`
@@ -24589,6 +24598,7 @@ func (o *ReadPrinterRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 type ReadPrinterResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pBuf: A pointer to a buffer that receives the printer data. If the hPrinter parameter
 	// is the handle to a port object, this method returns the data that is returned by
 	// the port monitor.
@@ -25117,6 +25127,7 @@ func (o *AddJobRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type AddJobResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pAddJob: A pointer to a buffer of undefined values. This value can be NULL if cbBuf
 	// is zero and Level is 0x00000001.
 	AddJob []byte `idl:"name:pAddJob;size_is:(cbBuf);pointer:unique" json:"add_job"`
@@ -25572,6 +25583,7 @@ func (o *GetPrinterDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 type GetPrinterDataResponse struct {
 	// XXX: nSize is an implicit input depedency for output parameters
 	Size uint32 `idl:"name:nSize" json:"size"`
+
 	// pType: A parameter specified in Dynamically Typed Query Parameters (section 3.1.4.1.2).
 	Type uint32 `idl:"name:pType" json:"type"`
 	// pData: A pointer to BUFFER as specified in Dynamically Typed Query Parameters.
@@ -26976,6 +26988,7 @@ func (o *GetFormRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type GetFormResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pForm: A pointer to the BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Form []byte `idl:"name:pForm;size_is:(cbBuf);pointer:unique" json:"form"`
@@ -27576,6 +27589,7 @@ func (o *EnumFormsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 type EnumFormsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pForm: This parameter MAY be NULL if cbBuf equals zero; otherwise, it is a pointer
 	// to the BUFFER, as specified in INFO Structures Query Parameters, section 3.1.4.1.9.
 	Form []byte `idl:"name:pForm;size_is:(cbBuf);pointer:unique" json:"form"`
@@ -27990,6 +28004,7 @@ func (o *EnumPortsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 type EnumPortsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pPort: A pointer to the BUFFER, as specified in INFO Structures Query Parameters,
 	// section 3.1.4.1.9.
 	Port []byte `idl:"name:pPort;size_is:(cbBuf);pointer:unique" json:"port"`
@@ -28405,6 +28420,7 @@ func (o *EnumMonitorsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 type EnumMonitorsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pMonitor: This parameter SHOULD be ignored if cbBuf equals zero; otherwise, it is
 	// a pointer to the BUFFER, as specified in INFO Structures Query Parameters, section
 	// 3.1.4.1.9.
@@ -29156,6 +29172,7 @@ func (o *PlayGDIScriptOnPrinterICRequest) UnmarshalNDR(ctx context.Context, r nd
 type PlayGDIScriptOnPrinterICResponse struct {
 	// XXX: cOut is an implicit input depedency for output parameters
 	OutCount uint32 `idl:"name:cOut" json:"out_count"`
+
 	// pOut: A pointer to a buffer, the size and contents of which are determined by the
 	// value of the cOut parameter.
 	Out []byte `idl:"name:pOut;size_is:(cOut)" json:"out"`
@@ -30444,6 +30461,7 @@ func (o *EnumPrintProcessorDataTypesRequest) UnmarshalNDR(ctx context.Context, r
 type EnumPrintProcessorDataTypesResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pDatatypes: This parameter MAY be NULL if cbBuf equals zero; otherwise, it is a pointer
 	// to BUFFER as specified in INFO Structures Query Parameters, section 3.1.4.1.9.
 	DataTypes []byte `idl:"name:pDatatypes;size_is:(cbBuf);pointer:unique" json:"data_types"`
@@ -31176,6 +31194,7 @@ func (o *GetPrinterDriver2Request) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type GetPrinterDriver2Response struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pDriver: A pointer to the BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Driver []byte `idl:"name:pDriver;size_is:(cbBuf);pointer:unique" json:"driver"`
@@ -32801,6 +32820,7 @@ func (o *RemoteFindFirstPrinterChangeNotificationRequest) UnmarshalNDR(ctx conte
 type RemoteFindFirstPrinterChangeNotificationResponse struct {
 	// XXX: cbBuffer is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuffer" json:"buffer_length"`
+
 	// pBuffer: A pointer that MUST be set to NULL when sent and MUST be ignored on receipt.
 	Buffer []byte `idl:"name:pBuffer;size_is:(cbBuffer);pointer:unique" json:"buffer"`
 	// Return: The RpcRemoteFindFirstPrinterChangeNotification return value.
@@ -34862,6 +34882,7 @@ type EnumPrinterDataResponse struct {
 	ValueNameInLength uint32 `idl:"name:cbValueNameIn" json:"value_name_in_length"`
 	// XXX: cbDataIn is an implicit input depedency for output parameters
 	DataInLength uint32 `idl:"name:cbDataIn" json:"data_in_length"`
+
 	// pValueName: A pointer to a buffer that receives a string specifying the name of the
 	// configuration data value. For rules governing value names, see section 2.2.4.18.
 	ValueName          string `idl:"name:pValueName;size_is:((cbValueNameIn/2))" json:"value_name"`
@@ -35638,6 +35659,7 @@ func (o *GetPrinterDataExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type GetPrinterDataExResponse struct {
 	// XXX: nSize is an implicit input depedency for output parameters
 	Size uint32 `idl:"name:nSize" json:"size"`
+
 	// pType: A parameter specified in Dynamically Typed Query Parameters (section 3.1.4.1.2).
 	Type uint32 `idl:"name:pType" json:"type"`
 	// pData: A pointer to BUFFER, as specified in Dynamically Typed Query Parameters. This
@@ -35923,6 +35945,7 @@ func (o *EnumPrinterDataExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type EnumPrinterDataExResponse struct {
 	// XXX: cbEnumValuesIn is an implicit input depedency for output parameters
 	EnumValuesInLength uint32 `idl:"name:cbEnumValuesIn" json:"enum_values_in_length"`
+
 	// pEnumValues: A pointer to BUFFER as specified in PRINTER_ENUM_VALUES Structures Query
 	// Parameters (section 3.1.4.1.10).
 	EnumValues          []byte `idl:"name:pEnumValues;size_is:(cbEnumValuesIn)" json:"enum_values"`
@@ -36199,6 +36222,7 @@ func (o *EnumPrinterKeyRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 type EnumPrinterKeyResponse struct {
 	// XXX: cbSubkeyIn is an implicit input depedency for output parameters
 	SubkeyInLength uint32 `idl:"name:cbSubkeyIn" json:"subkey_in_length"`
+
 	// pSubkey: A pointer to BUFFER as specified in String Query Parameters (section 3.1.4.1.7).
 	Subkey          string `idl:"name:pSubkey;size_is:((cbSubkeyIn/2))" json:"subkey"`
 	SubkeyOutLength uint32 `idl:"name:pcbSubkeyOut" json:"subkey_out_length"`
@@ -37636,6 +37660,7 @@ func (o *EnumPerMachineConnectionsRequest) UnmarshalNDR(ctx context.Context, r n
 type EnumPerMachineConnectionsResponse struct {
 	// XXX: cbBuf is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
+
 	// pPrinterEnum: A pointer to the BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	PrinterEnum []byte `idl:"name:pPrinterEnum;size_is:(cbBuf);pointer:unique" json:"printer_enum"`
@@ -38025,6 +38050,7 @@ func (o *XcvDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type XcvDataResponse struct {
 	// XXX: cbOutputData is an implicit input depedency for output parameters
 	OutputDataLength uint32 `idl:"name:cbOutputData" json:"output_data_length"`
+
 	// pOutputData: A pointer to a buffer to receive output data. This parameter can be
 	// NULL if cbOutputData equals zero.
 	OutputData []byte `idl:"name:pOutputData;size_is:(cbOutputData)" json:"output_data"`
@@ -39278,6 +39304,7 @@ func (o *GetCorePrinterDriversRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 type GetCorePrinterDriversResponse struct {
 	// XXX: cCorePrinterDrivers is an implicit input depedency for output parameters
 	CorePrinterDriversCount uint32 `idl:"name:cCorePrinterDrivers" json:"core_printer_drivers_count"`
+
 	// pCorePrinterDrivers: A pointer to a buffer that receives an array of CORE_PRINTER_DRIVER
 	// structures.
 	CorePrinterDrivers []*CorePrinterDriver `idl:"name:pCorePrinterDrivers;size_is:(cCorePrinterDrivers)" json:"core_printer_drivers"`
@@ -39740,6 +39767,7 @@ func (o *GetPrinterDriverPackagePathRequest) UnmarshalNDR(ctx context.Context, r
 type GetPrinterDriverPackagePathResponse struct {
 	// XXX: cchDriverPackageCab is an implicit input depedency for output parameters
 	DriverPackageCabLength uint32 `idl:"name:cchDriverPackageCab" json:"driver_package_cab_length"`
+
 	// pszDriverPackageCab: This parameter is a pointer to a buffer that receives a string
 	// that specifies the path name of the driver package file.<351> For rules governing
 	// path names, see section 2.2.4.9. pszDriverPackageCab MUST NOT be NULL unless cchDriverPackageCab

--- a/msrpc/rprn/winspool/v1/v1.go
+++ b/msrpc/rprn/winspool/v1/v1.go
@@ -18068,6 +18068,8 @@ func (o *EnumPrintersRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // EnumPrintersResponse structure represents the RpcEnumPrinters operation response
 type EnumPrintersResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pPrinterEnum: A pointer to a BUFFER defined in INFO Structures Query Parameters (section
 	// 3.1.4.1.9).
 	PrinterEnum []byte `idl:"name:pPrinterEnum;size_is:(cbBuf);pointer:unique" json:"printer_enum"`
@@ -18088,6 +18090,11 @@ func (o *EnumPrintersResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPrinter
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrinterEnum = o.PrinterEnum
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -18099,6 +18106,9 @@ func (o *EnumPrintersResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumPrint
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrinterEnum = op.PrinterEnum
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -19021,6 +19031,8 @@ func (o *GetJobRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // GetJobResponse structure represents the RpcGetJob operation response
 type GetJobResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pJob: A pointer to BUFFER as specified in INFO Structures Query Parameters (section
 	// 3.1.4.1.9).
 	Job []byte `idl:"name:pJob;size_is:(cbBuf);pointer:unique" json:"job"`
@@ -19037,6 +19049,11 @@ func (o *GetJobResponse) xxx_ToOp(ctx context.Context, op *xxx_GetJobOperation) 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Job = o.Job
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -19047,6 +19064,9 @@ func (o *GetJobResponse) xxx_FromOp(ctx context.Context, op *xxx_GetJobOperation
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Job = op.Job
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -19429,6 +19449,8 @@ func (o *EnumJobsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error 
 
 // EnumJobsResponse structure represents the RpcEnumJobs operation response
 type EnumJobsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pJob: A pointer to the BUFFER structure specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Job []byte `idl:"name:pJob;size_is:(cbBuf);pointer:unique" json:"job"`
@@ -19447,6 +19469,11 @@ func (o *EnumJobsResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumJobsOperati
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Job = o.Job
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -19458,6 +19485,9 @@ func (o *EnumJobsResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumJobsOpera
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Job = op.Job
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -20558,6 +20588,8 @@ func (o *GetPrinterRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 
 // GetPrinterResponse structure represents the RpcGetPrinter operation response
 type GetPrinterResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pPrinter: A pointer to a BUFFER (INFO Structures Query Parameters (section 3.1.4.1.9)).
 	PrinterBuffer []byte `idl:"name:pPrinter;size_is:(cbBuf);pointer:unique" json:"printer_buffer"`
 	// pcbNeeded: A parameter specified in INFO Structures Query Parameters.
@@ -20573,6 +20605,11 @@ func (o *GetPrinterResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrinterOpe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrinterBuffer = o.PrinterBuffer
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -20583,6 +20620,9 @@ func (o *GetPrinterResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPrinterO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrinterBuffer = op.PrinterBuffer
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -21211,6 +21251,8 @@ func (o *EnumPrinterDriversRequest) UnmarshalNDR(ctx context.Context, r ndr.Read
 
 // EnumPrinterDriversResponse structure represents the RpcEnumPrinterDrivers operation response
 type EnumPrinterDriversResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pDrivers: A pointer to the BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Drivers []byte `idl:"name:pDrivers;size_is:(cbBuf);pointer:unique" json:"drivers"`
@@ -21229,6 +21271,11 @@ func (o *EnumPrinterDriversResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumP
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Drivers = o.Drivers
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -21240,6 +21287,9 @@ func (o *EnumPrinterDriversResponse) xxx_FromOp(ctx context.Context, op *xxx_Enu
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Drivers = op.Drivers
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -21636,6 +21686,8 @@ func (o *GetPrinterDriverRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // GetPrinterDriverResponse structure represents the RpcGetPrinterDriver operation response
 type GetPrinterDriverResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pDriver: An optional pointer to BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Driver []byte `idl:"name:pDriver;size_is:(cbBuf);pointer:unique" json:"driver"`
@@ -21652,6 +21704,11 @@ func (o *GetPrinterDriverResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrin
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Driver = o.Driver
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -21662,6 +21719,9 @@ func (o *GetPrinterDriverResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPr
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Driver = op.Driver
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -22054,6 +22114,8 @@ func (o *GetPrinterDriverDirectoryRequest) UnmarshalNDR(ctx context.Context, r n
 
 // GetPrinterDriverDirectoryResponse structure represents the RpcGetPrinterDriverDirectory operation response
 type GetPrinterDriverDirectoryResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pDriverDirectory: An optional pointer to BUFFER, as specified in String Query Parameters
 	// (section 3.1.4.1.7). If cbBuf is zero, this parameter SHOULD be NULL.
 	DriverDirectory []byte `idl:"name:pDriverDirectory;size_is:(cbBuf);pointer:unique" json:"driver_directory"`
@@ -22070,6 +22132,11 @@ func (o *GetPrinterDriverDirectoryResponse) xxx_ToOp(ctx context.Context, op *xx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.DriverDirectory = o.DriverDirectory
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -22080,6 +22147,9 @@ func (o *GetPrinterDriverDirectoryResponse) xxx_FromOp(ctx context.Context, op *
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.DriverDirectory = op.DriverDirectory
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -22915,6 +22985,8 @@ func (o *EnumPrintProcessorsRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // EnumPrintProcessorsResponse structure represents the RpcEnumPrintProcessors operation response
 type EnumPrintProcessorsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pPrintProcessorInfo: A pointer to BUFFER as specified in INFO Structures Query Parameters,
 	// section 3.1.4.1.9
 	PrintProcessorInfo []byte `idl:"name:pPrintProcessorInfo;size_is:(cbBuf);pointer:unique" json:"print_processor_info"`
@@ -22933,6 +23005,11 @@ func (o *EnumPrintProcessorsResponse) xxx_ToOp(ctx context.Context, op *xxx_Enum
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrintProcessorInfo = o.PrintProcessorInfo
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -22944,6 +23021,9 @@ func (o *EnumPrintProcessorsResponse) xxx_FromOp(ctx context.Context, op *xxx_En
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrintProcessorInfo = op.PrintProcessorInfo
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -23340,6 +23420,8 @@ func (o *GetPrintProcessorDirectoryRequest) UnmarshalNDR(ctx context.Context, r 
 
 // GetPrintProcessorDirectoryResponse structure represents the RpcGetPrintProcessorDirectory operation response
 type GetPrintProcessorDirectoryResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pPrintProcessorDirectory: This parameter MAY be NULL if cbBuf equals zero; otherwise,
 	// it is a pointer to BUFFER as specified in String Query Parameters, section 3.1.4.1.7.
 	PrintProcessorDirectory []byte `idl:"name:pPrintProcessorDirectory;size_is:(cbBuf);pointer:unique" json:"print_processor_directory"`
@@ -23357,6 +23439,11 @@ func (o *GetPrintProcessorDirectoryResponse) xxx_ToOp(ctx context.Context, op *x
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrintProcessorDirectory = o.PrintProcessorDirectory
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -23367,6 +23454,9 @@ func (o *GetPrintProcessorDirectoryResponse) xxx_FromOp(ctx context.Context, op 
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrintProcessorDirectory = op.PrintProcessorDirectory
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -24497,6 +24587,8 @@ func (o *ReadPrinterRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 
 // ReadPrinterResponse structure represents the RpcReadPrinter operation response
 type ReadPrinterResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pBuf: A pointer to a buffer that receives the printer data. If the hPrinter parameter
 	// is the handle to a port object, this method returns the data that is returned by
 	// the port monitor.
@@ -24515,6 +24607,11 @@ func (o *ReadPrinterResponse) xxx_ToOp(ctx context.Context, op *xxx_ReadPrinterO
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.NoBytesReadCount = o.NoBytesReadCount
 	op.Return = o.Return
@@ -24525,6 +24622,9 @@ func (o *ReadPrinterResponse) xxx_FromOp(ctx context.Context, op *xxx_ReadPrinte
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.NoBytesReadCount = op.NoBytesReadCount
 	o.Return = op.Return
@@ -25015,6 +25115,8 @@ func (o *AddJobRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // AddJobResponse structure represents the RpcAddJob operation response
 type AddJobResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pAddJob: A pointer to a buffer of undefined values. This value can be NULL if cbBuf
 	// is zero and Level is 0x00000001.
 	AddJob []byte `idl:"name:pAddJob;size_is:(cbBuf);pointer:unique" json:"add_job"`
@@ -25031,6 +25133,11 @@ func (o *AddJobResponse) xxx_ToOp(ctx context.Context, op *xxx_AddJobOperation) 
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.AddJob = o.AddJob
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -25041,6 +25148,9 @@ func (o *AddJobResponse) xxx_FromOp(ctx context.Context, op *xxx_AddJobOperation
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.AddJob = op.AddJob
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -25460,6 +25570,8 @@ func (o *GetPrinterDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // GetPrinterDataResponse structure represents the RpcGetPrinterData operation response
 type GetPrinterDataResponse struct {
+	// XXX: nSize is an implicit input depedency for output parameters
+	Size uint32 `idl:"name:nSize" json:"size"`
 	// pType: A parameter specified in Dynamically Typed Query Parameters (section 3.1.4.1.2).
 	Type uint32 `idl:"name:pType" json:"type"`
 	// pData: A pointer to BUFFER as specified in Dynamically Typed Query Parameters.
@@ -25477,6 +25589,11 @@ func (o *GetPrinterDataResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrinte
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Size == uint32(0) {
+		op.Size = o.Size
+	}
+
 	op.Type = o.Type
 	op.Data = o.Data
 	op.NeededLength = o.NeededLength
@@ -25488,6 +25605,9 @@ func (o *GetPrinterDataResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPrin
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Size = op.Size
+
 	o.Type = op.Type
 	o.Data = op.Data
 	o.NeededLength = op.NeededLength
@@ -26854,6 +26974,8 @@ func (o *GetFormRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // GetFormResponse structure represents the RpcGetForm operation response
 type GetFormResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pForm: A pointer to the BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Form []byte `idl:"name:pForm;size_is:(cbBuf);pointer:unique" json:"form"`
@@ -26870,6 +26992,11 @@ func (o *GetFormResponse) xxx_ToOp(ctx context.Context, op *xxx_GetFormOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Form = o.Form
 	op.NeededLength = o.NeededLength
 	op.Return = o.Return
@@ -26880,6 +27007,9 @@ func (o *GetFormResponse) xxx_FromOp(ctx context.Context, op *xxx_GetFormOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Form = op.Form
 	o.NeededLength = op.NeededLength
 	o.Return = op.Return
@@ -27444,6 +27574,8 @@ func (o *EnumFormsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 
 // EnumFormsResponse structure represents the RpcEnumForms operation response
 type EnumFormsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pForm: This parameter MAY be NULL if cbBuf equals zero; otherwise, it is a pointer
 	// to the BUFFER, as specified in INFO Structures Query Parameters, section 3.1.4.1.9.
 	Form []byte `idl:"name:pForm;size_is:(cbBuf);pointer:unique" json:"form"`
@@ -27464,6 +27596,11 @@ func (o *EnumFormsResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumFormsOpera
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Form = o.Form
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -27475,6 +27612,9 @@ func (o *EnumFormsResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumFormsOpe
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Form = op.Form
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -27848,6 +27988,8 @@ func (o *EnumPortsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error
 
 // EnumPortsResponse structure represents the RpcEnumPorts operation response
 type EnumPortsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pPort: A pointer to the BUFFER, as specified in INFO Structures Query Parameters,
 	// section 3.1.4.1.9.
 	Port []byte `idl:"name:pPort;size_is:(cbBuf);pointer:unique" json:"port"`
@@ -27866,6 +28008,11 @@ func (o *EnumPortsResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPortsOpera
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Port = o.Port
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -27877,6 +28024,9 @@ func (o *EnumPortsResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumPortsOpe
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Port = op.Port
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -28253,6 +28403,8 @@ func (o *EnumMonitorsRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // EnumMonitorsResponse structure represents the RpcEnumMonitors operation response
 type EnumMonitorsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pMonitor: This parameter SHOULD be ignored if cbBuf equals zero; otherwise, it is
 	// a pointer to the BUFFER, as specified in INFO Structures Query Parameters, section
 	// 3.1.4.1.9.
@@ -28274,6 +28426,11 @@ func (o *EnumMonitorsResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumMonitor
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Monitor = o.Monitor
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -28285,6 +28442,9 @@ func (o *EnumMonitorsResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumMonit
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Monitor = op.Monitor
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -28994,6 +29154,8 @@ func (o *PlayGDIScriptOnPrinterICRequest) UnmarshalNDR(ctx context.Context, r nd
 
 // PlayGDIScriptOnPrinterICResponse structure represents the RpcPlayGdiScriptOnPrinterIC operation response
 type PlayGDIScriptOnPrinterICResponse struct {
+	// XXX: cOut is an implicit input depedency for output parameters
+	OutCount uint32 `idl:"name:cOut" json:"out_count"`
 	// pOut: A pointer to a buffer, the size and contents of which are determined by the
 	// value of the cOut parameter.
 	Out []byte `idl:"name:pOut;size_is:(cOut)" json:"out"`
@@ -29008,6 +29170,11 @@ func (o *PlayGDIScriptOnPrinterICResponse) xxx_ToOp(ctx context.Context, op *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutCount == uint32(0) {
+		op.OutCount = o.OutCount
+	}
+
 	op.Out = o.Out
 	op.Return = o.Return
 	return op
@@ -29017,6 +29184,9 @@ func (o *PlayGDIScriptOnPrinterICResponse) xxx_FromOp(ctx context.Context, op *x
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutCount = op.OutCount
+
 	o.Out = op.Out
 	o.Return = op.Return
 }
@@ -30272,6 +30442,8 @@ func (o *EnumPrintProcessorDataTypesRequest) UnmarshalNDR(ctx context.Context, r
 
 // EnumPrintProcessorDataTypesResponse structure represents the RpcEnumPrintProcessorDatatypes operation response
 type EnumPrintProcessorDataTypesResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pDatatypes: This parameter MAY be NULL if cbBuf equals zero; otherwise, it is a pointer
 	// to BUFFER as specified in INFO Structures Query Parameters, section 3.1.4.1.9.
 	DataTypes []byte `idl:"name:pDatatypes;size_is:(cbBuf);pointer:unique" json:"data_types"`
@@ -30292,6 +30464,11 @@ func (o *EnumPrintProcessorDataTypesResponse) xxx_ToOp(ctx context.Context, op *
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.DataTypes = o.DataTypes
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -30303,6 +30480,9 @@ func (o *EnumPrintProcessorDataTypesResponse) xxx_FromOp(ctx context.Context, op
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.DataTypes = op.DataTypes
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -30994,6 +31174,8 @@ func (o *GetPrinterDriver2Request) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // GetPrinterDriver2Response structure represents the RpcGetPrinterDriver2 operation response
 type GetPrinterDriver2Response struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pDriver: A pointer to the BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	Driver []byte `idl:"name:pDriver;size_is:(cbBuf);pointer:unique" json:"driver"`
@@ -31016,6 +31198,11 @@ func (o *GetPrinterDriver2Response) xxx_ToOp(ctx context.Context, op *xxx_GetPri
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Driver = o.Driver
 	op.NeededLength = o.NeededLength
 	op.ServerMaxVersion = o.ServerMaxVersion
@@ -31028,6 +31215,9 @@ func (o *GetPrinterDriver2Response) xxx_FromOp(ctx context.Context, op *xxx_GetP
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Driver = op.Driver
 	o.NeededLength = op.NeededLength
 	o.ServerMaxVersion = op.ServerMaxVersion
@@ -32609,6 +32799,8 @@ func (o *RemoteFindFirstPrinterChangeNotificationRequest) UnmarshalNDR(ctx conte
 
 // RemoteFindFirstPrinterChangeNotificationResponse structure represents the RpcRemoteFindFirstPrinterChangeNotification operation response
 type RemoteFindFirstPrinterChangeNotificationResponse struct {
+	// XXX: cbBuffer is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuffer" json:"buffer_length"`
 	// pBuffer: A pointer that MUST be set to NULL when sent and MUST be ignored on receipt.
 	Buffer []byte `idl:"name:pBuffer;size_is:(cbBuffer);pointer:unique" json:"buffer"`
 	// Return: The RpcRemoteFindFirstPrinterChangeNotification return value.
@@ -32622,6 +32814,11 @@ func (o *RemoteFindFirstPrinterChangeNotificationResponse) xxx_ToOp(ctx context.
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -32631,6 +32828,9 @@ func (o *RemoteFindFirstPrinterChangeNotificationResponse) xxx_FromOp(ctx contex
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -34658,6 +34858,10 @@ func (o *EnumPrinterDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // EnumPrinterDataResponse structure represents the RpcEnumPrinterData operation response
 type EnumPrinterDataResponse struct {
+	// XXX: cbValueNameIn is an implicit input depedency for output parameters
+	ValueNameInLength uint32 `idl:"name:cbValueNameIn" json:"value_name_in_length"`
+	// XXX: cbDataIn is an implicit input depedency for output parameters
+	DataInLength uint32 `idl:"name:cbDataIn" json:"data_in_length"`
 	// pValueName: A pointer to a buffer that receives a string specifying the name of the
 	// configuration data value. For rules governing value names, see section 2.2.4.18.
 	ValueName          string `idl:"name:pValueName;size_is:((cbValueNameIn/2))" json:"value_name"`
@@ -34679,6 +34883,14 @@ func (o *EnumPrinterDataResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPrin
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ValueNameInLength == uint32(0) {
+		op.ValueNameInLength = o.ValueNameInLength
+	}
+	if op.DataInLength == uint32(0) {
+		op.DataInLength = o.DataInLength
+	}
+
 	op.ValueName = o.ValueName
 	op.ValueNameOutLength = o.ValueNameOutLength
 	op.Type = o.Type
@@ -34692,6 +34904,10 @@ func (o *EnumPrinterDataResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumPr
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ValueNameInLength = op.ValueNameInLength
+	o.DataInLength = op.DataInLength
+
 	o.ValueName = op.ValueName
 	o.ValueNameOutLength = op.ValueNameOutLength
 	o.Type = op.Type
@@ -35420,6 +35636,8 @@ func (o *GetPrinterDataExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // GetPrinterDataExResponse structure represents the RpcGetPrinterDataEx operation response
 type GetPrinterDataExResponse struct {
+	// XXX: nSize is an implicit input depedency for output parameters
+	Size uint32 `idl:"name:nSize" json:"size"`
 	// pType: A parameter specified in Dynamically Typed Query Parameters (section 3.1.4.1.2).
 	Type uint32 `idl:"name:pType" json:"type"`
 	// pData: A pointer to BUFFER, as specified in Dynamically Typed Query Parameters. This
@@ -35438,6 +35656,11 @@ func (o *GetPrinterDataExResponse) xxx_ToOp(ctx context.Context, op *xxx_GetPrin
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Size == uint32(0) {
+		op.Size = o.Size
+	}
+
 	op.Type = o.Type
 	op.Data = o.Data
 	op.NeededLength = o.NeededLength
@@ -35449,6 +35672,9 @@ func (o *GetPrinterDataExResponse) xxx_FromOp(ctx context.Context, op *xxx_GetPr
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Size = op.Size
+
 	o.Type = op.Type
 	o.Data = op.Data
 	o.NeededLength = op.NeededLength
@@ -35695,6 +35921,8 @@ func (o *EnumPrinterDataExRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // EnumPrinterDataExResponse structure represents the RpcEnumPrinterDataEx operation response
 type EnumPrinterDataExResponse struct {
+	// XXX: cbEnumValuesIn is an implicit input depedency for output parameters
+	EnumValuesInLength uint32 `idl:"name:cbEnumValuesIn" json:"enum_values_in_length"`
 	// pEnumValues: A pointer to BUFFER as specified in PRINTER_ENUM_VALUES Structures Query
 	// Parameters (section 3.1.4.1.10).
 	EnumValues          []byte `idl:"name:pEnumValues;size_is:(cbEnumValuesIn)" json:"enum_values"`
@@ -35711,6 +35939,11 @@ func (o *EnumPrinterDataExResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPr
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.EnumValuesInLength == uint32(0) {
+		op.EnumValuesInLength = o.EnumValuesInLength
+	}
+
 	op.EnumValues = o.EnumValues
 	op.EnumValuesOutLength = o.EnumValuesOutLength
 	op.EnumValuesLength = o.EnumValuesLength
@@ -35722,6 +35955,9 @@ func (o *EnumPrinterDataExResponse) xxx_FromOp(ctx context.Context, op *xxx_Enum
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.EnumValuesInLength = op.EnumValuesInLength
+
 	o.EnumValues = op.EnumValues
 	o.EnumValuesOutLength = op.EnumValuesOutLength
 	o.EnumValuesLength = op.EnumValuesLength
@@ -35961,6 +36197,8 @@ func (o *EnumPrinterKeyRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) 
 
 // EnumPrinterKeyResponse structure represents the RpcEnumPrinterKey operation response
 type EnumPrinterKeyResponse struct {
+	// XXX: cbSubkeyIn is an implicit input depedency for output parameters
+	SubkeyInLength uint32 `idl:"name:cbSubkeyIn" json:"subkey_in_length"`
 	// pSubkey: A pointer to BUFFER as specified in String Query Parameters (section 3.1.4.1.7).
 	Subkey          string `idl:"name:pSubkey;size_is:((cbSubkeyIn/2))" json:"subkey"`
 	SubkeyOutLength uint32 `idl:"name:pcbSubkeyOut" json:"subkey_out_length"`
@@ -35975,6 +36213,11 @@ func (o *EnumPrinterKeyResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumPrint
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.SubkeyInLength == uint32(0) {
+		op.SubkeyInLength = o.SubkeyInLength
+	}
+
 	op.Subkey = o.Subkey
 	op.SubkeyOutLength = o.SubkeyOutLength
 	op.Return = o.Return
@@ -35985,6 +36228,9 @@ func (o *EnumPrinterKeyResponse) xxx_FromOp(ctx context.Context, op *xxx_EnumPri
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.SubkeyInLength = op.SubkeyInLength
+
 	o.Subkey = op.Subkey
 	o.SubkeyOutLength = op.SubkeyOutLength
 	o.Return = op.Return
@@ -37388,6 +37634,8 @@ func (o *EnumPerMachineConnectionsRequest) UnmarshalNDR(ctx context.Context, r n
 
 // EnumPerMachineConnectionsResponse structure represents the RpcEnumPerMachineConnections operation response
 type EnumPerMachineConnectionsResponse struct {
+	// XXX: cbBuf is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBuf" json:"buffer_length"`
 	// pPrinterEnum: A pointer to the BUFFER, as specified in INFO Structures Query Parameters
 	// (section 3.1.4.1.9).
 	PrinterEnum []byte `idl:"name:pPrinterEnum;size_is:(cbBuf);pointer:unique" json:"printer_enum"`
@@ -37406,6 +37654,11 @@ func (o *EnumPerMachineConnectionsResponse) xxx_ToOp(ctx context.Context, op *xx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.PrinterEnum = o.PrinterEnum
 	op.NeededLength = o.NeededLength
 	op.ReturnedCount = o.ReturnedCount
@@ -37417,6 +37670,9 @@ func (o *EnumPerMachineConnectionsResponse) xxx_FromOp(ctx context.Context, op *
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.PrinterEnum = op.PrinterEnum
 	o.NeededLength = op.NeededLength
 	o.ReturnedCount = op.ReturnedCount
@@ -37767,6 +38023,8 @@ func (o *XcvDataRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // XcvDataResponse structure represents the RpcXcvData operation response
 type XcvDataResponse struct {
+	// XXX: cbOutputData is an implicit input depedency for output parameters
+	OutputDataLength uint32 `idl:"name:cbOutputData" json:"output_data_length"`
 	// pOutputData: A pointer to a buffer to receive output data. This parameter can be
 	// NULL if cbOutputData equals zero.
 	OutputData []byte `idl:"name:pOutputData;size_is:(cbOutputData)" json:"output_data"`
@@ -37788,6 +38046,11 @@ func (o *XcvDataResponse) xxx_ToOp(ctx context.Context, op *xxx_XcvDataOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutputDataLength == uint32(0) {
+		op.OutputDataLength = o.OutputDataLength
+	}
+
 	op.OutputData = o.OutputData
 	op.OutputNeededLength = o.OutputNeededLength
 	op.Status = o.Status
@@ -37799,6 +38062,9 @@ func (o *XcvDataResponse) xxx_FromOp(ctx context.Context, op *xxx_XcvDataOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutputDataLength = op.OutputDataLength
+
 	o.OutputData = op.OutputData
 	o.OutputNeededLength = op.OutputNeededLength
 	o.Status = op.Status
@@ -39010,6 +39276,8 @@ func (o *GetCorePrinterDriversRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // GetCorePrinterDriversResponse structure represents the RpcGetCorePrinterDrivers operation response
 type GetCorePrinterDriversResponse struct {
+	// XXX: cCorePrinterDrivers is an implicit input depedency for output parameters
+	CorePrinterDriversCount uint32 `idl:"name:cCorePrinterDrivers" json:"core_printer_drivers_count"`
 	// pCorePrinterDrivers: A pointer to a buffer that receives an array of CORE_PRINTER_DRIVER
 	// structures.
 	CorePrinterDrivers []*CorePrinterDriver `idl:"name:pCorePrinterDrivers;size_is:(cCorePrinterDrivers)" json:"core_printer_drivers"`
@@ -39024,6 +39292,11 @@ func (o *GetCorePrinterDriversResponse) xxx_ToOp(ctx context.Context, op *xxx_Ge
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.CorePrinterDriversCount == uint32(0) {
+		op.CorePrinterDriversCount = o.CorePrinterDriversCount
+	}
+
 	op.CorePrinterDrivers = o.CorePrinterDrivers
 	op.Return = o.Return
 	return op
@@ -39033,6 +39306,9 @@ func (o *GetCorePrinterDriversResponse) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.CorePrinterDriversCount = op.CorePrinterDriversCount
+
 	o.CorePrinterDrivers = op.CorePrinterDrivers
 	o.Return = op.Return
 }
@@ -39462,6 +39738,8 @@ func (o *GetPrinterDriverPackagePathRequest) UnmarshalNDR(ctx context.Context, r
 
 // GetPrinterDriverPackagePathResponse structure represents the RpcGetPrinterDriverPackagePath operation response
 type GetPrinterDriverPackagePathResponse struct {
+	// XXX: cchDriverPackageCab is an implicit input depedency for output parameters
+	DriverPackageCabLength uint32 `idl:"name:cchDriverPackageCab" json:"driver_package_cab_length"`
 	// pszDriverPackageCab: This parameter is a pointer to a buffer that receives a string
 	// that specifies the path name of the driver package file.<351> For rules governing
 	// path names, see section 2.2.4.9. pszDriverPackageCab MUST NOT be NULL unless cchDriverPackageCab
@@ -39481,6 +39759,11 @@ func (o *GetPrinterDriverPackagePathResponse) xxx_ToOp(ctx context.Context, op *
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DriverPackageCabLength == uint32(0) {
+		op.DriverPackageCabLength = o.DriverPackageCabLength
+	}
+
 	op.DriverPackageCab = o.DriverPackageCab
 	op.RequiredLength = o.RequiredLength
 	op.Return = o.Return
@@ -39491,6 +39774,9 @@ func (o *GetPrinterDriverPackagePathResponse) xxx_FromOp(ctx context.Context, op
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DriverPackageCabLength = op.DriverPackageCabLength
+
 	o.DriverPackageCab = op.DriverPackageCab
 	o.RequiredLength = op.RequiredLength
 	o.Return = op.Return

--- a/msrpc/rrp/winreg/v1/v1.go
+++ b/msrpc/rrp/winreg/v1/v1.go
@@ -9278,6 +9278,8 @@ func (o *BaseRegQueryMultipleValuesRequest) UnmarshalNDR(ctx context.Context, r 
 
 // BaseRegQueryMultipleValuesResponse structure represents the BaseRegQueryMultipleValues operation response
 type BaseRegQueryMultipleValuesResponse struct {
+	// XXX: num_vals is an implicit input depedency for output parameters
+	ValsLength uint32 `idl:"name:num_vals" json:"vals_length"`
 	// val_listOut: A pointer to an array of RVALENT structures, one for each value to be
 	// queried.
 	ValueListOut []*ValueEntry `idl:"name:val_listOut;size_is:(num_vals);length_is:(num_vals)" json:"value_list_out"`
@@ -9297,6 +9299,11 @@ func (o *BaseRegQueryMultipleValuesResponse) xxx_ToOp(ctx context.Context, op *x
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ValsLength == uint32(0) {
+		op.ValsLength = o.ValsLength
+	}
+
 	op.ValueListOut = o.ValueListOut
 	op.Buffer = o.Buffer
 	op.TotalSize = o.TotalSize
@@ -9308,6 +9315,9 @@ func (o *BaseRegQueryMultipleValuesResponse) xxx_FromOp(ctx context.Context, op 
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ValsLength = op.ValsLength
+
 	o.ValueListOut = op.ValueListOut
 	o.Buffer = op.Buffer
 	o.TotalSize = op.TotalSize
@@ -10565,6 +10575,10 @@ func (o *BaseRegQueryMultipleValues2Request) UnmarshalNDR(ctx context.Context, r
 
 // BaseRegQueryMultipleValues2Response structure represents the BaseRegQueryMultipleValues2 operation response
 type BaseRegQueryMultipleValues2Response struct {
+	// XXX: num_vals is an implicit input depedency for output parameters
+	ValsLength uint32 `idl:"name:num_vals" json:"vals_length"`
+	// XXX: ldwTotsize is an implicit input depedency for output parameters
+	TotalSize uint32 `idl:"name:ldwTotsize" json:"total_size"`
 	// val_listOut: A pointer to an array of RVALENT structures, one for each value to be
 	// queried. This parameter is a placeholder to return the type, size, and data offset
 	// for each requested value.
@@ -10586,6 +10600,14 @@ func (o *BaseRegQueryMultipleValues2Response) xxx_ToOp(ctx context.Context, op *
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ValsLength == uint32(0) {
+		op.ValsLength = o.ValsLength
+	}
+	if op.TotalSize == uint32(0) {
+		op.TotalSize = o.TotalSize
+	}
+
 	op.ValueListOut = o.ValueListOut
 	op.Buffer = o.Buffer
 	op.RequiredSize = o.RequiredSize
@@ -10597,6 +10619,10 @@ func (o *BaseRegQueryMultipleValues2Response) xxx_FromOp(ctx context.Context, op
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ValsLength = op.ValsLength
+	o.TotalSize = op.TotalSize
+
 	o.ValueListOut = op.ValueListOut
 	o.Buffer = op.Buffer
 	o.RequiredSize = op.RequiredSize

--- a/msrpc/rrp/winreg/v1/v1.go
+++ b/msrpc/rrp/winreg/v1/v1.go
@@ -9280,6 +9280,7 @@ func (o *BaseRegQueryMultipleValuesRequest) UnmarshalNDR(ctx context.Context, r 
 type BaseRegQueryMultipleValuesResponse struct {
 	// XXX: num_vals is an implicit input depedency for output parameters
 	ValsLength uint32 `idl:"name:num_vals" json:"vals_length"`
+
 	// val_listOut: A pointer to an array of RVALENT structures, one for each value to be
 	// queried.
 	ValueListOut []*ValueEntry `idl:"name:val_listOut;size_is:(num_vals);length_is:(num_vals)" json:"value_list_out"`
@@ -10579,6 +10580,7 @@ type BaseRegQueryMultipleValues2Response struct {
 	ValsLength uint32 `idl:"name:num_vals" json:"vals_length"`
 	// XXX: ldwTotsize is an implicit input depedency for output parameters
 	TotalSize uint32 `idl:"name:ldwTotsize" json:"total_size"`
+
 	// val_listOut: A pointer to an array of RVALENT structures, one for each value to be
 	// queried. This parameter is a placeholder to return the type, size, and data offset
 	// for each requested value.

--- a/msrpc/samr/samr/v1/v1.go
+++ b/msrpc/samr/samr/v1/v1.go
@@ -17059,7 +17059,9 @@ func (o *QueryInformationDomainRequest) UnmarshalNDR(ctx context.Context, r ndr.
 
 // QueryInformationDomainResponse structure represents the SamrQueryInformationDomain operation response
 type QueryInformationDomainResponse struct {
-	Buffer *DomainInfoBuffer `idl:"name:Buffer;switch_is:DomainInformationClass" json:"buffer"`
+	// XXX: DomainInformationClass is an implicit input depedency for output parameters
+	DomainInformationClass DomainInformationClass `idl:"name:DomainInformationClass" json:"domain_information_class"`
+	Buffer                 *DomainInfoBuffer      `idl:"name:Buffer;switch_is:DomainInformationClass" json:"buffer"`
 	// Return: The SamrQueryInformationDomain return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -17071,6 +17073,11 @@ func (o *QueryInformationDomainResponse) xxx_ToOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DomainInformationClass == DomainInformationClass(0) {
+		op.DomainInformationClass = o.DomainInformationClass
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -17080,6 +17087,9 @@ func (o *QueryInformationDomainResponse) xxx_FromOp(ctx context.Context, op *xxx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DomainInformationClass = op.DomainInformationClass
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -20291,6 +20301,8 @@ func (o *QueryInformationGroupRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // QueryInformationGroupResponse structure represents the SamrQueryInformationGroup operation response
 type QueryInformationGroupResponse struct {
+	// XXX: GroupInformationClass is an implicit input depedency for output parameters
+	GroupInformationClass GroupInformationClass `idl:"name:GroupInformationClass" json:"group_information_class"`
 	// Buffer: The requested attributes on output. See section 2.2.4.7 for structure details.
 	//
 	// This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject
@@ -20308,6 +20320,11 @@ func (o *QueryInformationGroupResponse) xxx_ToOp(ctx context.Context, op *xxx_Qu
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.GroupInformationClass == GroupInformationClass(0) {
+		op.GroupInformationClass = o.GroupInformationClass
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -20317,6 +20334,9 @@ func (o *QueryInformationGroupResponse) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.GroupInformationClass = op.GroupInformationClass
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -21915,6 +21935,8 @@ func (o *QueryInformationAliasRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // QueryInformationAliasResponse structure represents the SamrQueryInformationAlias operation response
 type QueryInformationAliasResponse struct {
+	// XXX: AliasInformationClass is an implicit input depedency for output parameters
+	AliasInformationClass AliasInformationClass `idl:"name:AliasInformationClass" json:"alias_information_class"`
 	// Buffer: The requested attributes on output. See section 2.2.5.6 for structure details.
 	//
 	// This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject
@@ -21932,6 +21954,11 @@ func (o *QueryInformationAliasResponse) xxx_ToOp(ctx context.Context, op *xxx_Qu
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.AliasInformationClass == AliasInformationClass(0) {
+		op.AliasInformationClass = o.AliasInformationClass
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -21941,6 +21968,9 @@ func (o *QueryInformationAliasResponse) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.AliasInformationClass = op.AliasInformationClass
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -23509,7 +23539,9 @@ func (o *QueryInformationUserRequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 
 // QueryInformationUserResponse structure represents the SamrQueryInformationUser operation response
 type QueryInformationUserResponse struct {
-	Buffer *UserInfoBuffer `idl:"name:Buffer;switch_is:UserInformationClass" json:"buffer"`
+	// XXX: UserInformationClass is an implicit input depedency for output parameters
+	UserInformationClass UserInformationClass `idl:"name:UserInformationClass" json:"user_information_class"`
+	Buffer               *UserInfoBuffer      `idl:"name:Buffer;switch_is:UserInformationClass" json:"buffer"`
 	// Return: The SamrQueryInformationUser return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -23521,6 +23553,11 @@ func (o *QueryInformationUserResponse) xxx_ToOp(ctx context.Context, op *xxx_Que
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.UserInformationClass == UserInformationClass(0) {
+		op.UserInformationClass = o.UserInformationClass
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -23530,6 +23567,9 @@ func (o *QueryInformationUserResponse) xxx_FromOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.UserInformationClass = op.UserInformationClass
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -24747,9 +24787,11 @@ func (o *QueryDisplayInformationRequest) UnmarshalNDR(ctx context.Context, r ndr
 
 // QueryDisplayInformationResponse structure represents the SamrQueryDisplayInformation operation response
 type QueryDisplayInformationResponse struct {
-	TotalAvailable uint32             `idl:"name:TotalAvailable" json:"total_available"`
-	TotalReturned  uint32             `idl:"name:TotalReturned" json:"total_returned"`
-	Buffer         *DisplayInfoBuffer `idl:"name:Buffer;switch_is:DisplayInformationClass" json:"buffer"`
+	// XXX: DisplayInformationClass is an implicit input depedency for output parameters
+	DisplayInformationClass DomainDisplayInformation `idl:"name:DisplayInformationClass" json:"display_information_class"`
+	TotalAvailable          uint32                   `idl:"name:TotalAvailable" json:"total_available"`
+	TotalReturned           uint32                   `idl:"name:TotalReturned" json:"total_returned"`
+	Buffer                  *DisplayInfoBuffer       `idl:"name:Buffer;switch_is:DisplayInformationClass" json:"buffer"`
 	// Return: The SamrQueryDisplayInformation return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -24761,6 +24803,11 @@ func (o *QueryDisplayInformationResponse) xxx_ToOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DisplayInformationClass == DomainDisplayInformation(0) {
+		op.DisplayInformationClass = o.DisplayInformationClass
+	}
+
 	op.TotalAvailable = o.TotalAvailable
 	op.TotalReturned = o.TotalReturned
 	op.Buffer = o.Buffer
@@ -24772,6 +24819,9 @@ func (o *QueryDisplayInformationResponse) xxx_FromOp(ctx context.Context, op *xx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DisplayInformationClass = op.DisplayInformationClass
+
 	o.TotalAvailable = op.TotalAvailable
 	o.TotalReturned = op.TotalReturned
 	o.Buffer = op.Buffer
@@ -25568,6 +25618,8 @@ func (o *QueryInformationDomain2Request) UnmarshalNDR(ctx context.Context, r ndr
 
 // QueryInformationDomain2Response structure represents the SamrQueryInformationDomain2 operation response
 type QueryInformationDomain2Response struct {
+	// XXX: DomainInformationClass is an implicit input depedency for output parameters
+	DomainInformationClass DomainInformationClass `idl:"name:DomainInformationClass" json:"domain_information_class"`
 	// Buffer: The requested attributes on output. See section 2.2.3.17 for structure details.
 	//
 	// This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject
@@ -25585,6 +25637,11 @@ func (o *QueryInformationDomain2Response) xxx_ToOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DomainInformationClass == DomainInformationClass(0) {
+		op.DomainInformationClass = o.DomainInformationClass
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -25594,6 +25651,9 @@ func (o *QueryInformationDomain2Response) xxx_FromOp(ctx context.Context, op *xx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DomainInformationClass = op.DomainInformationClass
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -25799,6 +25859,8 @@ func (o *QueryInformationUser2Request) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // QueryInformationUser2Response structure represents the SamrQueryInformationUser2 operation response
 type QueryInformationUser2Response struct {
+	// XXX: UserInformationClass is an implicit input depedency for output parameters
+	UserInformationClass UserInformationClass `idl:"name:UserInformationClass" json:"user_information_class"`
 	// Buffer: The requested attributes on output. See section 2.2.6.29 for structure details.
 	//
 	// This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject
@@ -25816,6 +25878,11 @@ func (o *QueryInformationUser2Response) xxx_ToOp(ctx context.Context, op *xxx_Qu
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.UserInformationClass == UserInformationClass(0) {
+		op.UserInformationClass = o.UserInformationClass
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -25825,6 +25892,9 @@ func (o *QueryInformationUser2Response) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.UserInformationClass = op.UserInformationClass
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -26081,9 +26151,11 @@ func (o *QueryDisplayInformation2Request) UnmarshalNDR(ctx context.Context, r nd
 
 // QueryDisplayInformation2Response structure represents the SamrQueryDisplayInformation2 operation response
 type QueryDisplayInformation2Response struct {
-	TotalAvailable uint32             `idl:"name:TotalAvailable" json:"total_available"`
-	TotalReturned  uint32             `idl:"name:TotalReturned" json:"total_returned"`
-	Buffer         *DisplayInfoBuffer `idl:"name:Buffer;switch_is:DisplayInformationClass" json:"buffer"`
+	// XXX: DisplayInformationClass is an implicit input depedency for output parameters
+	DisplayInformationClass DomainDisplayInformation `idl:"name:DisplayInformationClass" json:"display_information_class"`
+	TotalAvailable          uint32                   `idl:"name:TotalAvailable" json:"total_available"`
+	TotalReturned           uint32                   `idl:"name:TotalReturned" json:"total_returned"`
+	Buffer                  *DisplayInfoBuffer       `idl:"name:Buffer;switch_is:DisplayInformationClass" json:"buffer"`
 	// Return: The SamrQueryDisplayInformation2 return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -26095,6 +26167,11 @@ func (o *QueryDisplayInformation2Response) xxx_ToOp(ctx context.Context, op *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DisplayInformationClass == DomainDisplayInformation(0) {
+		op.DisplayInformationClass = o.DisplayInformationClass
+	}
+
 	op.TotalAvailable = o.TotalAvailable
 	op.TotalReturned = o.TotalReturned
 	op.Buffer = o.Buffer
@@ -26106,6 +26183,9 @@ func (o *QueryDisplayInformation2Response) xxx_FromOp(ctx context.Context, op *x
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DisplayInformationClass = op.DisplayInformationClass
+
 	o.TotalAvailable = op.TotalAvailable
 	o.TotalReturned = op.TotalReturned
 	o.Buffer = op.Buffer
@@ -26892,6 +26972,8 @@ func (o *QueryDisplayInformation3Request) UnmarshalNDR(ctx context.Context, r nd
 
 // QueryDisplayInformation3Response structure represents the SamrQueryDisplayInformation3 operation response
 type QueryDisplayInformation3Response struct {
+	// XXX: DisplayInformationClass is an implicit input depedency for output parameters
+	DisplayInformationClass DomainDisplayInformation `idl:"name:DisplayInformationClass" json:"display_information_class"`
 	// TotalAvailable: The number of bytes required to see a complete listing of accounts
 	// specified by the DisplayInformationClass parameter.
 	TotalAvailable uint32 `idl:"name:TotalAvailable" json:"total_available"`
@@ -26914,6 +26996,11 @@ func (o *QueryDisplayInformation3Response) xxx_ToOp(ctx context.Context, op *xxx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.DisplayInformationClass == DomainDisplayInformation(0) {
+		op.DisplayInformationClass = o.DisplayInformationClass
+	}
+
 	op.TotalAvailable = o.TotalAvailable
 	op.TotalReturned = o.TotalReturned
 	op.Buffer = o.Buffer
@@ -26925,6 +27012,9 @@ func (o *QueryDisplayInformation3Response) xxx_FromOp(ctx context.Context, op *x
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.DisplayInformationClass = op.DisplayInformationClass
+
 	o.TotalAvailable = op.TotalAvailable
 	o.TotalReturned = op.TotalReturned
 	o.Buffer = op.Buffer
@@ -29903,6 +29993,8 @@ func (o *ValidatePasswordRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // ValidatePasswordResponse structure represents the SamrValidatePassword operation response
 type ValidatePasswordResponse struct {
+	// XXX: ValidationType is an implicit input depedency for output parameters
+	ValidationType PasswordPolicyValidationType `idl:"name:ValidationType" json:"validation_type"`
 	// OutputArg: The result of the validation.
 	OutputArg *SAMValidateOutputArg `idl:"name:OutputArg;switch_is:ValidationType" json:"output_arg"`
 	// Return: The SamrValidatePassword return value.
@@ -29916,6 +30008,11 @@ func (o *ValidatePasswordResponse) xxx_ToOp(ctx context.Context, op *xxx_Validat
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ValidationType == PasswordPolicyValidationType(0) {
+		op.ValidationType = o.ValidationType
+	}
+
 	op.OutputArg = o.OutputArg
 	op.Return = o.Return
 	return op
@@ -29925,6 +30022,9 @@ func (o *ValidatePasswordResponse) xxx_FromOp(ctx context.Context, op *xxx_Valid
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ValidationType = op.ValidationType
+
 	o.OutputArg = op.OutputArg
 	o.Return = op.Return
 }

--- a/msrpc/samr/samr/v1/v1.go
+++ b/msrpc/samr/samr/v1/v1.go
@@ -17061,7 +17061,8 @@ func (o *QueryInformationDomainRequest) UnmarshalNDR(ctx context.Context, r ndr.
 type QueryInformationDomainResponse struct {
 	// XXX: DomainInformationClass is an implicit input depedency for output parameters
 	DomainInformationClass DomainInformationClass `idl:"name:DomainInformationClass" json:"domain_information_class"`
-	Buffer                 *DomainInfoBuffer      `idl:"name:Buffer;switch_is:DomainInformationClass" json:"buffer"`
+
+	Buffer *DomainInfoBuffer `idl:"name:Buffer;switch_is:DomainInformationClass" json:"buffer"`
 	// Return: The SamrQueryInformationDomain return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -20303,6 +20304,7 @@ func (o *QueryInformationGroupRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 type QueryInformationGroupResponse struct {
 	// XXX: GroupInformationClass is an implicit input depedency for output parameters
 	GroupInformationClass GroupInformationClass `idl:"name:GroupInformationClass" json:"group_information_class"`
+
 	// Buffer: The requested attributes on output. See section 2.2.4.7 for structure details.
 	//
 	// This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject
@@ -21937,6 +21939,7 @@ func (o *QueryInformationAliasRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 type QueryInformationAliasResponse struct {
 	// XXX: AliasInformationClass is an implicit input depedency for output parameters
 	AliasInformationClass AliasInformationClass `idl:"name:AliasInformationClass" json:"alias_information_class"`
+
 	// Buffer: The requested attributes on output. See section 2.2.5.6 for structure details.
 	//
 	// This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject
@@ -23541,7 +23544,8 @@ func (o *QueryInformationUserRequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 type QueryInformationUserResponse struct {
 	// XXX: UserInformationClass is an implicit input depedency for output parameters
 	UserInformationClass UserInformationClass `idl:"name:UserInformationClass" json:"user_information_class"`
-	Buffer               *UserInfoBuffer      `idl:"name:Buffer;switch_is:UserInformationClass" json:"buffer"`
+
+	Buffer *UserInfoBuffer `idl:"name:Buffer;switch_is:UserInformationClass" json:"buffer"`
 	// Return: The SamrQueryInformationUser return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -24789,9 +24793,10 @@ func (o *QueryDisplayInformationRequest) UnmarshalNDR(ctx context.Context, r ndr
 type QueryDisplayInformationResponse struct {
 	// XXX: DisplayInformationClass is an implicit input depedency for output parameters
 	DisplayInformationClass DomainDisplayInformation `idl:"name:DisplayInformationClass" json:"display_information_class"`
-	TotalAvailable          uint32                   `idl:"name:TotalAvailable" json:"total_available"`
-	TotalReturned           uint32                   `idl:"name:TotalReturned" json:"total_returned"`
-	Buffer                  *DisplayInfoBuffer       `idl:"name:Buffer;switch_is:DisplayInformationClass" json:"buffer"`
+
+	TotalAvailable uint32             `idl:"name:TotalAvailable" json:"total_available"`
+	TotalReturned  uint32             `idl:"name:TotalReturned" json:"total_returned"`
+	Buffer         *DisplayInfoBuffer `idl:"name:Buffer;switch_is:DisplayInformationClass" json:"buffer"`
 	// Return: The SamrQueryDisplayInformation return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -25620,6 +25625,7 @@ func (o *QueryInformationDomain2Request) UnmarshalNDR(ctx context.Context, r ndr
 type QueryInformationDomain2Response struct {
 	// XXX: DomainInformationClass is an implicit input depedency for output parameters
 	DomainInformationClass DomainInformationClass `idl:"name:DomainInformationClass" json:"domain_information_class"`
+
 	// Buffer: The requested attributes on output. See section 2.2.3.17 for structure details.
 	//
 	// This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject
@@ -25861,6 +25867,7 @@ func (o *QueryInformationUser2Request) UnmarshalNDR(ctx context.Context, r ndr.R
 type QueryInformationUser2Response struct {
 	// XXX: UserInformationClass is an implicit input depedency for output parameters
 	UserInformationClass UserInformationClass `idl:"name:UserInformationClass" json:"user_information_class"`
+
 	// Buffer: The requested attributes on output. See section 2.2.6.29 for structure details.
 	//
 	// This protocol asks the RPC runtime, via the strict_context_handle attribute, to reject
@@ -26153,9 +26160,10 @@ func (o *QueryDisplayInformation2Request) UnmarshalNDR(ctx context.Context, r nd
 type QueryDisplayInformation2Response struct {
 	// XXX: DisplayInformationClass is an implicit input depedency for output parameters
 	DisplayInformationClass DomainDisplayInformation `idl:"name:DisplayInformationClass" json:"display_information_class"`
-	TotalAvailable          uint32                   `idl:"name:TotalAvailable" json:"total_available"`
-	TotalReturned           uint32                   `idl:"name:TotalReturned" json:"total_returned"`
-	Buffer                  *DisplayInfoBuffer       `idl:"name:Buffer;switch_is:DisplayInformationClass" json:"buffer"`
+
+	TotalAvailable uint32             `idl:"name:TotalAvailable" json:"total_available"`
+	TotalReturned  uint32             `idl:"name:TotalReturned" json:"total_returned"`
+	Buffer         *DisplayInfoBuffer `idl:"name:Buffer;switch_is:DisplayInformationClass" json:"buffer"`
 	// Return: The SamrQueryDisplayInformation2 return value.
 	Return int32 `idl:"name:Return" json:"return"`
 }
@@ -26974,6 +26982,7 @@ func (o *QueryDisplayInformation3Request) UnmarshalNDR(ctx context.Context, r nd
 type QueryDisplayInformation3Response struct {
 	// XXX: DisplayInformationClass is an implicit input depedency for output parameters
 	DisplayInformationClass DomainDisplayInformation `idl:"name:DisplayInformationClass" json:"display_information_class"`
+
 	// TotalAvailable: The number of bytes required to see a complete listing of accounts
 	// specified by the DisplayInformationClass parameter.
 	TotalAvailable uint32 `idl:"name:TotalAvailable" json:"total_available"`
@@ -29995,6 +30004,7 @@ func (o *ValidatePasswordRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type ValidatePasswordResponse struct {
 	// XXX: ValidationType is an implicit input depedency for output parameters
 	ValidationType PasswordPolicyValidationType `idl:"name:ValidationType" json:"validation_type"`
+
 	// OutputArg: The result of the validation.
 	OutputArg *SAMValidateOutputArg `idl:"name:OutputArg;switch_is:ValidationType" json:"output_arg"`
 	// Return: The SamrValidatePassword return value.

--- a/msrpc/scmr/svcctl/v2/v2.go
+++ b/msrpc/scmr/svcctl/v2/v2.go
@@ -10166,6 +10166,8 @@ func (o *QueryServiceObjectSecurityRequest) UnmarshalNDR(ctx context.Context, r 
 
 // QueryServiceObjectSecurityResponse structure represents the RQueryServiceObjectSecurity operation response
 type QueryServiceObjectSecurityResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpSecurityDescriptor: A pointer to a buffer that contains a copy of the SECURITY_DESCRIPTOR
 	// structure (as specified in [MS-DTYP] section 2.4.6) for the specified service object.
 	SecurityDescriptor []byte `idl:"name:lpSecurityDescriptor;size_is:(cbBufSize)" json:"security_descriptor"`
@@ -10184,6 +10186,11 @@ func (o *QueryServiceObjectSecurityResponse) xxx_ToOp(ctx context.Context, op *x
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.SecurityDescriptor = o.SecurityDescriptor
 	op.BytesNeededLength = o.BytesNeededLength
 	op.Return = o.Return
@@ -10194,6 +10201,9 @@ func (o *QueryServiceObjectSecurityResponse) xxx_FromOp(ctx context.Context, op 
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.SecurityDescriptor = op.SecurityDescriptor
 	o.BytesNeededLength = op.BytesNeededLength
 	o.Return = op.Return
@@ -12995,6 +13005,8 @@ func (o *EnumDependentServicesWRequest) UnmarshalNDR(ctx context.Context, r ndr.
 
 // EnumDependentServicesWResponse structure represents the REnumDependentServicesW operation response
 type EnumDependentServicesWResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpServices: A pointer to an array of ENUM_SERVICE_STATUSW (section 2.2.11) structures
 	// that contain the name and service status information for each dependent service in
 	// the database.
@@ -13016,6 +13028,11 @@ func (o *EnumDependentServicesWResponse) xxx_ToOp(ctx context.Context, op *xxx_E
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Services = o.Services
 	op.BytesNeededLength = o.BytesNeededLength
 	op.ServicesReturned = o.ServicesReturned
@@ -13027,6 +13044,9 @@ func (o *EnumDependentServicesWResponse) xxx_FromOp(ctx context.Context, op *xxx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Services = op.Services
 	o.BytesNeededLength = op.BytesNeededLength
 	o.ServicesReturned = op.ServicesReturned
@@ -13404,6 +13424,8 @@ func (o *EnumServicesStatusWRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // EnumServicesStatusWResponse structure represents the REnumServicesStatusW operation response
 type EnumServicesStatusWResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: A pointer to an array of ENUM_SERVICE_STATUSW (section 2.2.11) structures
 	// that contain the name and service status information for each service in the database.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -13431,6 +13453,11 @@ func (o *EnumServicesStatusWResponse) xxx_ToOp(ctx context.Context, op *xxx_Enum
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.ServicesReturned = o.ServicesReturned
@@ -13443,6 +13470,9 @@ func (o *EnumServicesStatusWResponse) xxx_FromOp(ctx context.Context, op *xxx_En
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.ServicesReturned = op.ServicesReturned
@@ -17057,6 +17087,8 @@ func (o *EnumDependentServicesARequest) UnmarshalNDR(ctx context.Context, r ndr.
 
 // EnumDependentServicesAResponse structure represents the REnumDependentServicesA operation response
 type EnumDependentServicesAResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpServices: A pointer to an array of ENUM_SERVICE_STATUSA (section 2.2.10) structures
 	// that contain the name and service status information for each dependent service record
 	// in the database.
@@ -17078,6 +17110,11 @@ func (o *EnumDependentServicesAResponse) xxx_ToOp(ctx context.Context, op *xxx_E
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Services = o.Services
 	op.BytesNeededLength = o.BytesNeededLength
 	op.ServicesReturned = o.ServicesReturned
@@ -17089,6 +17126,9 @@ func (o *EnumDependentServicesAResponse) xxx_FromOp(ctx context.Context, op *xxx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Services = op.Services
 	o.BytesNeededLength = op.BytesNeededLength
 	o.ServicesReturned = op.ServicesReturned
@@ -17465,6 +17505,8 @@ func (o *EnumServicesStatusARequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 
 // EnumServicesStatusAResponse structure represents the REnumServicesStatusA operation response
 type EnumServicesStatusAResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: A pointer to an array of ENUM_SERVICE_STATUSA (section 2.2.10) structures
 	// that contain the name and service status information for each dependent service in
 	// the database.
@@ -17493,6 +17535,11 @@ func (o *EnumServicesStatusAResponse) xxx_ToOp(ctx context.Context, op *xxx_Enum
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.ServicesReturned = o.ServicesReturned
@@ -17505,6 +17552,9 @@ func (o *EnumServicesStatusAResponse) xxx_FromOp(ctx context.Context, op *xxx_En
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.ServicesReturned = op.ServicesReturned
@@ -19728,6 +19778,8 @@ func (o *EnumServiceGroupWRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // EnumServiceGroupWResponse structure represents the REnumServiceGroupW operation response
 type EnumServiceGroupWResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: A pointer to an array of ENUM_SERVICE_STATUSW (section 2.2.11) structures
 	// that contain the name and service status information for each dependent service in
 	// the database.
@@ -19756,6 +19808,11 @@ func (o *EnumServiceGroupWResponse) xxx_ToOp(ctx context.Context, op *xxx_EnumSe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.ServicesReturned = o.ServicesReturned
@@ -19768,6 +19825,9 @@ func (o *EnumServiceGroupWResponse) xxx_FromOp(ctx context.Context, op *xxx_Enum
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.ServicesReturned = op.ServicesReturned
@@ -20416,6 +20476,8 @@ func (o *QueryServiceConfig2ARequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 
 // QueryServiceConfig2AResponse structure represents the RQueryServiceConfig2A operation response
 type QueryServiceConfig2AResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: A pointer to the buffer that contains the service configuration information.
 	// The format of this data depends on the value of the dwInfoLevel parameter.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -20434,6 +20496,11 @@ func (o *QueryServiceConfig2AResponse) xxx_ToOp(ctx context.Context, op *xxx_Que
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.Return = o.Return
@@ -20444,6 +20511,9 @@ func (o *QueryServiceConfig2AResponse) xxx_FromOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.Return = op.Return
@@ -20710,6 +20780,8 @@ func (o *QueryServiceConfig2WRequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 
 // QueryServiceConfig2WResponse structure represents the RQueryServiceConfig2W operation response
 type QueryServiceConfig2WResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: A pointer to the buffer that contains the service configuration information.
 	// The format of this data depends on the value of the dwInfoLevel parameter.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -20728,6 +20800,11 @@ func (o *QueryServiceConfig2WResponse) xxx_ToOp(ctx context.Context, op *xxx_Que
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.Return = o.Return
@@ -20738,6 +20815,9 @@ func (o *QueryServiceConfig2WResponse) xxx_FromOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.Return = op.Return
@@ -20976,6 +21056,8 @@ func (o *QueryServiceStatusExRequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 
 // QueryServiceStatusExResponse structure represents the RQueryServiceStatusEx operation response
 type QueryServiceStatusExResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: A pointer to the buffer that contains the status information in the form
 	// of a SERVICE_STATUS_PROCESS (section 2.2.49) structure.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -20994,6 +21076,11 @@ func (o *QueryServiceStatusExResponse) xxx_ToOp(ctx context.Context, op *xxx_Que
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.Return = o.Return
@@ -21004,6 +21091,9 @@ func (o *QueryServiceStatusExResponse) xxx_FromOp(ctx context.Context, op *xxx_Q
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.Return = op.Return
@@ -21443,6 +21533,8 @@ func (o *EnumServicesStatusExARequest) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // EnumServicesStatusExAResponse structure represents the REnumServicesStatusExA operation response
 type EnumServicesStatusExAResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: A pointer to the buffer that contains the status information in the form
 	// of an array of ENUM_SERVICE_STATUS_PROCESSA (section 2.2.12) structures.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -21470,6 +21562,11 @@ func (o *EnumServicesStatusExAResponse) xxx_ToOp(ctx context.Context, op *xxx_En
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.ServicesReturned = o.ServicesReturned
@@ -21482,6 +21579,9 @@ func (o *EnumServicesStatusExAResponse) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.ServicesReturned = op.ServicesReturned
@@ -21923,6 +22023,8 @@ func (o *EnumServicesStatusExWRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // EnumServicesStatusExWResponse structure represents the REnumServicesStatusExW operation response
 type EnumServicesStatusExWResponse struct {
+	// XXX: cbBufSize is an implicit input depedency for output parameters
+	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
 	// lpBuffer: A pointer to the buffer that contains the status information in the form
 	// of an array of ENUM_SERVICE_STATUS_PROCESSW (section 2.2.13) structures.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -21951,6 +22053,11 @@ func (o *EnumServicesStatusExWResponse) xxx_ToOp(ctx context.Context, op *xxx_En
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferLength == uint32(0) {
+		op.BufferLength = o.BufferLength
+	}
+
 	op.Buffer = o.Buffer
 	op.BytesNeededLength = o.BytesNeededLength
 	op.ServicesReturned = o.ServicesReturned
@@ -21963,6 +22070,9 @@ func (o *EnumServicesStatusExWResponse) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferLength = op.BufferLength
+
 	o.Buffer = op.Buffer
 	o.BytesNeededLength = op.BytesNeededLength
 	o.ServicesReturned = op.ServicesReturned
@@ -24519,6 +24629,8 @@ func (o *ControlServiceExARequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // ControlServiceExAResponse structure represents the RControlServiceExA operation response
 type ControlServiceExAResponse struct {
+	// XXX: dwInfoLevel is an implicit input depedency for output parameters
+	InfoLevel uint32 `idl:"name:dwInfoLevel" json:"info_level"`
 	// pControlOutParams: A pointer to a buffer that contains a SERVICE_CONTROL_STATUS_REASON_OUT_PARAMS
 	// (section 2.2.32) structure to receive the current status on the service.
 	ControlOutParams *ServiceControlOutParamsA `idl:"name:pControlOutParams;switch_is:dwInfoLevel" json:"control_out_params"`
@@ -24533,6 +24645,11 @@ func (o *ControlServiceExAResponse) xxx_ToOp(ctx context.Context, op *xxx_Contro
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InfoLevel == uint32(0) {
+		op.InfoLevel = o.InfoLevel
+	}
+
 	op.ControlOutParams = o.ControlOutParams
 	op.Return = o.Return
 	return op
@@ -24542,6 +24659,9 @@ func (o *ControlServiceExAResponse) xxx_FromOp(ctx context.Context, op *xxx_Cont
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InfoLevel = op.InfoLevel
+
 	o.ControlOutParams = op.ControlOutParams
 	o.Return = op.Return
 }
@@ -24837,6 +24957,8 @@ func (o *ControlServiceExWRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 
 // ControlServiceExWResponse structure represents the RControlServiceExW operation response
 type ControlServiceExWResponse struct {
+	// XXX: dwInfoLevel is an implicit input depedency for output parameters
+	InfoLevel uint32 `idl:"name:dwInfoLevel" json:"info_level"`
 	// pControlOutParams: A pointer to a buffer that contains a SERVICE_CONTROL_STATUS_REASON_OUT_PARAMS
 	// (section 2.2.32) structure to receive the current status on the service.
 	ControlOutParams *ServiceControlOutParamsW `idl:"name:pControlOutParams;switch_is:dwInfoLevel" json:"control_out_params"`
@@ -24851,6 +24973,11 @@ func (o *ControlServiceExWResponse) xxx_ToOp(ctx context.Context, op *xxx_Contro
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.InfoLevel == uint32(0) {
+		op.InfoLevel = o.InfoLevel
+	}
+
 	op.ControlOutParams = o.ControlOutParams
 	op.Return = o.Return
 	return op
@@ -24860,6 +24987,9 @@ func (o *ControlServiceExWResponse) xxx_FromOp(ctx context.Context, op *xxx_Cont
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.InfoLevel = op.InfoLevel
+
 	o.ControlOutParams = op.ControlOutParams
 	o.Return = op.Return
 }

--- a/msrpc/scmr/svcctl/v2/v2.go
+++ b/msrpc/scmr/svcctl/v2/v2.go
@@ -10168,6 +10168,7 @@ func (o *QueryServiceObjectSecurityRequest) UnmarshalNDR(ctx context.Context, r 
 type QueryServiceObjectSecurityResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpSecurityDescriptor: A pointer to a buffer that contains a copy of the SECURITY_DESCRIPTOR
 	// structure (as specified in [MS-DTYP] section 2.4.6) for the specified service object.
 	SecurityDescriptor []byte `idl:"name:lpSecurityDescriptor;size_is:(cbBufSize)" json:"security_descriptor"`
@@ -13007,6 +13008,7 @@ func (o *EnumDependentServicesWRequest) UnmarshalNDR(ctx context.Context, r ndr.
 type EnumDependentServicesWResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpServices: A pointer to an array of ENUM_SERVICE_STATUSW (section 2.2.11) structures
 	// that contain the name and service status information for each dependent service in
 	// the database.
@@ -13426,6 +13428,7 @@ func (o *EnumServicesStatusWRequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type EnumServicesStatusWResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: A pointer to an array of ENUM_SERVICE_STATUSW (section 2.2.11) structures
 	// that contain the name and service status information for each service in the database.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -17089,6 +17092,7 @@ func (o *EnumDependentServicesARequest) UnmarshalNDR(ctx context.Context, r ndr.
 type EnumDependentServicesAResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpServices: A pointer to an array of ENUM_SERVICE_STATUSA (section 2.2.10) structures
 	// that contain the name and service status information for each dependent service record
 	// in the database.
@@ -17507,6 +17511,7 @@ func (o *EnumServicesStatusARequest) UnmarshalNDR(ctx context.Context, r ndr.Rea
 type EnumServicesStatusAResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: A pointer to an array of ENUM_SERVICE_STATUSA (section 2.2.10) structures
 	// that contain the name and service status information for each dependent service in
 	// the database.
@@ -19780,6 +19785,7 @@ func (o *EnumServiceGroupWRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type EnumServiceGroupWResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: A pointer to an array of ENUM_SERVICE_STATUSW (section 2.2.11) structures
 	// that contain the name and service status information for each dependent service in
 	// the database.
@@ -20478,6 +20484,7 @@ func (o *QueryServiceConfig2ARequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 type QueryServiceConfig2AResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: A pointer to the buffer that contains the service configuration information.
 	// The format of this data depends on the value of the dwInfoLevel parameter.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -20782,6 +20789,7 @@ func (o *QueryServiceConfig2WRequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 type QueryServiceConfig2WResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: A pointer to the buffer that contains the service configuration information.
 	// The format of this data depends on the value of the dwInfoLevel parameter.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -21058,6 +21066,7 @@ func (o *QueryServiceStatusExRequest) UnmarshalNDR(ctx context.Context, r ndr.Re
 type QueryServiceStatusExResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: A pointer to the buffer that contains the status information in the form
 	// of a SERVICE_STATUS_PROCESS (section 2.2.49) structure.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -21535,6 +21544,7 @@ func (o *EnumServicesStatusExARequest) UnmarshalNDR(ctx context.Context, r ndr.R
 type EnumServicesStatusExAResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: A pointer to the buffer that contains the status information in the form
 	// of an array of ENUM_SERVICE_STATUS_PROCESSA (section 2.2.12) structures.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -22025,6 +22035,7 @@ func (o *EnumServicesStatusExWRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 type EnumServicesStatusExWResponse struct {
 	// XXX: cbBufSize is an implicit input depedency for output parameters
 	BufferLength uint32 `idl:"name:cbBufSize" json:"buffer_length"`
+
 	// lpBuffer: A pointer to the buffer that contains the status information in the form
 	// of an array of ENUM_SERVICE_STATUS_PROCESSW (section 2.2.13) structures.
 	Buffer []byte `idl:"name:lpBuffer;size_is:(cbBufSize)" json:"buffer"`
@@ -24631,6 +24642,7 @@ func (o *ControlServiceExARequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type ControlServiceExAResponse struct {
 	// XXX: dwInfoLevel is an implicit input depedency for output parameters
 	InfoLevel uint32 `idl:"name:dwInfoLevel" json:"info_level"`
+
 	// pControlOutParams: A pointer to a buffer that contains a SERVICE_CONTROL_STATUS_REASON_OUT_PARAMS
 	// (section 2.2.32) structure to receive the current status on the service.
 	ControlOutParams *ServiceControlOutParamsA `idl:"name:pControlOutParams;switch_is:dwInfoLevel" json:"control_out_params"`
@@ -24959,6 +24971,7 @@ func (o *ControlServiceExWRequest) UnmarshalNDR(ctx context.Context, r ndr.Reade
 type ControlServiceExWResponse struct {
 	// XXX: dwInfoLevel is an implicit input depedency for output parameters
 	InfoLevel uint32 `idl:"name:dwInfoLevel" json:"info_level"`
+
 	// pControlOutParams: A pointer to a buffer that contains a SERVICE_CONTROL_STATUS_REASON_OUT_PARAMS
 	// (section 2.2.32) structure to receive the current status on the service.
 	ControlOutParams *ServiceControlOutParamsW `idl:"name:pControlOutParams;switch_is:dwInfoLevel" json:"control_out_params"`

--- a/msrpc/srvs/srvsvc/v3/v3.go
+++ b/msrpc/srvs/srvsvc/v3/v3.go
@@ -20367,6 +20367,8 @@ func (o *FileGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 
 // FileGetInfoResponse structure represents the NetrFileGetInfo operation response
 type FileGetInfoResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// InfoStruct: This parameter is of type LPFILE_INFO, which is defined in section 2.2.3.3.
 	// Its contents are determined by the value of the Level member, as shown in the previous
 	// parameter table.
@@ -20382,6 +20384,11 @@ func (o *FileGetInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_FileGetInfoO
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.Info = o.Info
 	op.Return = o.Return
 	return op
@@ -20391,6 +20398,9 @@ func (o *FileGetInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_FileGetInf
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.Info = op.Info
 	o.Return = op.Return
 }
@@ -22195,6 +22205,8 @@ func (o *ShareGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 
 // ShareGetInfoResponse structure represents the NetrShareGetInfo operation response
 type ShareGetInfoResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// InfoStruct: This parameter is of type LPSHARE_INFO union, as specified in section
 	// 2.2.3.6. Its contents are determined by the value of the Level parameter, as shown
 	// in the preceding table.
@@ -22210,6 +22222,11 @@ func (o *ShareGetInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_ShareGetInf
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.Info = o.Info
 	op.Return = o.Return
 	return op
@@ -22219,6 +22236,9 @@ func (o *ShareGetInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_ShareGetI
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.Info = op.Info
 	o.Return = op.Return
 }
@@ -23402,6 +23422,8 @@ func (o *GetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // GetInfoResponse structure represents the NetrServerGetInfo operation response
 type GetInfoResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// InfoStruct: This is a structure of type LPSERVER_INFO, as specified in section 2.2.3.7.
 	// The content of the InfoStruct parameter is determined by the Level parameter, as
 	// the preceding table shows.
@@ -23417,6 +23439,11 @@ func (o *GetInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_GetInfoOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.Info = o.Info
 	op.Return = o.Return
 	return op
@@ -23426,6 +23453,9 @@ func (o *GetInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_GetInfoOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.Info = op.Info
 	o.Return = op.Return
 }
@@ -26080,6 +26110,8 @@ func (o *PathCanonicalizeRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // PathCanonicalizeResponse structure represents the NetprPathCanonicalize operation response
 type PathCanonicalizeResponse struct {
+	// XXX: OutbufLen is an implicit input depedency for output parameters
+	OutputBufferLength uint32 `idl:"name:OutbufLen" json:"output_buffer_length"`
 	// Outbuf: A pointer to the output buffer where the canonicalized path name is returned.
 	OutputBuffer []byte `idl:"name:Outbuf;size_is:(OutbufLen)" json:"output_buffer"`
 	// PathType: A place to store the path type. This parameter MUST be set by the client
@@ -26098,6 +26130,11 @@ func (o *PathCanonicalizeResponse) xxx_ToOp(ctx context.Context, op *xxx_PathCan
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutputBufferLength == uint32(0) {
+		op.OutputBufferLength = o.OutputBufferLength
+	}
+
 	op.OutputBuffer = o.OutputBuffer
 	op.PathType = o.PathType
 	op.Return = o.Return
@@ -26108,6 +26145,9 @@ func (o *PathCanonicalizeResponse) xxx_FromOp(ctx context.Context, op *xxx_PathC
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutputBufferLength = op.OutputBufferLength
+
 	o.OutputBuffer = op.OutputBuffer
 	o.PathType = op.PathType
 	o.Return = op.Return
@@ -26874,6 +26914,8 @@ func (o *NameCanonicalizeRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 
 // NameCanonicalizeResponse structure represents the NetprNameCanonicalize operation response
 type NameCanonicalizeResponse struct {
+	// XXX: OutbufLen is an implicit input depedency for output parameters
+	OutputBufferLength uint32 `idl:"name:OutbufLen" json:"output_buffer_length"`
 	// Outbuf: A pointer to a null-terminated UTF-16 string that is the buffer where the
 	// canonicalized name is returned.
 	OutputBuffer string `idl:"name:Outbuf;size_is:(OutbufLen)" json:"output_buffer"`
@@ -26888,6 +26930,11 @@ func (o *NameCanonicalizeResponse) xxx_ToOp(ctx context.Context, op *xxx_NameCan
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.OutputBufferLength == uint32(0) {
+		op.OutputBufferLength = o.OutputBufferLength
+	}
+
 	op.OutputBuffer = o.OutputBuffer
 	op.Return = o.Return
 	return op
@@ -26897,6 +26944,9 @@ func (o *NameCanonicalizeResponse) xxx_FromOp(ctx context.Context, op *xxx_NameC
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.OutputBufferLength = op.OutputBufferLength
+
 	o.OutputBuffer = op.OutputBuffer
 	o.Return = op.Return
 }
@@ -29981,6 +30031,8 @@ func (o *CreateExitPointRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 
 // CreateExitPointResponse structure represents the NetrDfsCreateExitPoint operation response
 type CreateExitPointResponse struct {
+	// XXX: ShortPrefixLen is an implicit input depedency for output parameters
+	ShortPrefixLength uint32 `idl:"name:ShortPrefixLen" json:"short_prefix_length"`
 	// ShortPrefix: A pointer to a null-terminated UTF-16 string that is the buffer where
 	// the name of the DFS namespace root or link is returned.<147>
 	ShortPrefix string `idl:"name:ShortPrefix;size_is:(ShortPrefixLen)" json:"short_prefix"`
@@ -29995,6 +30047,11 @@ func (o *CreateExitPointResponse) xxx_ToOp(ctx context.Context, op *xxx_CreateEx
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.ShortPrefixLength == uint32(0) {
+		op.ShortPrefixLength = o.ShortPrefixLength
+	}
+
 	op.ShortPrefix = o.ShortPrefix
 	op.Return = o.Return
 	return op
@@ -30004,6 +30061,9 @@ func (o *CreateExitPointResponse) xxx_FromOp(ctx context.Context, op *xxx_Create
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.ShortPrefixLength = op.ShortPrefixLength
+
 	o.ShortPrefix = op.ShortPrefix
 	o.Return = op.Return
 }

--- a/msrpc/srvs/srvsvc/v3/v3.go
+++ b/msrpc/srvs/srvsvc/v3/v3.go
@@ -20369,6 +20369,7 @@ func (o *FileGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) err
 type FileGetInfoResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// InfoStruct: This parameter is of type LPFILE_INFO, which is defined in section 2.2.3.3.
 	// Its contents are determined by the value of the Level member, as shown in the previous
 	// parameter table.
@@ -22207,6 +22208,7 @@ func (o *ShareGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) er
 type ShareGetInfoResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// InfoStruct: This parameter is of type LPSHARE_INFO union, as specified in section
 	// 2.2.3.6. Its contents are determined by the value of the Level parameter, as shown
 	// in the preceding table.
@@ -23424,6 +23426,7 @@ func (o *GetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type GetInfoResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// InfoStruct: This is a structure of type LPSERVER_INFO, as specified in section 2.2.3.7.
 	// The content of the InfoStruct parameter is determined by the Level parameter, as
 	// the preceding table shows.
@@ -26112,6 +26115,7 @@ func (o *PathCanonicalizeRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type PathCanonicalizeResponse struct {
 	// XXX: OutbufLen is an implicit input depedency for output parameters
 	OutputBufferLength uint32 `idl:"name:OutbufLen" json:"output_buffer_length"`
+
 	// Outbuf: A pointer to the output buffer where the canonicalized path name is returned.
 	OutputBuffer []byte `idl:"name:Outbuf;size_is:(OutbufLen)" json:"output_buffer"`
 	// PathType: A place to store the path type. This parameter MUST be set by the client
@@ -26916,6 +26920,7 @@ func (o *NameCanonicalizeRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader
 type NameCanonicalizeResponse struct {
 	// XXX: OutbufLen is an implicit input depedency for output parameters
 	OutputBufferLength uint32 `idl:"name:OutbufLen" json:"output_buffer_length"`
+
 	// Outbuf: A pointer to a null-terminated UTF-16 string that is the buffer where the
 	// canonicalized name is returned.
 	OutputBuffer string `idl:"name:Outbuf;size_is:(OutbufLen)" json:"output_buffer"`
@@ -30033,6 +30038,7 @@ func (o *CreateExitPointRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader)
 type CreateExitPointResponse struct {
 	// XXX: ShortPrefixLen is an implicit input depedency for output parameters
 	ShortPrefixLength uint32 `idl:"name:ShortPrefixLen" json:"short_prefix_length"`
+
 	// ShortPrefix: A pointer to a null-terminated UTF-16 string that is the buffer where
 	// the name of the DFS namespace root or link is returned.<147>
 	ShortPrefix string `idl:"name:ShortPrefix;size_is:(ShortPrefixLen)" json:"short_prefix"`

--- a/msrpc/trp/tapsrv/v1/v1.go
+++ b/msrpc/trp/tapsrv/v1/v1.go
@@ -766,6 +766,7 @@ func (o *ClientRequestRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 type ClientRequestResponse struct {
 	// XXX: lNeededSize is an implicit input depedency for output parameters
 	NeededSize int32 `idl:"name:lNeededSize" json:"needed_size"`
+
 	// pBuffer: Packet that MUST contain event packets or function calls. The packet follows
 	// the structure of a TAPI32_MSG (section 2.2.5.2) packet. The Req_Func field of this
 	// packet contains information about the operation to be performed on the server.

--- a/msrpc/trp/tapsrv/v1/v1.go
+++ b/msrpc/trp/tapsrv/v1/v1.go
@@ -764,6 +764,8 @@ func (o *ClientRequestRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) e
 
 // ClientRequestResponse structure represents the ClientRequest operation response
 type ClientRequestResponse struct {
+	// XXX: lNeededSize is an implicit input depedency for output parameters
+	NeededSize int32 `idl:"name:lNeededSize" json:"needed_size"`
 	// pBuffer: Packet that MUST contain event packets or function calls. The packet follows
 	// the structure of a TAPI32_MSG (section 2.2.5.2) packet. The Req_Func field of this
 	// packet contains information about the operation to be performed on the server.
@@ -781,6 +783,11 @@ func (o *ClientRequestResponse) xxx_ToOp(ctx context.Context, op *xxx_ClientRequ
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.NeededSize == int32(0) {
+		op.NeededSize = o.NeededSize
+	}
+
 	op.Buffer = o.Buffer
 	op.UsedSize = o.UsedSize
 	return op
@@ -790,6 +797,9 @@ func (o *ClientRequestResponse) xxx_FromOp(ctx context.Context, op *xxx_ClientRe
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.NeededSize = op.NeededSize
+
 	o.Buffer = op.Buffer
 	o.UsedSize = op.UsedSize
 }

--- a/msrpc/tsch/sasec/v1/v1.go
+++ b/msrpc/tsch/sasec/v1/v1.go
@@ -977,6 +977,7 @@ func (o *GetNSAccountInformationRequest) UnmarshalNDR(ctx context.Context, r ndr
 type GetNSAccountInformationResponse struct {
 	// XXX: ccBufferSize is an implicit input depedency for output parameters
 	BufferSize uint32 `idl:"name:ccBufferSize" json:"buffer_size"`
+
 	// wszBuffer: Upon input, MUST be an empty array of size equal to the ccBufferSize parameter.
 	// The client SHOULD initialize the array to contain zeroes. Upon return, the array
 	// MUST contain the ATSvc account name.
@@ -1318,6 +1319,7 @@ func (o *GetAccountInformationRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 type GetAccountInformationResponse struct {
 	// XXX: ccBufferSize is an implicit input depedency for output parameters
 	BufferSize uint32 `idl:"name:ccBufferSize" json:"buffer_size"`
+
 	// wszBuffer: Upon input, MUST be an empty array of size equal to the ccBufferSize parameter.
 	// The client SHOULD initialize the array to contain zeroes. Upon return, the array
 	// MUST contain the name of the account to be used as the context the task runs under.

--- a/msrpc/tsch/sasec/v1/v1.go
+++ b/msrpc/tsch/sasec/v1/v1.go
@@ -975,6 +975,8 @@ func (o *GetNSAccountInformationRequest) UnmarshalNDR(ctx context.Context, r ndr
 
 // GetNSAccountInformationResponse structure represents the SAGetNSAccountInformation operation response
 type GetNSAccountInformationResponse struct {
+	// XXX: ccBufferSize is an implicit input depedency for output parameters
+	BufferSize uint32 `idl:"name:ccBufferSize" json:"buffer_size"`
 	// wszBuffer: Upon input, MUST be an empty array of size equal to the ccBufferSize parameter.
 	// The client SHOULD initialize the array to contain zeroes. Upon return, the array
 	// MUST contain the ATSvc account name.
@@ -990,6 +992,11 @@ func (o *GetNSAccountInformationResponse) xxx_ToOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferSize == uint32(0) {
+		op.BufferSize = o.BufferSize
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -999,6 +1006,9 @@ func (o *GetNSAccountInformationResponse) xxx_FromOp(ctx context.Context, op *xx
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferSize = op.BufferSize
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }
@@ -1306,6 +1316,8 @@ func (o *GetAccountInformationRequest) UnmarshalNDR(ctx context.Context, r ndr.R
 
 // GetAccountInformationResponse structure represents the SAGetAccountInformation operation response
 type GetAccountInformationResponse struct {
+	// XXX: ccBufferSize is an implicit input depedency for output parameters
+	BufferSize uint32 `idl:"name:ccBufferSize" json:"buffer_size"`
 	// wszBuffer: Upon input, MUST be an empty array of size equal to the ccBufferSize parameter.
 	// The client SHOULD initialize the array to contain zeroes. Upon return, the array
 	// MUST contain the name of the account to be used as the context the task runs under.
@@ -1321,6 +1333,11 @@ func (o *GetAccountInformationResponse) xxx_ToOp(ctx context.Context, op *xxx_Ge
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.BufferSize == uint32(0) {
+		op.BufferSize = o.BufferSize
+	}
+
 	op.Buffer = o.Buffer
 	op.Return = o.Return
 	return op
@@ -1330,6 +1347,9 @@ func (o *GetAccountInformationResponse) xxx_FromOp(ctx context.Context, op *xxx_
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.BufferSize = op.BufferSize
+
 	o.Buffer = op.Buffer
 	o.Return = op.Return
 }

--- a/msrpc/wkst/wkssvc/v1/v1.go
+++ b/msrpc/wkst/wkssvc/v1/v1.go
@@ -6553,6 +6553,7 @@ func (o *GetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 type GetInfoResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// WkstaInfo: A pointer to the buffer that receives the data. The format of this data
 	// depends on the value of the level parameter.
 	WorkstationInfo *WorkstationInfo `idl:"name:WkstaInfo;switch_is:Level" json:"workstation_info"`
@@ -8691,6 +8692,7 @@ func (o *UseGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 type UseGetInfoResponse struct {
 	// XXX: Level is an implicit input depedency for output parameters
 	Level uint32 `idl:"name:Level" json:"level"`
+
 	// InfoStruct: A pointer to the buffer that specifies the data. The format of this data
 	// depends on the value of the Level parameter.
 	Info *UseInfo `idl:"name:InfoStruct;switch_is:Level" json:"info"`

--- a/msrpc/wkst/wkssvc/v1/v1.go
+++ b/msrpc/wkst/wkssvc/v1/v1.go
@@ -6551,6 +6551,8 @@ func (o *GetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) error {
 
 // GetInfoResponse structure represents the NetrWkstaGetInfo operation response
 type GetInfoResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// WkstaInfo: A pointer to the buffer that receives the data. The format of this data
 	// depends on the value of the level parameter.
 	WorkstationInfo *WorkstationInfo `idl:"name:WkstaInfo;switch_is:Level" json:"workstation_info"`
@@ -6565,6 +6567,11 @@ func (o *GetInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_GetInfoOperation
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.WorkstationInfo = o.WorkstationInfo
 	op.Return = o.Return
 	return op
@@ -6574,6 +6581,9 @@ func (o *GetInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_GetInfoOperati
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.WorkstationInfo = op.WorkstationInfo
 	o.Return = op.Return
 }
@@ -8679,6 +8689,8 @@ func (o *UseGetInfoRequest) UnmarshalNDR(ctx context.Context, r ndr.Reader) erro
 
 // UseGetInfoResponse structure represents the NetrUseGetInfo operation response
 type UseGetInfoResponse struct {
+	// XXX: Level is an implicit input depedency for output parameters
+	Level uint32 `idl:"name:Level" json:"level"`
 	// InfoStruct: A pointer to the buffer that specifies the data. The format of this data
 	// depends on the value of the Level parameter.
 	Info *UseInfo `idl:"name:InfoStruct;switch_is:Level" json:"info"`
@@ -8693,6 +8705,11 @@ func (o *UseGetInfoResponse) xxx_ToOp(ctx context.Context, op *xxx_UseGetInfoOpe
 	if o == nil {
 		return op
 	}
+	// XXX: implicit input dependencies for output parameters
+	if op.Level == uint32(0) {
+		op.Level = o.Level
+	}
+
 	op.Info = o.Info
 	op.Return = o.Return
 	return op
@@ -8702,6 +8719,9 @@ func (o *UseGetInfoResponse) xxx_FromOp(ctx context.Context, op *xxx_UseGetInfoO
 	if o == nil {
 		return
 	}
+	// XXX: implicit input dependencies for output parameters
+	o.Level = op.Level
+
 	o.Info = op.Info
 	o.Return = op.Return
 }


### PR DESCRIPTION
This feature renders the set of request parameters that are dependencies for response parameters (through size_is, length_is, switch_is and so on). This should allow to render Response payload independently from any provided request.

Fixes: https://github.com/oiweiwei/go-msrpc/issues/32