### PR TITLE
midl: change attribute goext_null_if name to goext_default_null()

### DIFF
--- a/codegen/gen/type.go
+++ b/codegen/gen/type.go
@@ -636,7 +636,7 @@ func (p *TypeGenerator) GenFieldMarshalNDR(ctx context.Context, field *midl.Fiel
 				}))
 			} else {
 				p.P("//", "XXX", "pointer to primitive type, default behavior is to write non-null pointer.")
-				p.P("//", "if this behavior is not desired, use goext_null_if(cond) attribute.")
+				p.P("//", "if this behavior is not desired, use goext_default_null([cond]) attribute.")
 				fN := "_ptr_" + field.Name
 				p.P(fN, ":=", "ndr.MarshalNDRFunc", "(", "func(ctx context.Context, w ndr.Writer) error {")
 				p.GenFieldMarshalNDR(ctx, field, scopes.Next(), index...)

--- a/idl/scmr.idl
+++ b/idl/scmr.idl
@@ -335,7 +335,7 @@ RChangeServiceConfigW(
             wchar_t *  lpBinaryPathName,
     [in,string,unique,range(0, SC_MAX_NAME_LENGTH)] 
             wchar_t *  lpLoadOrderGroup,
-    [in,out,unique,goext_null_if(lpdwTagId==0)] LPDWORD  lpdwTagId,
+    [in,out,unique,goext_default_null()] LPDWORD  lpdwTagId,
     [in,unique,size_is(dwDependSize)] LPBYTE  lpDependencies,
     [in, range (0, SC_MAX_DEPEND_SIZE)] DWORD  dwDependSize,
     [in,string,unique,range(0, SC_MAX_ACCOUNT_NAME_LENGTH)] 
@@ -361,7 +361,7 @@ RCreateServiceW(
                 wchar_t *  lpBinaryPathName,
     [in,string,unique,range(0, SC_MAX_NAME_LENGTH)] 
                 wchar_t *  lpLoadOrderGroup,
-    [in,out,unique,goext_null_if(lpdwTagId==0)] LPDWORD  lpdwTagId,
+    [in,out,unique,goext_default_null()] LPDWORD  lpdwTagId,
     [in,unique,size_is(dwDependSize)] LPBYTE  lpDependencies,
     [in, range (0, SC_MAX_DEPEND_SIZE)] DWORD  dwDependSize,
     [in,string,unique,range(0, SC_MAX_ACCOUNT_NAME_LENGTH)] 
@@ -469,7 +469,7 @@ RChangeServiceConfigA(
             LPSTR  lpBinaryPathName,
     [in,string,unique,range(0, SC_MAX_NAME_LENGTH)] 
             LPSTR  lpLoadOrderGroup,
-    [in,out,unique,goext_null_if(lpdwTagId==0)] LPDWORD  lpdwTagId,
+    [in,out,unique,goext_default_null()] LPDWORD  lpdwTagId,
     [in,unique,size_is(dwDependSize)] LPBYTE  lpDependencies,
     [in, range (0, SC_MAX_DEPEND_SIZE)] DWORD dwDependSize,
     [in,string,unique,range(0, SC_MAX_ACCOUNT_NAME_LENGTH)] 
@@ -495,7 +495,7 @@ RCreateServiceA(
                 LPSTR  lpBinaryPathName,
     [in,string,unique,range(0, SC_MAX_NAME_LENGTH)] 
                 LPSTR  lpLoadOrderGroup,
-    [in,out,unique,goext_null_if(lpdwTagId==0)] LPDWORD  lpdwTagId,
+    [in,out,unique,goext_default_null()] LPDWORD  lpdwTagId,
     [in,unique,size_is(dwDependSize)] LPBYTE  lpDependencies,
     [in, range (0, SC_MAX_DEPEND_SIZE)] DWORD  dwDependSize,
     [in,string,unique,range(0, SC_MAX_ACCOUNT_NAME_LENGTH)] 
@@ -752,7 +752,7 @@ RCreateServiceWOW64A(
                 LPSTR  lpBinaryPathName,
     [in,string,unique,range(0, SC_MAX_NAME_LENGTH)] 
                 LPSTR  lpLoadOrderGroup,
-    [in,out,unique,goext_null_if(lpdwTagId==0)] LPDWORD  lpdwTagId,
+    [in,out,unique,goext_default_null()] LPDWORD  lpdwTagId,
     [in,unique,size_is(dwDependSize)] LPBYTE  lpDependencies,
     [in, range (0, SC_MAX_DEPEND_SIZE)] DWORD  dwDependSize,
     [in,string,unique,range(0, SC_MAX_ACCOUNT_NAME_LENGTH)] 
@@ -777,7 +777,7 @@ RCreateServiceWOW64W(
                 wchar_t *  lpBinaryPathName,
     [in,string,unique,range(0, SC_MAX_NAME_LENGTH)] 
                 wchar_t *  lpLoadOrderGroup,
-    [in,out,unique,goext_null_if(lpdwTagId==0)] LPDWORD  lpdwTagId,
+    [in,out,unique,goext_default_null()] LPDWORD  lpdwTagId,
     [in,unique,size_is(dwDependSize)] LPBYTE  lpDependencies,
     [in, range (0, SC_MAX_DEPEND_SIZE)] DWORD  dwDependSize,
     [in,string,unique,range(0, SC_MAX_ACCOUNT_NAME_LENGTH)] 
@@ -976,7 +976,7 @@ RCreateWowService(
                 wchar_t *           lpBinaryPathName,
     [in,string,unique,range(0, SC_MAX_NAME_LENGTH)]
                 wchar_t *           lpLoadOrderGroup,
-    [in,out,unique,goext_null_if(lpdwTagId==0)]
+    [in,out,unique,goext_default_null()]
                 LPDWORD             lpdwTagId,
     [in,unique,size_is(dwDependSize)]
                 LPBYTE              lpDependencies,

--- a/midl/keyword.go
+++ b/midl/keyword.go
@@ -67,7 +67,7 @@ var (
 		SAFEARRAY:                  "safearray",
 		PAD:                        "pad",
 		GOEXT_LAYOUT:               "goext_layout",
-		GOEXT_NULL_IF:              "goext_null_if",
+		GOEXT_DEFAULT_NULL:         "goext_default_null",
 		OPTIONAL:                   "optional",
 		COCLASS:                    "coclass",
 		SWITCH_TYPE:                "switch_type",
@@ -182,7 +182,7 @@ var (
 		WIRE_MARSHAL:               {},
 		PAD:                        {},
 		GOEXT_LAYOUT:               {},
-		GOEXT_NULL_IF:              {},
+		GOEXT_DEFAULT_NULL:         {},
 		SAFEARRAY:                  {},
 	}
 

--- a/midl/parse.go
+++ b/midl/parse.go
@@ -171,7 +171,7 @@ const APPOBJECT = 57445
 const SAFEARRAY = 57446
 const PAD = 57447
 const GOEXT_LAYOUT = 57448
-const GOEXT_NULL_IF = 57449
+const GOEXT_DEFAULT_NULL = 57449
 const GOEXT_NO_SIZE_LIMIT = 57450
 const CALL_AS = 57451
 const ANNOTATION = 57452
@@ -318,7 +318,7 @@ var RPCToknames = [...]string{
 	"SAFEARRAY",
 	"PAD",
 	"GOEXT_LAYOUT",
-	"GOEXT_NULL_IF",
+	"GOEXT_DEFAULT_NULL",
 	"GOEXT_NO_SIZE_LIMIT",
 	"CALL_AS",
 	"ANNOTATION",
@@ -384,7 +384,7 @@ const RPCEofCode = 1
 const RPCErrCode = 2
 const RPCInitialStackSize = 16
 
-//line midl/parse.y:2753
+//line midl/parse.y:2757
 
 //line yacctab:1
 var RPCExca = [...]int16{
@@ -1652,113 +1652,117 @@ RPCdefault:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
 //line midl/parse.y:737
 		{
-			RPCVAL.AttrType = pAttrType{GOEXT_NULL_IF, pAttr{NullIf: RPCDollar[3].Expr}}
+			if RPCDollar[3].Expr.Empty() {
+				RPCVAL.AttrType = pAttrType{GOEXT_DEFAULT_NULL, pAttr{DefaultNull: []Expr{}}}
+			} else {
+				RPCVAL.AttrType = pAttrType{GOEXT_DEFAULT_NULL, pAttr{DefaultNull: []Expr{RPCDollar[3].Expr}}}
+			}
 		}
 	case 60:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:741
+//line midl/parse.y:745
 		{
 			RPCVAL.AttrType = pAttrType{RPCDollar[1].Token, pAttr{}}
 		}
 	case 61:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:745
+//line midl/parse.y:749
 		{
 			RPCVAL.AttrType = pAttrType{RPCDollar[3].Token, pAttr{}}
 		}
 	case 62:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:749
+//line midl/parse.y:753
 		{
 			RPCVAL.AttrType = RPCDollar[1].AttrType
 		}
 	case 63:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:753
+//line midl/parse.y:757
 		{
 			RPCVAL.AttrType = pAttrType{IGNORE, pAttr{}}
 		}
 	case 64:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:757
+//line midl/parse.y:761
 		{
 			RPCVAL.AttrType = RPCDollar[1].AttrType
 		}
 	case 65:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:761
+//line midl/parse.y:765
 		{
 			RPCVAL.AttrType = pAttrType{TRANSMIT_AS, pAttr{TransmitAs: RPCDollar[3].Type}}
 		}
 	case 66:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:765
+//line midl/parse.y:769
 		{
 			RPCVAL.AttrType = pAttrType{SWITCH_TYPE, pAttr{SwitchType: RPCDollar[1].Type}}
 		}
 	case 67:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:769
+//line midl/parse.y:773
 		{
 			RPCVAL.AttrType = pAttrType{HANDLE, pAttr{}}
 		}
 	case 68:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:773
+//line midl/parse.y:777
 		{
 			RPCVAL.AttrType = pAttrType{IDEMPOTENT, pAttr{}}
 		}
 	case 69:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:777
+//line midl/parse.y:781
 		{
 			RPCVAL.AttrType = pAttrType{BROADCAST, pAttr{}}
 		}
 	case 70:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:781
+//line midl/parse.y:785
 		{
 			RPCVAL.AttrType = pAttrType{MAYBE, pAttr{}}
 		}
 	case 71:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:785
+//line midl/parse.y:789
 		{
 			RPCVAL.AttrType = pAttrType{REFLECT_DELETIONS, pAttr{}}
 		}
 	case 72:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:789
+//line midl/parse.y:793
 		{
 			RPCVAL.AttrType = pAttrType{UUID, pAttr{UUID: RPCDollar[1].UUID}}
 		}
 	case 73:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:793
+//line midl/parse.y:797
 		{
 			RPCVAL.AttrType = pAttrType{VERSION, pAttr{Version: RPCDollar[3].Version}}
 		}
 	case 74:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:797
+//line midl/parse.y:801
 		{
 			RPCVAL.AttrType = pAttrType{ENDPOINT, pAttr{Endpoints: RPCDollar[3].Strings}}
 		}
 	case 75:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:801
+//line midl/parse.y:805
 		{
 			RPCVAL.AttrType = pAttrType{EXCEPTIONS, pAttr{Exceptions: RPCDollar[3].Strings}}
 		}
 	case 76:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:805
+//line midl/parse.y:809
 		{
 			RPCVAL.AttrType = pAttrType{LOCAL, pAttr{}}
 		}
 	case 77:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:809
+//line midl/parse.y:813
 		{
 			switch RPCDollar[3].Token {
 			case POINTER_PTR:
@@ -1771,85 +1775,85 @@ RPCdefault:
 		}
 	case 78:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:820
+//line midl/parse.y:824
 		{
 			RPCVAL.AttrType = pAttrType{V1_ENUM, pAttr{}}
 		}
 	case 79:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:824
+//line midl/parse.y:828
 		{
 			RPCVAL.AttrType = pAttrType{MS_UNION, pAttr{}}
 		}
 	case 80:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:828
+//line midl/parse.y:832
 		{
 			RPCVAL.AttrType = RPCDollar[1].AttrType
 		}
 	case 81:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:832
+//line midl/parse.y:836
 		{
 			RPCVAL.AttrType = pAttrType{DISABLE_CONSISTENCY_CHECK, pAttr{}}
 		}
 	case 82:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:836
+//line midl/parse.y:840
 		{
 			RPCVAL.AttrType = pAttrType{OBJECT, pAttr{}}
 		}
 	case 83:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:840
+//line midl/parse.y:844
 		{
 			RPCVAL.AttrType = pAttrType{CALLBACK, pAttr{}}
 		}
 	case 84:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:844
+//line midl/parse.y:848
 		{
 			RPCVAL.AttrType = pAttrType{RETVAL, pAttr{}}
 		}
 	case 85:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:848
+//line midl/parse.y:852
 		{
 			RPCVAL.AttrType = pAttrType{IID_IS, pAttr{IIDIs: RPCDollar[3].Expr}}
 		}
 	case 86:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:852
+//line midl/parse.y:856
 		{
 			RPCVAL.AttrType = pAttrType{HELP_STRING, pAttr{HelpString: RPCDollar[3].String}}
 		}
 	case 87:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:856
+//line midl/parse.y:860
 		{
 			RPCVAL.AttrType = pAttrType{DUAL, pAttr{}}
 		}
 	case 88:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:860
+//line midl/parse.y:864
 		{
 			RPCVAL.AttrType = pAttrType{PROPGET, pAttr{}}
 		}
 	case 89:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:864
+//line midl/parse.y:868
 		{
 			RPCVAL.AttrType = pAttrType{PROPPUT, pAttr{}}
 		}
 	case 90:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:868
+//line midl/parse.y:872
 		{
 			RPCVAL.AttrType = pAttrType{PROPPUTREF, pAttr{}}
 		}
 	case 91:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:872
+//line midl/parse.y:876
 		{
 			val, ok := RPCDollar[3].Expr.Eval(RPClex.(ExprStore))
 			if !ok {
@@ -1864,25 +1868,25 @@ RPCdefault:
 		}
 	case 92:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:885
+//line midl/parse.y:889
 		{
 			RPCVAL.AttrType = pAttrType{HIDDEN, pAttr{}}
 		}
 	case 93:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:889
+//line midl/parse.y:893
 		{
 			RPCVAL.AttrType = pAttrType{NONEXTENSIBLE, pAttr{}}
 		}
 	case 94:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:893
+//line midl/parse.y:897
 		{
 			RPCVAL.AttrType = pAttrType{RESTRICTED, pAttr{}}
 		}
 	case 95:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:897
+//line midl/parse.y:901
 		{
 			exp, ok := RPCDollar[3].Expr.Eval(RPClex.(ExprStore))
 			if !ok {
@@ -1893,67 +1897,67 @@ RPCdefault:
 		}
 	case 96:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:906
+//line midl/parse.y:910
 		{
 			RPCVAL.AttrType = pAttrType{ODL, pAttr{}}
 		}
 	case 97:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:910
+//line midl/parse.y:914
 		{
 			RPCVAL.AttrType = pAttrType{OLEAUTOMATION, pAttr{}}
 		}
 	case 98:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:914
+//line midl/parse.y:918
 		{
 			RPCVAL.AttrType = pAttrType{OPTIONAL, pAttr{}}
 		}
 	case 99:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:918
+//line midl/parse.y:922
 		{
 			RPCVAL.AttrType = pAttrType{APPOBJECT, pAttr{}}
 		}
 	case 100:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:922
+//line midl/parse.y:926
 		{
 			RPCVAL.AttrType = pAttrType{ANNOTATION, pAttr{Annotation: RPCDollar[3].String}}
 		}
 	case 101:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:926
+//line midl/parse.y:930
 		{
 			RPCVAL.AttrType = pAttrType{CALL_AS, pAttr{CallAs: RPCDollar[3].Ident}}
 		}
 	case 102:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:930
+//line midl/parse.y:934
 		{
 			RPCVAL.AttrType = pAttrType{WIRE_MARSHAL, pAttr{WireMarshal: RPCDollar[3].Ident}}
 		}
 	case 103:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:934
+//line midl/parse.y:938
 		{
 			RPCVAL.AttrType = pAttrType{PUBLIC, pAttr{}}
 		}
 	case 104:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:938
+//line midl/parse.y:942
 		{
 			RPCVAL.AttrType = pAttrType{SAFEARRAY, pAttr{Safearray: RPCDollar[3].Type}}
 		}
 	case 105:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:942
+//line midl/parse.y:946
 		{
 			RPCVAL.AttrType = pAttrType{PAD, pAttr{Pad: RPCDollar[3].Int.Uint64()}}
 		}
 	case 106:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:946
+//line midl/parse.y:950
 		{
 			for i := range RPCDollar[3].Fields {
 				RPCDollar[3].Fields[i].Attrs.IsLayout = true
@@ -1962,61 +1966,61 @@ RPCdefault:
 		}
 	case 107:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:953
+//line midl/parse.y:957
 		{
 			RPCVAL.AttrType = pAttrType{GOEXT_NO_SIZE_LIMIT, pAttr{NoSizeLimit: true}}
 		}
 	case 108:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:959
+//line midl/parse.y:963
 		{
 			RPCVAL.Version = &Version{Major: uint16(RPCDollar[1].Int.Uint64())}
 		}
 	case 109:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:963
+//line midl/parse.y:967
 		{
 			RPCVAL.Version = &Version{Major: uint16(RPCDollar[1].Int.Uint64()), Minor: uint16(RPCDollar[3].Int.Uint64())}
 		}
 	case 110:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:969
+//line midl/parse.y:973
 		{
 			RPCVAL.Strings = []string{RPCDollar[1].String}
 		}
 	case 111:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:973
+//line midl/parse.y:977
 		{
 			RPCVAL.Strings = append(RPCVAL.Strings, RPCDollar[3].String)
 		}
 	case 112:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:979
+//line midl/parse.y:983
 		{
 			RPCVAL.Strings = []string{RPCDollar[1].String}
 		}
 	case 113:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:983
+//line midl/parse.y:987
 		{
 			RPCVAL.Strings = append(RPCVAL.Strings, RPCDollar[3].String)
 		}
 	case 114:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:989
+//line midl/parse.y:993
 		{
 			RPCVAL.String = RPCDollar[1].String
 		}
 	case 115:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:995
+//line midl/parse.y:999
 		{
 			RPCVAL.String = RPCDollar[1].Ident
 		}
 	case 116:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1001
+//line midl/parse.y:1005
 		{
 			RPCVAL.InterfaceBody = InterfaceBody{Imports: RPCDollar[1].Strings, Export: RPCDollar[2].InterfaceBody.Export, Operations: RPCDollar[2].InterfaceBody.Operations}
 			for i, o := range RPCVAL.InterfaceBody.Operations {
@@ -2025,7 +2029,7 @@ RPCdefault:
 		}
 	case 117:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1010
+//line midl/parse.y:1014
 		{
 			RPCVAL.InterfaceBody = RPCDollar[1].InterfaceBody
 			export := make([]*Export, len(RPCDollar[1].InterfaceBody.Export))
@@ -2038,7 +2042,7 @@ RPCdefault:
 		}
 	case 118:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1021
+//line midl/parse.y:1025
 		{
 			if len(RPCDollar[2].InterfaceBody.Export) > 0 {
 				if RPCVAL.InterfaceBody.Export == nil {
@@ -2059,19 +2063,19 @@ RPCdefault:
 		}
 	case 119:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:1042
+//line midl/parse.y:1046
 		{
 			RPCVAL.Strings = []string{}
 		}
 	case 120:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1046
+//line midl/parse.y:1050
 		{
 			RPCVAL.Strings = RPCDollar[1].Strings
 		}
 	case 121:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1052
+//line midl/parse.y:1056
 		{
 			RPCVAL.Strings = RPCDollar[2].Strings
 			// XXX: load import files.
@@ -2084,7 +2088,7 @@ RPCdefault:
 		}
 	case 122:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1064
+//line midl/parse.y:1068
 		{
 			RPCVAL.InterfaceBody = InterfaceBody{Export: make(map[string]*Export)}
 			for _, e := range RPCDollar[1].Export {
@@ -2094,55 +2098,55 @@ RPCdefault:
 		}
 	case 123:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1072
+//line midl/parse.y:1076
 		{
 			RPCVAL.InterfaceBody = InterfaceBody{Operations: []*Operation{RPCDollar[1].Operation}}
 		}
 	case 124:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1078
+//line midl/parse.y:1082
 		{
 			RPCVAL.Export = RPCDollar[1].Typedef.pToExport_()
 		}
 	case 125:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1082
+//line midl/parse.y:1086
 		{
 			RPCVAL.Export = []*Export{&Export{Name: RPCDollar[1].Const.Name, Const: RPCDollar[1].Const}}
 		}
 	case 126:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1086
+//line midl/parse.y:1090
 		{
 			RPCVAL.Export = RPCDollar[1].Export
 		}
 	case 127:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1090
+//line midl/parse.y:1094
 		{
 			RPCVAL.Export = []*Export{&Export{Name: RPCDollar[1].Type.TypeName(), Type: RPCDollar[1].Type}}
 		}
 	case 128:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1096
+//line midl/parse.y:1100
 		{
 			RPCVAL.Strings = []string{RPCDollar[1].String}
 		}
 	case 129:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1100
+//line midl/parse.y:1104
 		{
 			RPCVAL.Strings = append(RPCVAL.Strings, RPCDollar[3].String)
 		}
 	case 130:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1106
+//line midl/parse.y:1110
 		{
 			RPCVAL.String = RPCDollar[1].String
 		}
 	case 131:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:1112
+//line midl/parse.y:1116
 		{
 			exp, err := RPCDollar[5].Expr.Coerce(RPCDollar[2].Kind)
 			if err != nil {
@@ -2153,7 +2157,7 @@ RPCdefault:
 		}
 	case 132:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1123
+//line midl/parse.y:1127
 		{
 			switch v := RPCDollar[3].Expr.Value.(type) {
 			case *big.Int:
@@ -2184,20 +2188,20 @@ RPCdefault:
 		}
 	case 133:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:1152
+//line midl/parse.y:1156
 		{
 			// XXX: re-enter the STRING_LITERAL as PRAGMA_DEFINE.
 			pushLex(RPClex, RPCDollar[3].String)
 		}
 	case 134:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1159
+//line midl/parse.y:1163
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 135:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1163
+//line midl/parse.y:1167
 		{
 			typ, ok := lookupType(RPClex, RPCDollar[1].Ident)
 			if !ok {
@@ -2233,85 +2237,85 @@ RPCdefault:
 		}
 	case 136:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1197
+//line midl/parse.y:1201
 		{
 			RPCVAL.Kind = TypeChar
 		}
 	case 137:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1201
+//line midl/parse.y:1205
 		{
 			RPCVAL.Kind = TypeUChar
 		}
 	case 138:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1205
+//line midl/parse.y:1209
 		{
 			RPCVAL.Kind = TypeBoolean
 		}
 	case 139:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1209
+//line midl/parse.y:1213
 		{
 			RPCVAL.Kind = TypeVoid
 		}
 	case 140:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1213
+//line midl/parse.y:1217
 		{
 			RPCVAL.Kind = TypeString
 		}
 	case 141:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1219
+//line midl/parse.y:1223
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 142:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1223
+//line midl/parse.y:1227
 		{
 			RPCVAL.Expr = NewValue(RPCDollar[1].String)
 		}
 	case 143:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1227
+//line midl/parse.y:1231
 		{
 			RPCVAL.Expr = NewValue(RPCDollar[1].Char)
 		}
 	case 144:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1231
+//line midl/parse.y:1235
 		{
 			RPCVAL.Expr = NewValue(nil)
 		}
 	case 145:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1235
+//line midl/parse.y:1239
 		{
 			RPCVAL.Expr = NewValue(true)
 		}
 	case 146:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1239
+//line midl/parse.y:1243
 		{
 			RPCVAL.Expr = NewValue(false)
 		}
 	case 147:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1245
+//line midl/parse.y:1249
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 148:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1251
+//line midl/parse.y:1255
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 149:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:1255
+//line midl/parse.y:1259
 		{
 			exp, ok := RPCDollar[1].Expr.Ter(RPCDollar[3].Expr, RPCDollar[5].Expr)
 			if !ok {
@@ -2322,13 +2326,13 @@ RPCdefault:
 		}
 	case 150:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1266
+//line midl/parse.y:1270
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 151:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1270
+//line midl/parse.y:1274
 		{
 			exp, ok := RPCDollar[1].Expr.LogicalOr(RPCDollar[3].Expr)
 			if !ok {
@@ -2339,13 +2343,13 @@ RPCdefault:
 		}
 	case 152:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1281
+//line midl/parse.y:1285
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 153:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1285
+//line midl/parse.y:1289
 		{
 			exp, ok := RPCDollar[1].Expr.LogicalAnd(RPCDollar[3].Expr)
 			if !ok {
@@ -2356,13 +2360,13 @@ RPCdefault:
 		}
 	case 154:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1296
+//line midl/parse.y:1300
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 155:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1300
+//line midl/parse.y:1304
 		{
 			exp, ok := RPCDollar[1].Expr.Or(RPCDollar[3].Expr)
 			if !ok {
@@ -2373,13 +2377,13 @@ RPCdefault:
 		}
 	case 156:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1311
+//line midl/parse.y:1315
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 157:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1315
+//line midl/parse.y:1319
 		{
 			exp, ok := RPCDollar[1].Expr.Xor(RPCDollar[3].Expr)
 			if !ok {
@@ -2390,13 +2394,13 @@ RPCdefault:
 		}
 	case 158:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1326
+//line midl/parse.y:1330
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 159:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1330
+//line midl/parse.y:1334
 		{
 			exp, ok := RPCDollar[1].Expr.And(RPCDollar[3].Expr)
 			if !ok {
@@ -2407,13 +2411,13 @@ RPCdefault:
 		}
 	case 160:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1341
+//line midl/parse.y:1345
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 161:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1345
+//line midl/parse.y:1349
 		{
 			exp, ok := RPCDollar[1].Expr.Eq(RPCDollar[3].Expr)
 			if !ok {
@@ -2424,7 +2428,7 @@ RPCdefault:
 		}
 	case 162:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1354
+//line midl/parse.y:1358
 		{
 			exp, ok := RPCDollar[1].Expr.Ne(RPCDollar[3].Expr)
 			if !ok {
@@ -2435,13 +2439,13 @@ RPCdefault:
 		}
 	case 163:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1365
+//line midl/parse.y:1369
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 164:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1369
+//line midl/parse.y:1373
 		{
 			exp, ok := RPCDollar[1].Expr.Lt(RPCDollar[3].Expr)
 			if !ok {
@@ -2452,7 +2456,7 @@ RPCdefault:
 		}
 	case 165:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1378
+//line midl/parse.y:1382
 		{
 			exp, ok := RPCDollar[1].Expr.Gt(RPCDollar[3].Expr)
 			if !ok {
@@ -2463,7 +2467,7 @@ RPCdefault:
 		}
 	case 166:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1387
+//line midl/parse.y:1391
 		{
 			exp, ok := RPCDollar[1].Expr.Le(RPCDollar[3].Expr)
 			if !ok {
@@ -2474,7 +2478,7 @@ RPCdefault:
 		}
 	case 167:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1396
+//line midl/parse.y:1400
 		{
 			exp, ok := RPCDollar[1].Expr.Ge(RPCDollar[3].Expr)
 			if !ok {
@@ -2485,13 +2489,13 @@ RPCdefault:
 		}
 	case 168:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1407
+//line midl/parse.y:1411
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 169:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1411
+//line midl/parse.y:1415
 		{
 			exp, ok := RPCDollar[1].Expr.Lsh(RPCDollar[3].Expr)
 			if !ok {
@@ -2502,7 +2506,7 @@ RPCdefault:
 		}
 	case 170:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1420
+//line midl/parse.y:1424
 		{
 			exp, ok := RPCDollar[1].Expr.Rsh(RPCDollar[3].Expr)
 			if !ok {
@@ -2513,13 +2517,13 @@ RPCdefault:
 		}
 	case 171:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1431
+//line midl/parse.y:1435
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 172:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1435
+//line midl/parse.y:1439
 		{
 			exp, ok := RPCDollar[1].Expr.Sub(RPCDollar[3].Expr)
 			if !ok {
@@ -2530,7 +2534,7 @@ RPCdefault:
 		}
 	case 173:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1444
+//line midl/parse.y:1448
 		{
 			exp, ok := RPCDollar[1].Expr.Add(RPCDollar[3].Expr)
 			if !ok {
@@ -2541,13 +2545,13 @@ RPCdefault:
 		}
 	case 174:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1455
+//line midl/parse.y:1459
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 175:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1459
+//line midl/parse.y:1463
 		{
 			exp, ok := RPCDollar[1].Expr.Mul(RPCDollar[3].Expr)
 			if !ok {
@@ -2558,7 +2562,7 @@ RPCdefault:
 		}
 	case 176:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1468
+//line midl/parse.y:1472
 		{
 			exp, ok := RPCDollar[1].Expr.Div(RPCDollar[3].Expr)
 			if !ok {
@@ -2569,7 +2573,7 @@ RPCdefault:
 		}
 	case 177:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1477
+//line midl/parse.y:1481
 		{
 			exp, ok := RPCDollar[1].Expr.Rem(RPCDollar[3].Expr)
 			if !ok {
@@ -2580,13 +2584,13 @@ RPCdefault:
 		}
 	case 178:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1488
+//line midl/parse.y:1492
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 179:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1492
+//line midl/parse.y:1496
 		{
 			exp, ok := RPCDollar[2].Expr.Positive()
 			if !ok {
@@ -2597,7 +2601,7 @@ RPCdefault:
 		}
 	case 180:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1501
+//line midl/parse.y:1505
 		{
 			exp, ok := RPCDollar[2].Expr.Negative()
 			if !ok {
@@ -2608,7 +2612,7 @@ RPCdefault:
 		}
 	case 181:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1510
+//line midl/parse.y:1514
 		{
 			exp, ok := RPCDollar[2].Expr.Neg()
 			if !ok {
@@ -2619,7 +2623,7 @@ RPCdefault:
 		}
 	case 182:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1519
+//line midl/parse.y:1523
 		{
 			exp, ok := RPCDollar[2].Expr.Not()
 			if !ok {
@@ -2630,13 +2634,13 @@ RPCdefault:
 		}
 	case 183:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1530
+//line midl/parse.y:1534
 		{
 			RPCVAL.Expr = NewValue(RPCDollar[1].Int)
 		}
 	case 184:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:1534
+//line midl/parse.y:1538
 		{
 			sz := TypeSize(RPClex.(TypeStore), RPCDollar[3].Type)
 			if sz == 0 {
@@ -2647,7 +2651,7 @@ RPCdefault:
 		}
 	case 185:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1543
+//line midl/parse.y:1547
 		{
 			if c, ok := lookupConst(RPClex, RPCDollar[1].Ident); !ok {
 				RPCVAL.Expr = NewIdent(RPCDollar[1].Ident)
@@ -2657,7 +2661,7 @@ RPCdefault:
 		}
 	case 186:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1551
+//line midl/parse.y:1555
 		{
 			exp, ok := NewIdent(RPCDollar[2].Ident).Ptr()
 			if !ok {
@@ -2668,13 +2672,13 @@ RPCdefault:
 		}
 	case 187:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1560
+//line midl/parse.y:1564
 		{
 			RPCVAL.Expr = RPCDollar[2].Expr
 		}
 	case 188:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:1566
+//line midl/parse.y:1570
 		{
 			attrs := RPCDollar[1].Attr.Merge(RPCDollar[3].Attr).Type()
 			if attrs.Usage.ContextHandle {
@@ -2692,49 +2696,49 @@ RPCdefault:
 		}
 	case 189:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1584
+//line midl/parse.y:1588
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 190:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1588
+//line midl/parse.y:1592
 		{
 			RPCVAL.Type = RPCDollar[2].Type
 		}
 	case 191:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1592
+//line midl/parse.y:1596
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 192:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1596
+//line midl/parse.y:1600
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 193:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1602
+//line midl/parse.y:1606
 		{
 			RPCVAL.Type = &Type{Kind: RPCDollar[1].Kind}
 		}
 	case 194:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1606
+//line midl/parse.y:1610
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 195:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1610
+//line midl/parse.y:1614
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 196:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1616
+//line midl/parse.y:1620
 		{
 			ref := &Type{Kind: TypeRef, Name: RPCDollar[1].Ident}
 			typ, ok := lookupType(RPClex, ref.Name)
@@ -2747,25 +2751,25 @@ RPCdefault:
 		}
 	case 197:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1630
+//line midl/parse.y:1634
 		{
 			RPCVAL.Declarators = pDeclarators{RPCDollar[1].Declarator}
 		}
 	case 198:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1634
+//line midl/parse.y:1638
 		{
 			RPCVAL.Declarators = append(RPCVAL.Declarators, RPCDollar[3].Declarator)
 		}
 	case 199:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:1639
+//line midl/parse.y:1643
 		{
 			RPCVAL.Declarators = pDeclarators{&pDeclarator{Name: ""}}
 		}
 	case 200:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1645
+//line midl/parse.y:1649
 		{
 			RPCVAL.Declarator = RPCDollar[2].Declarator
 			for i := 0; i < int(RPCDollar[1].Int64); i++ {
@@ -2774,37 +2778,37 @@ RPCdefault:
 		}
 	case 201:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1654
+//line midl/parse.y:1658
 		{
 			RPCVAL.Declarator = &pDeclarator{Name: RPCDollar[1].String}
 		}
 	case 202:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1658
+//line midl/parse.y:1662
 		{
 			RPCVAL.Declarator = RPCDollar[2].Declarator
 		}
 	case 203:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1662
+//line midl/parse.y:1666
 		{
 			RPCVAL.Declarator = RPCDollar[1].Declarator
 		}
 	case 204:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1666
+//line midl/parse.y:1670
 		{
 			RPCVAL.Declarator = RPCDollar[1].Declarator
 		}
 	case 205:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1672
+//line midl/parse.y:1676
 		{
 			RPCVAL.String = RPCDollar[1].Ident
 		}
 	case 206:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1676
+//line midl/parse.y:1680
 		{
 			ident, ok := tokName(RPClex, RPCrcvr.char)
 			if !ok {
@@ -2814,91 +2818,91 @@ RPCdefault:
 		}
 	case 207:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1686
+//line midl/parse.y:1690
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 208:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1690
+//line midl/parse.y:1694
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 209:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1695
+//line midl/parse.y:1699
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 210:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1709
+//line midl/parse.y:1713
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 211:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1713
+//line midl/parse.y:1717
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 212:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1717
+//line midl/parse.y:1721
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 213:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1721
+//line midl/parse.y:1725
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 214:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1725
+//line midl/parse.y:1729
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 215:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1729
+//line midl/parse.y:1733
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 216:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1733
+//line midl/parse.y:1737
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 217:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1738
+//line midl/parse.y:1742
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 218:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1745
+//line midl/parse.y:1749
 		{
 			RPCVAL.Kind = TypeFloat32
 		}
 	case 219:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1749
+//line midl/parse.y:1753
 		{
 			RPCVAL.Kind = TypeFloat64
 		}
 	case 220:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1755
+//line midl/parse.y:1759
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 221:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1759
+//line midl/parse.y:1763
 		{
 			switch RPCDollar[2].Token {
 			case UNSIGNED:
@@ -2909,31 +2913,31 @@ RPCdefault:
 		}
 	case 222:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1768
+//line midl/parse.y:1772
 		{
 			RPCVAL.Kind = TypeUint64
 		}
 	case 223:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1774
+//line midl/parse.y:1778
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 224:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1778
+//line midl/parse.y:1782
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 225:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1782
+//line midl/parse.y:1786
 		{
 			RPCVAL.Kind = RPCDollar[1].Kind
 		}
 	case 226:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1788
+//line midl/parse.y:1792
 		{
 			switch RPCDollar[2].Token {
 			case LONG:
@@ -2946,7 +2950,7 @@ RPCdefault:
 		}
 	case 227:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1799
+//line midl/parse.y:1803
 		{
 			switch RPCDollar[1].Token {
 			case LONG:
@@ -2959,7 +2963,7 @@ RPCdefault:
 		}
 	case 228:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1812
+//line midl/parse.y:1816
 		{
 			switch RPCDollar[1].Token {
 			case LONG:
@@ -2972,7 +2976,7 @@ RPCdefault:
 		}
 	case 229:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:1823
+//line midl/parse.y:1827
 		{
 			switch RPCDollar[2].Token {
 			case LONG:
@@ -2985,7 +2989,7 @@ RPCdefault:
 		}
 	case 230:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1837
+//line midl/parse.y:1841
 		{
 			switch RPCDollar[1].Token {
 			case UNSIGNED:
@@ -2996,7 +3000,7 @@ RPCdefault:
 		}
 	case 231:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1846
+//line midl/parse.y:1850
 		{
 			switch RPCDollar[1].Token {
 			case UNSIGNED:
@@ -3007,7 +3011,7 @@ RPCdefault:
 		}
 	case 232:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1855
+//line midl/parse.y:1859
 		{
 			switch RPCDollar[1].Token {
 			case UNSIGNED:
@@ -3018,7 +3022,7 @@ RPCdefault:
 		}
 	case 233:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1864
+//line midl/parse.y:1868
 		{
 			switch RPCDollar[1].Token {
 			case UNSIGNED:
@@ -3029,7 +3033,7 @@ RPCdefault:
 		}
 	case 234:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1873
+//line midl/parse.y:1877
 		{
 			switch RPCDollar[1].Token {
 			case UNSIGNED:
@@ -3040,7 +3044,7 @@ RPCdefault:
 		}
 	case 235:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1882
+//line midl/parse.y:1886
 		{
 			switch RPCDollar[1].Token {
 			case UNSIGNED:
@@ -3051,25 +3055,25 @@ RPCdefault:
 		}
 	case 236:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1894
+//line midl/parse.y:1898
 		{
 			RPCVAL.Token = LONG
 		}
 	case 237:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1898
+//line midl/parse.y:1902
 		{
 			RPCVAL.Token = SHORT
 		}
 	case 238:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1902
+//line midl/parse.y:1906
 		{
 			RPCVAL.Token = SMALL
 		}
 	case 239:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:1908
+//line midl/parse.y:1912
 		{
 			switch RPCDollar[1].Token {
 			case UNSIGNED:
@@ -3080,97 +3084,97 @@ RPCdefault:
 		}
 	case 240:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1920
+//line midl/parse.y:1924
 		{
 			RPCVAL.Kind = TypeWChar
 		}
 	case 241:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1927
+//line midl/parse.y:1931
 		{
 			RPCVAL.Kind = TypeBoolean
 		}
 	case 242:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1933
+//line midl/parse.y:1937
 		{
 			RPCVAL.Kind = TypeUint8
 		}
 	case 243:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1939
+//line midl/parse.y:1943
 		{
 			RPCVAL.Kind = TypeVoid
 		}
 	case 244:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1945
+//line midl/parse.y:1949
 		{
 			RPCVAL.Kind = TypeHandle
 		}
 	case 245:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:1951
+//line midl/parse.y:1955
 		{
 			RPCVAL.Token = 0
 		}
 	case 246:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1955
+//line midl/parse.y:1959
 		{
 			RPCVAL.Token = UNSIGNED
 		}
 	case 247:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:1961
+//line midl/parse.y:1965
 		{
 			RPCVAL.Token = 0
 		}
 	case 248:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1965
+//line midl/parse.y:1969
 		{
 			RPCVAL.Token = UNSIGNED
 		}
 	case 249:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1969
+//line midl/parse.y:1973
 		{
 			RPCVAL.Token = 0
 		}
 	case 254:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1984
+//line midl/parse.y:1988
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 255:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1988
+//line midl/parse.y:1992
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 256:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1992
+//line midl/parse.y:1996
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 257:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:1996
+//line midl/parse.y:2000
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 258:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2000
+//line midl/parse.y:2004
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 259:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2006
+//line midl/parse.y:2010
 		{
 			ref := &Type{Kind: TypeRef, Name: "_struct_" + RPCDollar[2].String}
 			typ, ok := lookupType(RPClex, ref.Name)
@@ -3183,13 +3187,13 @@ RPCdefault:
 		}
 	case 260:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2017
+//line midl/parse.y:2021
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 261:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2023
+//line midl/parse.y:2027
 		{
 			for i := range RPCDollar[3].Fields {
 				RPCDollar[3].Fields[i].Position = i + 1
@@ -3200,7 +3204,7 @@ RPCdefault:
 		}
 	case 262:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:2034
+//line midl/parse.y:2038
 		{
 			for i := range RPCDollar[4].Fields {
 				RPCDollar[4].Fields[i].Position = i + 1
@@ -3211,31 +3215,31 @@ RPCdefault:
 		}
 	case 263:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2045
+//line midl/parse.y:2049
 		{
 			RPCVAL.String = RPCDollar[1].Ident
 		}
 	case 264:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2051
+//line midl/parse.y:2055
 		{
 			RPCVAL.Fields = RPCDollar[1].Fields
 		}
 	case 265:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2055
+//line midl/parse.y:2059
 		{
 			RPCVAL.Fields = append(RPCVAL.Fields, RPCDollar[2].Fields...)
 		}
 	case 266:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2061
+//line midl/parse.y:2065
 		{
 			RPCVAL.Fields = RPCDollar[1].Fields
 		}
 	case 267:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2067
+//line midl/parse.y:2071
 		{
 			RPCVAL.Fields = make([]*Field, 0, len(RPCDollar[3].Declarators))
 			for _, decl := range RPCDollar[3].Declarators {
@@ -3246,31 +3250,31 @@ RPCdefault:
 		}
 	case 268:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:2078
+//line midl/parse.y:2082
 		{
 			RPCVAL.Expr = Expr{}
 		}
 	case 269:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2082
+//line midl/parse.y:2086
 		{
 			RPCVAL.Expr = RPCDollar[2].Expr
 		}
 	case 270:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2088
+//line midl/parse.y:2092
 		{
 			RPCVAL.Type = &Type{Kind: TypeUnion, Tag: RPCDollar[2].String}
 		}
 	case 271:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2092
+//line midl/parse.y:2096
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 272:
 		RPCDollar = RPCS[RPCpt-6 : RPCpt+1]
-//line midl/parse.y:2098
+//line midl/parse.y:2102
 		{
 			pos := 1
 			for i := range RPCDollar[5].UnionCases {
@@ -3283,7 +3287,7 @@ RPCdefault:
 		}
 	case 273:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2109
+//line midl/parse.y:2113
 		{
 			pos := 1
 			for i := range RPCDollar[3].UnionCases {
@@ -3296,7 +3300,7 @@ RPCdefault:
 		}
 	case 274:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2120
+//line midl/parse.y:2124
 		{
 			pos := 1
 			for i := range RPCDollar[3].UnionCases {
@@ -3309,37 +3313,37 @@ RPCdefault:
 		}
 	case 275:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:2133
+//line midl/parse.y:2137
 		{
 			RPCVAL.UnionSwitch = &UnionSwitch{Type: RPCDollar[3].Type, Name: RPCDollar[4].Ident}
 		}
 	case 276:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2139
+//line midl/parse.y:2143
 		{
 			RPCVAL.Type = &Type{Kind: RPCDollar[1].Kind}
 		}
 	case 277:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2143
+//line midl/parse.y:2147
 		{
 			RPCVAL.Type = &Type{Kind: RPCDollar[1].Kind}
 		}
 	case 278:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2147
+//line midl/parse.y:2151
 		{
 			RPCVAL.Type = &Type{Kind: RPCDollar[1].Kind}
 		}
 	case 279:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2151
+//line midl/parse.y:2155
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 280:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2156
+//line midl/parse.y:2160
 		{
 			ref := &Type{Kind: TypeRef, Name: "_enum_" + RPCDollar[2].String}
 			typ, ok := lookupType(RPClex, ref.Name)
@@ -3352,7 +3356,7 @@ RPCdefault:
 		}
 	case 281:
 		RPCDollar = RPCS[RPCpt-7 : RPCpt+1]
-//line midl/parse.y:2169
+//line midl/parse.y:2173
 		{
 			pos := 1
 			for i := range RPCDollar[6].UnionCases {
@@ -3365,7 +3369,7 @@ RPCdefault:
 		}
 	case 282:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:2180
+//line midl/parse.y:2184
 		{
 			pos := 1
 			for i := range RPCDollar[4].UnionCases {
@@ -3378,7 +3382,7 @@ RPCdefault:
 		}
 	case 283:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:2191
+//line midl/parse.y:2195
 		{
 			pos := 1
 			for i := range RPCDollar[4].UnionCases {
@@ -3391,7 +3395,7 @@ RPCdefault:
 		}
 	case 284:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:2204
+//line midl/parse.y:2208
 		{
 			// In encapsulated unions, if the <union_name> is
 			// omitted, the union is assigned the name tagged_union
@@ -3400,49 +3404,49 @@ RPCdefault:
 		}
 	case 285:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2211
+//line midl/parse.y:2215
 		{
 			RPCVAL.String = RPCDollar[1].Ident
 		}
 	case 286:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2217
+//line midl/parse.y:2221
 		{
 			RPCVAL.UnionCases = []*UnionCase{RPCDollar[1].UnionCase}
 		}
 	case 287:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2221
+//line midl/parse.y:2225
 		{
 			RPCVAL.UnionCases = append(RPCVAL.UnionCases, RPCDollar[2].UnionCase)
 		}
 	case 288:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2227
+//line midl/parse.y:2231
 		{
 			RPCVAL.UnionCases = []*UnionCase{&UnionCase{Arms: RPCDollar[1].Fields}}
 		}
 	case 289:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2231
+//line midl/parse.y:2235
 		{
 			RPCVAL.UnionCases = append(RPCVAL.UnionCases, &UnionCase{Arms: RPCDollar[2].Fields})
 		}
 	case 290:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2237
+//line midl/parse.y:2241
 		{
 			RPCVAL.UnionCases = []*UnionCase{RPCDollar[1].UnionCase}
 		}
 	case 291:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2241
+//line midl/parse.y:2245
 		{
 			RPCVAL.UnionCases = append(RPCVAL.UnionCases, RPCDollar[2].UnionCase)
 		}
 	case 292:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2247
+//line midl/parse.y:2251
 		{
 			labels := make([]interface{}, 0, len(RPCDollar[1].Exprs))
 			for _, label := range RPCDollar[1].Exprs {
@@ -3452,25 +3456,25 @@ RPCdefault:
 		}
 	case 293:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2255
+//line midl/parse.y:2259
 		{
 			RPCVAL.UnionCase = &UnionCase{Arms: RPCDollar[1].Fields, IsDefault: true}
 		}
 	case 294:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2261
+//line midl/parse.y:2265
 		{
 			RPCVAL.Exprs = RPCDollar[1].Exprs
 		}
 	case 295:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2265
+//line midl/parse.y:2269
 		{
 			RPCVAL.Exprs = append(RPCVAL.Exprs, RPCDollar[2].Exprs...)
 		}
 	case 296:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2271
+//line midl/parse.y:2275
 		{
 			labels := make([]interface{}, 0, len(RPCDollar[1].Exprs))
 			for _, label := range RPCDollar[1].Exprs {
@@ -3480,55 +3484,55 @@ RPCdefault:
 		}
 	case 297:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2279
+//line midl/parse.y:2283
 		{
 			RPCVAL.UnionCase = &UnionCase{Labels: nil, Arms: RPCDollar[1].Fields, IsDefault: true}
 		}
 	case 298:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2285
+//line midl/parse.y:2289
 		{
 			RPCVAL.Exprs = Exprs{RPCDollar[2].Expr}
 		}
 	case 299:
 		RPCDollar = RPCS[RPCpt-6 : RPCpt+1]
-//line midl/parse.y:2291
+//line midl/parse.y:2295
 		{
 			RPCVAL.Exprs = RPCDollar[4].Exprs
 		}
 	case 300:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2297
+//line midl/parse.y:2301
 		{
 			RPCVAL.Exprs = Exprs{RPCDollar[1].Expr}
 		}
 	case 301:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2301
+//line midl/parse.y:2305
 		{
 			RPCVAL.Exprs = append(RPCVAL.Exprs, RPCDollar[3].Expr)
 		}
 	case 302:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2308
+//line midl/parse.y:2312
 		{
 			RPCVAL.Fields = RPCDollar[3].Fields
 		}
 	case 303:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2314
+//line midl/parse.y:2318
 		{
 			RPCVAL.Fields = RPCDollar[4].Fields
 		}
 	case 304:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2320
+//line midl/parse.y:2324
 		{
 			RPCVAL.Fields = nil
 		}
 	case 305:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2324
+//line midl/parse.y:2328
 		{
 			for i := range RPCDollar[1].Fields {
 				RPCDollar[1].Fields[i].Position = i + 1
@@ -3537,19 +3541,19 @@ RPCdefault:
 		}
 	case 306:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2333
+//line midl/parse.y:2337
 		{
 			RPCVAL.Type = RPCDollar[3].Type
 		}
 	case 307:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2339
+//line midl/parse.y:2343
 		{
 			RPCVAL.AttrType = pAttrType{SWITCH_IS, pAttr{SwitchIs: RPCDollar[3].Expr}}
 		}
 	case 308:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:2345
+//line midl/parse.y:2349
 		{
 			RPCVAL.Type = &Type{Kind: TypeEnum, Enum: &Enum{Elems: make([]*Element, 0, len(RPCDollar[3].TagIDs))}}
 			for idx, i := 0, 0; i < len(RPCDollar[3].TagIDs); i, idx = i+1, idx+1 {
@@ -3578,19 +3582,19 @@ RPCdefault:
 		}
 	case 309:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2375
+//line midl/parse.y:2379
 		{
 			RPCVAL.Type = &Type{Kind: TypeEnum, Tag: RPCDollar[2].String}
 		}
 	case 310:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2379
+//line midl/parse.y:2383
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 311:
 		RPCDollar = RPCS[RPCpt-6 : RPCpt+1]
-//line midl/parse.y:2385
+//line midl/parse.y:2389
 		{
 			RPCVAL.Type = &Type{Kind: TypeEnum, Tag: RPCDollar[2].String, Enum: &Enum{Elems: make([]*Element, 0, len(RPCDollar[4].TagIDs))}}
 			for idx, i := 0, 0; i < len(RPCDollar[4].TagIDs); i, idx = i+1, idx+1 {
@@ -3619,37 +3623,37 @@ RPCdefault:
 		}
 	case 312:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2415
+//line midl/parse.y:2419
 		{
 			RPCVAL.TagIDs = pTagIDs{RPCDollar[1].TagID}
 		}
 	case 313:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2419
+//line midl/parse.y:2423
 		{
 			RPCVAL.TagIDs = append(RPCVAL.TagIDs, RPCDollar[3].TagID)
 		}
 	case 316:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2429
+//line midl/parse.y:2433
 		{
 			RPCVAL.TagID = pTagID{Tag: RPCDollar[1].Ident}
 		}
 	case 317:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2434
+//line midl/parse.y:2438
 		{
 			RPCVAL.TagID = pTagID{Tag: RPCDollar[1].Ident, ID: RPCDollar[3].Expr}
 		}
 	case 318:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2441
+//line midl/parse.y:2445
 		{
 			RPCVAL.Type = &Type{Kind: TypePipe, Elem: RPCDollar[2].Type}
 		}
 	case 319:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2447
+//line midl/parse.y:2451
 		{
 
 			// XXX: array associativity is different from pointer.
@@ -3675,13 +3679,13 @@ RPCdefault:
 		}
 	case 320:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:2473
+//line midl/parse.y:2477
 		{
 			RPCVAL.ArrayBound = ArrayBound{Lower: 0, Upper: -1}
 		}
 	case 321:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2477
+//line midl/parse.y:2481
 		{
 			if RPCDollar[1].Int.Int64() == -1 {
 				RPCVAL.ArrayBound = ArrayBound{Lower: -1, Upper: 0}
@@ -3692,25 +3696,25 @@ RPCdefault:
 		}
 	case 322:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2486
+//line midl/parse.y:2490
 		{
 			RPCVAL.ArrayBound = RPCDollar[1].ArrayBound
 		}
 	case 323:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2492
+//line midl/parse.y:2496
 		{
 			RPCVAL.ArrayBound = ArrayBound{Lower: RPCDollar[1].Int.Int64(), Upper: RPCDollar[3].Int.Int64()}
 		}
 	case 324:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2498
+//line midl/parse.y:2502
 		{
 			RPCVAL.Int = big.NewInt(-1)
 		}
 	case 325:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2502
+//line midl/parse.y:2506
 		{
 			if !RPCDollar[1].Expr.CanEval() {
 				RPClex.Error("cannot evaluate integer bound")
@@ -3725,61 +3729,61 @@ RPCdefault:
 		}
 	case 326:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2517
+//line midl/parse.y:2521
 		{
 			RPCVAL.Token = USAGE_STRING
 		}
 	case 327:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2521
+//line midl/parse.y:2525
 		{
 			RPCVAL.Token = USAGE_CONTEXT_HANDLE
 		}
 	case 328:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2527
+//line midl/parse.y:2531
 		{
 			RPCVAL.Token = FORMAT_UTF8
 		}
 	case 329:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2531
+//line midl/parse.y:2535
 		{
 			RPCVAL.Token = FORMAT_NULL_TERMINATED
 		}
 	case 330:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2535
+//line midl/parse.y:2539
 		{
 			RPCVAL.Token = FORMAT_MULTI_SIZE
 		}
 	case 331:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2539
+//line midl/parse.y:2543
 		{
 			RPCVAL.Token = FORMAT_RUNE
 		}
 	case 332:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2543
+//line midl/parse.y:2547
 		{
 			RPCVAL.Token = FORMAT_HEX
 		}
 	case 333:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2549
+//line midl/parse.y:2553
 		{
 			RPCVAL.Type = RPCDollar[1].Type
 		}
 	case 334:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2555
+//line midl/parse.y:2559
 		{
 			RPCVAL.AttrType = pAttrType{RANGE, pAttr{Range: RPCDollar[2].Range}}
 		}
 	case 335:
 		RPCDollar = RPCS[RPCpt-5 : RPCpt+1]
-//line midl/parse.y:2561
+//line midl/parse.y:2565
 		{
 			if !CanEval(RPCDollar[2].Expr, RPCDollar[4].Expr) {
 				RPClex.Error("cannot evaluate range declaration")
@@ -3799,13 +3803,13 @@ RPCdefault:
 		}
 	case 336:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2582
+//line midl/parse.y:2586
 		{
 			RPCVAL.Exprs = []Expr{RPCDollar[1].Expr}
 		}
 	case 337:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2586
+//line midl/parse.y:2590
 		{
 			// see https://learn.microsoft.com/en-us/windows/win32/rpc/multiple-levels-of-pointers
 			// for (,Size) constructions.
@@ -3813,61 +3817,61 @@ RPCdefault:
 		}
 	case 338:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:2594
+//line midl/parse.y:2598
 		{
 			RPCVAL.Expr = Expr{}
 		}
 	case 339:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2598
+//line midl/parse.y:2602
 		{
 			RPCVAL.Expr = RPCDollar[1].Expr
 		}
 	case 340:
 		RPCDollar = RPCS[RPCpt-0 : RPCpt+1]
-//line midl/parse.y:2604
+//line midl/parse.y:2608
 		{
 			RPCVAL.Int64 = 0
 		}
 	case 341:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2608
+//line midl/parse.y:2612
 		{
 			RPCVAL.Int64 = RPCDollar[1].Int64
 		}
 	case 342:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2614
+//line midl/parse.y:2618
 		{
 			RPCVAL.Int64++
 		}
 	case 343:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2618
+//line midl/parse.y:2622
 		{
 			RPCVAL.Int64++
 		}
 	case 344:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2628
+//line midl/parse.y:2632
 		{
 			RPCVAL.Token = POINTER_REF
 		}
 	case 345:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2632
+//line midl/parse.y:2636
 		{
 			RPCVAL.Token = POINTER_UNIQUE
 		}
 	case 346:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2636
+//line midl/parse.y:2640
 		{
 			RPCVAL.Token = POINTER_PTR
 		}
 	case 347:
 		RPCDollar = RPCS[RPCpt-6 : RPCpt+1]
-//line midl/parse.y:2642
+//line midl/parse.y:2646
 		{
 			for i := range RPCDollar[5].Params {
 				if RPCDollar[5].Params[i].Name == "" {
@@ -3881,25 +3885,25 @@ RPCdefault:
 		}
 	case 348:
 		RPCDollar = RPCS[RPCpt-6 : RPCpt+1]
-//line midl/parse.y:2654
+//line midl/parse.y:2658
 		{
 			RPCVAL.Operation = &Operation{Attrs: RPCDollar[1].Attr.Operation(), Type: RPCDollar[2].Type, Name: RPCDollar[3].Ident}
 		}
 	case 349:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2660
+//line midl/parse.y:2664
 		{
 			RPCVAL.Params = append(RPCVAL.Params, RPCDollar[3].Param)
 		}
 	case 350:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2664
+//line midl/parse.y:2668
 		{
 			RPCVAL.Params = []*Param{RPCDollar[1].Param}
 		}
 	case 351:
 		RPCDollar = RPCS[RPCpt-3 : RPCpt+1]
-//line midl/parse.y:2670
+//line midl/parse.y:2674
 		{
 			RPCDollar[3].Declarator.Type = RPCDollar[3].Declarator.Type.Append(RPCDollar[2].Type)
 			RPCVAL.Param = &Param{Attrs: RPCDollar[1].Attr.Param(), Name: RPCDollar[3].Declarator.Name, Type: RPCDollar[3].Declarator.Type}
@@ -3915,7 +3919,7 @@ RPCdefault:
 		}
 	case 352:
 		RPCDollar = RPCS[RPCpt-2 : RPCpt+1]
-//line midl/parse.y:2684
+//line midl/parse.y:2688
 		{
 			RPCDollar[2].Declarator.Type = RPCDollar[2].Declarator.Type.Append(RPCDollar[1].Type)
 			attrs := pAttr{Direction: Direction{In: true}}
@@ -3923,19 +3927,19 @@ RPCdefault:
 		}
 	case 353:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2692
+//line midl/parse.y:2696
 		{
 			RPCVAL.AttrType = pAttrType{IN, pAttr{}}
 		}
 	case 354:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2696
+//line midl/parse.y:2700
 		{
 			RPCVAL.AttrType = pAttrType{OUT, pAttr{}}
 		}
 	case 355:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2702
+//line midl/parse.y:2706
 		{
 			for i := range RPCDollar[3].Params {
 				if RPCDollar[3].Params[i].Name == "" {
@@ -3946,19 +3950,19 @@ RPCdefault:
 		}
 	case 356:
 		RPCDollar = RPCS[RPCpt-4 : RPCpt+1]
-//line midl/parse.y:2711
+//line midl/parse.y:2715
 		{
 			RPCVAL.Declarator = &pDeclarator{Name: RPCDollar[1].Declarator.Name, Type: &Type{Kind: TypeFunc, Func: &Func{}, Elem: RPCDollar[1].Declarator.Type}}
 		}
 	case 357:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2722
+//line midl/parse.y:2726
 		{
 			RPCVAL.Type = &Type{Kind: TypeError}
 		}
 	case 358:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2726
+//line midl/parse.y:2730
 		{
 			RPCVAL.Type = &Type{Kind: TypeCharset}
 
@@ -3973,19 +3977,19 @@ RPCdefault:
 		}
 	case 359:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2741
+//line midl/parse.y:2745
 		{
 			RPCVAL.Token = ISO_LATIN_1
 		}
 	case 360:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2745
+//line midl/parse.y:2749
 		{
 			RPCVAL.Token = ISO_MULTILINGUAL
 		}
 	case 361:
 		RPCDollar = RPCS[RPCpt-1 : RPCpt+1]
-//line midl/parse.y:2749
+//line midl/parse.y:2753
 		{
 			RPCVAL.Token = ISO_UCS
 		}

--- a/midl/parse.y
+++ b/midl/parse.y
@@ -312,7 +312,7 @@ var (
 %token <Token> SAFEARRAY
 %token <Token> PAD
 %token <Token> GOEXT_LAYOUT
-%token <Token> GOEXT_NULL_IF
+%token <Token> GOEXT_DEFAULT_NULL
 %token <Token> GOEXT_NO_SIZE_LIMIT
 %token <Token> CALL_AS
 %token <Token> ANNOTATION
@@ -733,9 +733,13 @@ attribute               : FIRST_IS '(' attr_var_list ')'
                             {
                                 $$ = pAttrType{$1, pAttr{}}
                             }
-                        | GOEXT_NULL_IF '(' attr_var ')'
+                        | GOEXT_DEFAULT_NULL '(' attr_var ')'
                             {
-                                $$ = pAttrType{GOEXT_NULL_IF, pAttr{NullIf: $3}}
+                                if $3.Empty() {
+                                    $$ = pAttrType{GOEXT_DEFAULT_NULL, pAttr{DefaultNull: []Expr{}}}
+                                } else {
+                                    $$ = pAttrType{GOEXT_DEFAULT_NULL, pAttr{DefaultNull: []Expr{$3}}}
+                                }
                             }
                         | usage_attribute
                             {

--- a/midl/parser_types.go
+++ b/midl/parser_types.go
@@ -218,7 +218,7 @@ type pAttr struct {
 	Layout                  []*Field
 	NoSizeLimit             bool
 	IsLayout                bool
-	NullIf                  Expr
+	DefaultNull             []Expr
 }
 
 func (a pAttr) Set(at pAttrType) pAttr {
@@ -349,8 +349,8 @@ func (a pAttr) Set(at pAttrType) pAttr {
 		a.Layout = at.Attr.Layout
 	case GOEXT_NO_SIZE_LIMIT:
 		a.NoSizeLimit = at.Attr.NoSizeLimit
-	case GOEXT_NULL_IF:
-		a.NullIf = at.Attr.NullIf
+	case GOEXT_DEFAULT_NULL:
+		a.DefaultNull = at.Attr.DefaultNull
 	default:
 		panic(fmt.Sprintf("unknown attribute: %d", at.Type))
 	}
@@ -552,8 +552,8 @@ func (a pAttr) MapAttr() map[int]interface{} {
 		ret[GOEXT_NO_SIZE_LIMIT] = a.NoSizeLimit
 	}
 
-	if !a.NullIf.Empty() {
-		ret[GOEXT_NULL_IF] = a.NullIf
+	if a.DefaultNull != nil {
+		ret[GOEXT_DEFAULT_NULL] = a.DefaultNull
 	}
 
 	return ret
@@ -750,8 +750,8 @@ func (a pAttr) Merge(ma pAttr) pAttr {
 	if ma.NoSizeLimit {
 		a.NoSizeLimit = ma.NoSizeLimit
 	}
-	if !ma.NullIf.Empty() {
-		a.NullIf = ma.NullIf
+	if ma.DefaultNull != nil {
+		a.DefaultNull = ma.DefaultNull
 	}
 
 	return a
@@ -837,7 +837,7 @@ var pAllowedFieldAttr = []int{
 	RANGE,
 	POINTER,
 	SWITCH_TYPE,
-	GOEXT_NULL_IF,
+	GOEXT_DEFAULT_NULL,
 }
 
 var pAllowedParamAttr = []int{
@@ -866,7 +866,7 @@ var pAllowedParamAttr = []int{
 	IID_IS,
 	RETVAL,
 	OPTIONAL,
-	GOEXT_NULL_IF,
+	GOEXT_DEFAULT_NULL,
 }
 
 var pAllowedTypeAttr = []int{
@@ -925,7 +925,7 @@ func (a pAttr) Field() *FieldAttr {
 		a.Layout,
 		a.NoSizeLimit,
 		a.IsLayout,
-		a.NullIf,
+		a.DefaultNull,
 	}
 }
 

--- a/midl/types.go
+++ b/midl/types.go
@@ -583,7 +583,7 @@ type FieldAttr struct {
 	Layout      []*Field
 	NoSizeLimit bool
 	IsLayout    bool
-	NullIf      Expr
+	DefaultNull []Expr
 }
 
 func (f *FieldAttr) SizeAttr() *SizeAttr {

--- a/midl/y.out
+++ b/midl/y.out
@@ -168,7 +168,7 @@ state 12
 state 13
 	export:  pragma_declarator.    (126)
 
-	.  reduce 126 (src line 1085)
+	.  reduce 126 (src line 1089)
 
 
 state 14
@@ -236,7 +236,7 @@ state 20
 	BOOLEAN  shift 60
 	VOID  shift 61
 	IDENT  shift 57
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	const_type_spec  goto 55
 	primitive_integer_type  goto 56
@@ -263,19 +263,19 @@ state 22
 state 23
 	tagged_declarator:  tagged_struct_declarator.    (207)
 
-	.  reduce 207 (src line 1685)
+	.  reduce 207 (src line 1689)
 
 
 state 24
 	tagged_declarator:  tagged_union_declarator.    (208)
 
-	.  reduce 208 (src line 1689)
+	.  reduce 208 (src line 1693)
 
 
 state 25
 	tagged_declarator:  tagged_enumeration_declarator.    (209)
 
-	.  reduce 209 (src line 1694)
+	.  reduce 209 (src line 1698)
 
 
 state 26
@@ -298,7 +298,7 @@ state 27
 state 28
 	tagged_struct_declarator:  tagged_struct.    (260)
 
-	.  reduce 260 (src line 2016)
+	.  reduce 260 (src line 2020)
 
 
 state 29
@@ -315,7 +315,7 @@ state 29
 state 30
 	tagged_union_declarator:  tagged_union.    (271)
 
-	.  reduce 271 (src line 2091)
+	.  reduce 271 (src line 2095)
 
 
 state 31
@@ -330,7 +330,7 @@ state 31
 state 32
 	tagged_enumeration_declarator:  tagged_enumeration.    (310)
 
-	.  reduce 310 (src line 2378)
+	.  reduce 310 (src line 2382)
 
 
 state 33
@@ -390,7 +390,7 @@ state 33
 	SAFEARRAY  shift 132
 	PAD  shift 133
 	GOEXT_LAYOUT  shift 134
-	GOEXT_NULL_IF  shift 87
+	GOEXT_DEFAULT_NULL  shift 87
 	CALL_AS  shift 129
 	ANNOTATION  shift 128
 	WIRE_MARSHAL  shift 130
@@ -454,31 +454,31 @@ state 40
 state 41
 	import_list:  import_name.    (128)
 
-	.  reduce 128 (src line 1095)
+	.  reduce 128 (src line 1099)
 
 
 state 42
 	import_name:  STRING_LITERAL.    (130)
 
-	.  reduce 130 (src line 1105)
+	.  reduce 130 (src line 1109)
 
 
 state 43
 	export:  type_declarator ';'.    (124)
 
-	.  reduce 124 (src line 1077)
+	.  reduce 124 (src line 1081)
 
 
 state 44
 	export:  const_declarator ';'.    (125)
 
-	.  reduce 125 (src line 1081)
+	.  reduce 125 (src line 1085)
 
 
 state 45
 	export:  tagged_declarator ';'.    (127)
 
-	.  reduce 127 (src line 1089)
+	.  reduce 127 (src line 1093)
 
 
 state 46
@@ -488,7 +488,7 @@ state 46
 
 	IMPORT  shift 10
 	'}'  shift 148
-	.  reduce 119 (src line 1041)
+	.  reduce 119 (src line 1045)
 
 	interface_body  goto 147
 	import  goto 149
@@ -576,13 +576,13 @@ state 55
 state 56
 	const_type_spec:  primitive_integer_type.    (134)
 
-	.  reduce 134 (src line 1158)
+	.  reduce 134 (src line 1162)
 
 
 state 57
 	const_type_spec:  IDENT.    (135)
 
-	.  reduce 135 (src line 1162)
+	.  reduce 135 (src line 1166)
 
 
 state 58
@@ -590,7 +590,7 @@ state 58
 	const_type_spec:  CHAR.'*' 
 
 	'*'  shift 168
-	.  reduce 136 (src line 1196)
+	.  reduce 136 (src line 1200)
 
 
 state 59
@@ -602,14 +602,14 @@ state 59
 	SHORT  shift 69
 	SMALL  shift 70
 	CHAR  shift 169
-	.  reduce 248 (src line 1964)
+	.  reduce 248 (src line 1968)
 
 	integer_size  goto 170
 
 state 60
 	const_type_spec:  BOOLEAN.    (138)
 
-	.  reduce 138 (src line 1204)
+	.  reduce 138 (src line 1208)
 
 
 state 61
@@ -622,19 +622,19 @@ state 61
 state 62
 	primitive_integer_type:  signed_integer.    (223)
 
-	.  reduce 223 (src line 1773)
+	.  reduce 223 (src line 1777)
 
 
 state 63
 	primitive_integer_type:  unsigned_integer.    (224)
 
-	.  reduce 224 (src line 1777)
+	.  reduce 224 (src line 1781)
 
 
 state 64
 	primitive_integer_type:  ms_integer.    (225)
 
-	.  reduce 225 (src line 1781)
+	.  reduce 225 (src line 1785)
 
 
 state 65
@@ -644,7 +644,7 @@ state 65
 	LONG  shift 68
 	SHORT  shift 69
 	SMALL  shift 70
-	.  reduce 249 (src line 1968)
+	.  reduce 249 (src line 1972)
 
 	integer_size  goto 172
 
@@ -655,7 +655,7 @@ state 66
 
 	UNSIGNED  shift 174
 	INT  shift 175
-	.  reduce 252 (src line 1978)
+	.  reduce 252 (src line 1982)
 
 	int  goto 173
 
@@ -679,19 +679,19 @@ state 67
 state 68
 	integer_size:  LONG.    (236)
 
-	.  reduce 236 (src line 1893)
+	.  reduce 236 (src line 1897)
 
 
 state 69
 	integer_size:  SHORT.    (237)
 
-	.  reduce 237 (src line 1897)
+	.  reduce 237 (src line 1901)
 
 
 state 70
 	integer_size:  SMALL.    (238)
 
-	.  reduce 238 (src line 1901)
+	.  reduce 238 (src line 1905)
 
 
 state 71
@@ -793,7 +793,7 @@ state 73
 	SAFEARRAY  shift 132
 	PAD  shift 133
 	GOEXT_LAYOUT  shift 134
-	GOEXT_NULL_IF  shift 87
+	GOEXT_DEFAULT_NULL  shift 87
 	CALL_AS  shift 129
 	ANNOTATION  shift 128
 	WIRE_MARSHAL  shift 130
@@ -814,13 +814,13 @@ state 74
 	tagged_struct:  STRUCT tag.'{' member_list '}' 
 
 	'{'  shift 213
-	.  reduce 259 (src line 2005)
+	.  reduce 259 (src line 2009)
 
 
 state 75
 	tag:  IDENT.    (263)
 
-	.  reduce 263 (src line 2044)
+	.  reduce 263 (src line 2048)
 
 
 state 76
@@ -831,7 +831,7 @@ state 76
 
 	SWITCH  shift 216
 	'{'  shift 215
-	.  reduce 270 (src line 2087)
+	.  reduce 270 (src line 2091)
 
 	union_switch  goto 214
 
@@ -840,7 +840,7 @@ state 77
 	tagged_enumeration:  ENUM tag.'{' enumeration1 comma '}' 
 
 	'{'  shift 217
-	.  reduce 309 (src line 2374)
+	.  reduce 309 (src line 2378)
 
 
 state 78
@@ -849,7 +849,7 @@ state 78
 	comma: .    (314)
 
 	','  shift 219
-	.  reduce 314 (src line 2424)
+	.  reduce 314 (src line 2428)
 
 	comma  goto 218
 
@@ -909,7 +909,7 @@ state 86
 
 
 state 87
-	attribute:  GOEXT_NULL_IF.'(' attr_var ')' 
+	attribute:  GOEXT_DEFAULT_NULL.'(' attr_var ')' 
 
 	'('  shift 226
 	.  error
@@ -918,7 +918,7 @@ state 87
 state 88
 	attribute:  usage_attribute.    (60)
 
-	.  reduce 60 (src line 740)
+	.  reduce 60 (src line 744)
 
 
 state 89
@@ -931,19 +931,19 @@ state 89
 state 90
 	attribute:  union_instance_switch_attr.    (62)
 
-	.  reduce 62 (src line 748)
+	.  reduce 62 (src line 752)
 
 
 state 91
 	attribute:  IGNORE.    (63)
 
-	.  reduce 63 (src line 752)
+	.  reduce 63 (src line 756)
 
 
 state 92
 	attribute:  directional_attribute.    (64)
 
-	.  reduce 64 (src line 756)
+	.  reduce 64 (src line 760)
 
 
 state 93
@@ -956,43 +956,43 @@ state 93
 state 94
 	attribute:  union_type_switch_attr.    (66)
 
-	.  reduce 66 (src line 764)
+	.  reduce 66 (src line 768)
 
 
 state 95
 	attribute:  HANDLE.    (67)
 
-	.  reduce 67 (src line 768)
+	.  reduce 67 (src line 772)
 
 
 state 96
 	attribute:  IDEMPOTENT.    (68)
 
-	.  reduce 68 (src line 772)
+	.  reduce 68 (src line 776)
 
 
 state 97
 	attribute:  BROADCAST.    (69)
 
-	.  reduce 69 (src line 776)
+	.  reduce 69 (src line 780)
 
 
 state 98
 	attribute:  MAYBE.    (70)
 
-	.  reduce 70 (src line 780)
+	.  reduce 70 (src line 784)
 
 
 state 99
 	attribute:  REFLECT_DELETIONS.    (71)
 
-	.  reduce 71 (src line 784)
+	.  reduce 71 (src line 788)
 
 
 state 100
 	attribute:  UUID.    (72)
 
-	.  reduce 72 (src line 788)
+	.  reduce 72 (src line 792)
 
 
 state 101
@@ -1019,7 +1019,7 @@ state 103
 state 104
 	attribute:  LOCAL.    (76)
 
-	.  reduce 76 (src line 804)
+	.  reduce 76 (src line 808)
 
 
 state 105
@@ -1032,43 +1032,43 @@ state 105
 state 106
 	attribute:  V1_ENUM.    (78)
 
-	.  reduce 78 (src line 819)
+	.  reduce 78 (src line 823)
 
 
 state 107
 	attribute:  MS_UNION.    (79)
 
-	.  reduce 79 (src line 823)
+	.  reduce 79 (src line 827)
 
 
 state 108
 	attribute:  range_attribute.    (80)
 
-	.  reduce 80 (src line 827)
+	.  reduce 80 (src line 831)
 
 
 state 109
 	attribute:  DISABLE_CONSISTENCY_CHECK.    (81)
 
-	.  reduce 81 (src line 831)
+	.  reduce 81 (src line 835)
 
 
 state 110
 	attribute:  OBJECT.    (82)
 
-	.  reduce 82 (src line 835)
+	.  reduce 82 (src line 839)
 
 
 state 111
 	attribute:  CALLBACK.    (83)
 
-	.  reduce 83 (src line 839)
+	.  reduce 83 (src line 843)
 
 
 state 112
 	attribute:  RETVAL.    (84)
 
-	.  reduce 84 (src line 843)
+	.  reduce 84 (src line 847)
 
 
 state 113
@@ -1088,25 +1088,25 @@ state 114
 state 115
 	attribute:  DUAL.    (87)
 
-	.  reduce 87 (src line 855)
+	.  reduce 87 (src line 859)
 
 
 state 116
 	attribute:  PROPGET.    (88)
 
-	.  reduce 88 (src line 859)
+	.  reduce 88 (src line 863)
 
 
 state 117
 	attribute:  PROPPUT.    (89)
 
-	.  reduce 89 (src line 863)
+	.  reduce 89 (src line 867)
 
 
 state 118
 	attribute:  PROPPUTREF.    (90)
 
-	.  reduce 90 (src line 867)
+	.  reduce 90 (src line 871)
 
 
 state 119
@@ -1119,19 +1119,19 @@ state 119
 state 120
 	attribute:  HIDDEN.    (92)
 
-	.  reduce 92 (src line 884)
+	.  reduce 92 (src line 888)
 
 
 state 121
 	attribute:  NONEXTENSIBLE.    (93)
 
-	.  reduce 93 (src line 888)
+	.  reduce 93 (src line 892)
 
 
 state 122
 	attribute:  RESTRICTED.    (94)
 
-	.  reduce 94 (src line 892)
+	.  reduce 94 (src line 896)
 
 
 state 123
@@ -1144,25 +1144,25 @@ state 123
 state 124
 	attribute:  ODL.    (96)
 
-	.  reduce 96 (src line 905)
+	.  reduce 96 (src line 909)
 
 
 state 125
 	attribute:  OLEAUTOMATION.    (97)
 
-	.  reduce 97 (src line 909)
+	.  reduce 97 (src line 913)
 
 
 state 126
 	attribute:  OPTIONAL.    (98)
 
-	.  reduce 98 (src line 913)
+	.  reduce 98 (src line 917)
 
 
 state 127
 	attribute:  APPOBJECT.    (99)
 
-	.  reduce 99 (src line 917)
+	.  reduce 99 (src line 921)
 
 
 state 128
@@ -1189,7 +1189,7 @@ state 130
 state 131
 	attribute:  PUBLIC.    (103)
 
-	.  reduce 103 (src line 933)
+	.  reduce 103 (src line 937)
 
 
 state 132
@@ -1216,31 +1216,31 @@ state 134
 state 135
 	ptr_attr:  POINTER_REF.    (344)
 
-	.  reduce 344 (src line 2627)
+	.  reduce 344 (src line 2631)
 
 
 state 136
 	ptr_attr:  POINTER_UNIQUE.    (345)
 
-	.  reduce 345 (src line 2631)
+	.  reduce 345 (src line 2635)
 
 
 state 137
 	ptr_attr:  POINTER_PTR.    (346)
 
-	.  reduce 346 (src line 2635)
+	.  reduce 346 (src line 2639)
 
 
 state 138
 	usage_attribute:  USAGE_STRING.    (326)
 
-	.  reduce 326 (src line 2516)
+	.  reduce 326 (src line 2520)
 
 
 state 139
 	usage_attribute:  USAGE_CONTEXT_HANDLE.    (327)
 
-	.  reduce 327 (src line 2520)
+	.  reduce 327 (src line 2524)
 
 
 state 140
@@ -1253,13 +1253,13 @@ state 140
 state 141
 	directional_attribute:  IN.    (353)
 
-	.  reduce 353 (src line 2691)
+	.  reduce 353 (src line 2695)
 
 
 state 142
 	directional_attribute:  OUT.    (354)
 
-	.  reduce 354 (src line 2695)
+	.  reduce 354 (src line 2699)
 
 
 state 143
@@ -1280,7 +1280,7 @@ state 144
 state 145
 	import1:  IMPORT import_list ';'.    (121)
 
-	.  reduce 121 (src line 1051)
+	.  reduce 121 (src line 1055)
 
 
 state 146
@@ -1337,7 +1337,7 @@ state 149
 state 150
 	import:  import1.    (120)
 
-	.  reduce 120 (src line 1045)
+	.  reduce 120 (src line 1049)
 
 
 state 151
@@ -1492,7 +1492,7 @@ state 166
 	UNION  shift 296
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -1537,13 +1537,13 @@ state 167
 state 168
 	const_type_spec:  CHAR '*'.    (140)
 
-	.  reduce 140 (src line 1212)
+	.  reduce 140 (src line 1216)
 
 
 state 169
 	const_type_spec:  UNSIGNED CHAR.    (137)
 
-	.  reduce 137 (src line 1200)
+	.  reduce 137 (src line 1204)
 
 
 state 170
@@ -1551,14 +1551,14 @@ state 170
 	int: .    (252)
 
 	INT  shift 175
-	.  reduce 252 (src line 1978)
+	.  reduce 252 (src line 1982)
 
 	int  goto 314
 
 state 171
 	const_type_spec:  VOID '*'.    (139)
 
-	.  reduce 139 (src line 1208)
+	.  reduce 139 (src line 1212)
 
 
 state 172
@@ -1566,14 +1566,14 @@ state 172
 	int: .    (252)
 
 	INT  shift 175
-	.  reduce 252 (src line 1978)
+	.  reduce 252 (src line 1982)
 
 	int  goto 315
 
 state 173
 	signed_integer:  integer_size int.    (227)
 
-	.  reduce 227 (src line 1798)
+	.  reduce 227 (src line 1802)
 
 
 state 174
@@ -1581,98 +1581,98 @@ state 174
 	int: .    (252)
 
 	INT  shift 175
-	.  reduce 252 (src line 1978)
+	.  reduce 252 (src line 1982)
 
 	int  goto 316
 
 state 175
 	int:  INT.    (253)
 
-	.  reduce 253 (src line 1979)
+	.  reduce 253 (src line 1983)
 
 
 state 176
 	ms_integer:  sign INT.    (230)
 
-	.  reduce 230 (src line 1836)
+	.  reduce 230 (src line 1840)
 
 
 state 177
 	ms_integer:  sign INT8.    (231)
 
-	.  reduce 231 (src line 1845)
+	.  reduce 231 (src line 1849)
 
 
 state 178
 	ms_integer:  sign INT16.    (232)
 
-	.  reduce 232 (src line 1854)
+	.  reduce 232 (src line 1858)
 
 
 state 179
 	ms_integer:  sign INT32.    (233)
 
-	.  reduce 233 (src line 1863)
+	.  reduce 233 (src line 1867)
 
 
 state 180
 	ms_integer:  sign INT3264.    (234)
 
-	.  reduce 234 (src line 1872)
+	.  reduce 234 (src line 1876)
 
 
 state 181
 	ms_integer:  sign INT64.    (235)
 
-	.  reduce 235 (src line 1881)
+	.  reduce 235 (src line 1885)
 
 
 state 182
 	pragma_declarator:  PRAGMA_DEFINE IDENT const_exp.    (132)
 
-	.  reduce 132 (src line 1122)
+	.  reduce 132 (src line 1126)
 
 
 state 183
 	const_exp:  integer_const_exp.    (141)
 
-	.  reduce 141 (src line 1218)
+	.  reduce 141 (src line 1222)
 
 
 state 184
 	const_exp:  STRING_LITERAL.    (142)
 
-	.  reduce 142 (src line 1222)
+	.  reduce 142 (src line 1226)
 
 
 state 185
 	const_exp:  CHARACTER_LITERAL.    (143)
 
-	.  reduce 143 (src line 1226)
+	.  reduce 143 (src line 1230)
 
 
 state 186
 	const_exp:  NULL.    (144)
 
-	.  reduce 144 (src line 1230)
+	.  reduce 144 (src line 1234)
 
 
 state 187
 	const_exp:  TRUE.    (145)
 
-	.  reduce 145 (src line 1234)
+	.  reduce 145 (src line 1238)
 
 
 state 188
 	const_exp:  FALSE.    (146)
 
-	.  reduce 146 (src line 1238)
+	.  reduce 146 (src line 1242)
 
 
 state 189
 	integer_const_exp:  conditional_exp.    (147)
 
-	.  reduce 147 (src line 1244)
+	.  reduce 147 (src line 1248)
 
 
 state 190
@@ -1682,7 +1682,7 @@ state 190
 
 	LOGICAL_OR  shift 318
 	'?'  shift 317
-	.  reduce 148 (src line 1250)
+	.  reduce 148 (src line 1254)
 
 
 state 191
@@ -1690,7 +1690,7 @@ state 191
 	logical_and_exp:  logical_and_exp.LOGICAL_AND inclusive_or_exp 
 
 	LOGICAL_AND  shift 319
-	.  reduce 150 (src line 1265)
+	.  reduce 150 (src line 1269)
 
 
 state 192
@@ -1698,7 +1698,7 @@ state 192
 	inclusive_or_exp:  inclusive_or_exp.OR exclusive_or_exp 
 
 	OR  shift 320
-	.  reduce 152 (src line 1280)
+	.  reduce 152 (src line 1284)
 
 
 state 193
@@ -1706,7 +1706,7 @@ state 193
 	exclusive_or_exp:  exclusive_or_exp.XOR and_exp 
 
 	XOR  shift 321
-	.  reduce 154 (src line 1295)
+	.  reduce 154 (src line 1299)
 
 
 state 194
@@ -1714,7 +1714,7 @@ state 194
 	and_exp:  and_exp.AND equality_exp 
 
 	AND  shift 322
-	.  reduce 156 (src line 1310)
+	.  reduce 156 (src line 1314)
 
 
 state 195
@@ -1724,7 +1724,7 @@ state 195
 
 	EQ  shift 323
 	NE  shift 324
-	.  reduce 158 (src line 1325)
+	.  reduce 158 (src line 1329)
 
 
 state 196
@@ -1738,7 +1738,7 @@ state 196
 	GE  shift 328
 	LT  shift 325
 	GT  shift 326
-	.  reduce 160 (src line 1340)
+	.  reduce 160 (src line 1344)
 
 
 state 197
@@ -1748,7 +1748,7 @@ state 197
 
 	LSH  shift 329
 	RSH  shift 330
-	.  reduce 163 (src line 1364)
+	.  reduce 163 (src line 1368)
 
 
 state 198
@@ -1758,7 +1758,7 @@ state 198
 
 	'+'  shift 332
 	'-'  shift 331
-	.  reduce 168 (src line 1406)
+	.  reduce 168 (src line 1410)
 
 
 state 199
@@ -1770,19 +1770,19 @@ state 199
 	'*'  shift 333
 	'/'  shift 334
 	'%'  shift 335
-	.  reduce 171 (src line 1430)
+	.  reduce 171 (src line 1434)
 
 
 state 200
 	multiplicative_exp:  unary_exp.    (174)
 
-	.  reduce 174 (src line 1454)
+	.  reduce 174 (src line 1458)
 
 
 state 201
 	unary_exp:  primary_exp.    (178)
 
-	.  reduce 178 (src line 1487)
+	.  reduce 178 (src line 1491)
 
 
 state 202
@@ -1836,7 +1836,7 @@ state 205
 state 206
 	primary_exp:  INT_LITERAL.    (183)
 
-	.  reduce 183 (src line 1529)
+	.  reduce 183 (src line 1533)
 
 
 state 207
@@ -1849,7 +1849,7 @@ state 207
 state 208
 	primary_exp:  IDENT.    (185)
 
-	.  reduce 185 (src line 1542)
+	.  reduce 185 (src line 1546)
 
 
 state 209
@@ -1907,7 +1907,7 @@ state 212
 	comma: .    (314)
 
 	','  shift 219
-	.  reduce 314 (src line 2424)
+	.  reduce 314 (src line 2428)
 
 	comma  goto 344
 
@@ -1929,7 +1929,7 @@ state 214
 	union_name: .    (284)
 
 	IDENT  shift 350
-	.  reduce 284 (src line 2203)
+	.  reduce 284 (src line 2207)
 
 	union_name  goto 349
 
@@ -2033,12 +2033,12 @@ state 219
 	SAFEARRAY  shift 132
 	PAD  shift 133
 	GOEXT_LAYOUT  shift 134
-	GOEXT_NULL_IF  shift 87
+	GOEXT_DEFAULT_NULL  shift 87
 	CALL_AS  shift 129
 	ANNOTATION  shift 128
 	WIRE_MARSHAL  shift 130
 	PUBLIC  shift 131
-	.  reduce 315 (src line 2425)
+	.  reduce 315 (src line 2429)
 
 	union_type_switch_attr  goto 94
 	attribute  goto 365
@@ -2061,7 +2061,7 @@ state 220
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2093,7 +2093,7 @@ state 221
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2125,7 +2125,7 @@ state 222
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2157,7 +2157,7 @@ state 223
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2189,7 +2189,7 @@ state 224
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2222,7 +2222,7 @@ state 225
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2242,7 +2242,7 @@ state 225
 	attr_var_list  goto 373
 
 state 226
-	attribute:  GOEXT_NULL_IF '('.attr_var ')' 
+	attribute:  GOEXT_DEFAULT_NULL '('.attr_var ')' 
 	attr_var: .    (338)
 
 	SIZEOF  shift 207
@@ -2254,7 +2254,7 @@ state 226
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2306,7 +2306,7 @@ state 228
 	ISO_UCS  shift 312
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	xmit_type  goto 382
 	simple_type_spec  goto 383
@@ -2378,7 +2378,7 @@ state 233
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2515,7 +2515,7 @@ state 240
 	UNION  shift 296
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -2581,7 +2581,7 @@ state 243
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -2611,7 +2611,7 @@ state 244
 	BOOLEAN  shift 305
 	ENUM  shift 409
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	switch_type_spec  goto 404
 	type_ident  goto 408
@@ -2627,7 +2627,7 @@ state 244
 state 245
 	range_attribute:  RANGE range_declarator.    (334)
 
-	.  reduce 334 (src line 2554)
+	.  reduce 334 (src line 2558)
 
 
 state 246
@@ -2662,7 +2662,7 @@ state 246
 state 247
 	import_list:  import_list ',' import_name.    (129)
 
-	.  reduce 129 (src line 1099)
+	.  reduce 129 (src line 1103)
 
 
 state 248
@@ -2682,7 +2682,7 @@ state 249
 	UNION  shift 29
 	PRAGMA_DEFINE  shift 21
 	PRAGMA_CPP_QUOTE  shift 22
-	'}'  reduce 116 (src line 1000)
+	'}'  reduce 116 (src line 1004)
 	'['  shift 33
 	.  reduce 46 (src line 677)
 
@@ -2705,13 +2705,13 @@ state 249
 state 250
 	interface_component1:  interface_component.    (117)
 
-	.  reduce 117 (src line 1009)
+	.  reduce 117 (src line 1013)
 
 
 state 251
 	interface_component:  export.    (122)
 
-	.  reduce 122 (src line 1063)
+	.  reduce 122 (src line 1067)
 
 
 state 252
@@ -2746,7 +2746,7 @@ state 253
 	TYPEDEF  shift 54
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	simple_type_spec  goto 414
 	type_ident  goto 278
@@ -2805,7 +2805,7 @@ state 259
 	comma: .    (314)
 
 	','  shift 417
-	.  reduce 314 (src line 2424)
+	.  reduce 314 (src line 2428)
 
 	comma  goto 416
 
@@ -2909,9 +2909,9 @@ state 272
 	pointer_opt0: .    (340)
 
 	'*'  shift 429
-	';'  reduce 199 (src line 1638)
-	','  reduce 199 (src line 1638)
-	.  reduce 340 (src line 2603)
+	';'  reduce 199 (src line 1642)
+	','  reduce 199 (src line 1642)
+	.  reduce 340 (src line 2607)
 
 	declarator  goto 426
 	declarators  goto 425
@@ -2923,7 +2923,7 @@ state 273
 	type_spec:  simple_type_spec.CONST 
 
 	CONST  shift 430
-	.  reduce 189 (src line 1583)
+	.  reduce 189 (src line 1587)
 
 
 state 274
@@ -2948,7 +2948,7 @@ state 274
 	ISO_UCS  shift 312
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	simple_type_spec  goto 431
 	type_ident  goto 278
@@ -2973,121 +2973,121 @@ state 274
 state 275
 	type_spec:  constructed_type_spec.    (192)
 
-	.  reduce 192 (src line 1595)
+	.  reduce 192 (src line 1599)
 
 
 state 276
 	simple_type_spec:  base_type_spec.    (193)
 
-	.  reduce 193 (src line 1601)
+	.  reduce 193 (src line 1605)
 
 
 state 277
 	simple_type_spec:  predefined_type_spec.    (194)
 
-	.  reduce 194 (src line 1605)
+	.  reduce 194 (src line 1609)
 
 
 state 278
 	simple_type_spec:  type_ident.    (195)
 
-	.  reduce 195 (src line 1609)
+	.  reduce 195 (src line 1613)
 
 
 state 279
 	constructed_type_spec:  struct_type.    (254)
 
-	.  reduce 254 (src line 1983)
+	.  reduce 254 (src line 1987)
 
 
 state 280
 	constructed_type_spec:  union_type.    (255)
 
-	.  reduce 255 (src line 1987)
+	.  reduce 255 (src line 1991)
 
 
 state 281
 	constructed_type_spec:  enumeration_type.    (256)
 
-	.  reduce 256 (src line 1991)
+	.  reduce 256 (src line 1995)
 
 
 state 282
 	constructed_type_spec:  tagged_declarator.    (257)
 
-	.  reduce 257 (src line 1995)
+	.  reduce 257 (src line 1999)
 
 
 state 283
 	constructed_type_spec:  pipe_type.    (258)
 
-	.  reduce 258 (src line 1999)
+	.  reduce 258 (src line 2003)
 
 
 state 284
 	base_type_spec:  floating_pt_type.    (210)
 
-	.  reduce 210 (src line 1708)
+	.  reduce 210 (src line 1712)
 
 
 state 285
 	base_type_spec:  integer_type.    (211)
 
-	.  reduce 211 (src line 1712)
+	.  reduce 211 (src line 1716)
 
 
 state 286
 	base_type_spec:  char_type.    (212)
 
-	.  reduce 212 (src line 1716)
+	.  reduce 212 (src line 1720)
 
 
 state 287
 	base_type_spec:  boolean_type.    (213)
 
-	.  reduce 213 (src line 1720)
+	.  reduce 213 (src line 1724)
 
 
 state 288
 	base_type_spec:  byte_type.    (214)
 
-	.  reduce 214 (src line 1724)
+	.  reduce 214 (src line 1728)
 
 
 state 289
 	base_type_spec:  void_type.    (215)
 
-	.  reduce 215 (src line 1728)
+	.  reduce 215 (src line 1732)
 
 
 state 290
 	base_type_spec:  handle_type.    (216)
 
-	.  reduce 216 (src line 1732)
+	.  reduce 216 (src line 1736)
 
 
 state 291
 	base_type_spec:  wchar_type.    (217)
 
-	.  reduce 217 (src line 1737)
+	.  reduce 217 (src line 1741)
 
 
 state 292
 	predefined_type_spec:  ERROR_STATUS_T.    (357)
 
-	.  reduce 357 (src line 2721)
+	.  reduce 357 (src line 2725)
 
 
 state 293
 	predefined_type_spec:  international_character_type.    (358)
 
-	.  reduce 358 (src line 2725)
+	.  reduce 358 (src line 2729)
 
 
 state 294
 	type_ident:  IDENT.    (196)
 
-	.  reduce 196 (src line 1615)
+	.  reduce 196 (src line 1619)
 
 
 state 295
@@ -3156,7 +3156,7 @@ state 298
 	UNION  shift 296
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -3194,19 +3194,19 @@ state 298
 state 299
 	floating_pt_type:  FLOAT.    (218)
 
-	.  reduce 218 (src line 1744)
+	.  reduce 218 (src line 1748)
 
 
 state 300
 	floating_pt_type:  DOUBLE.    (219)
 
-	.  reduce 219 (src line 1748)
+	.  reduce 219 (src line 1752)
 
 
 state 301
 	integer_type:  primitive_integer_type.    (220)
 
-	.  reduce 220 (src line 1754)
+	.  reduce 220 (src line 1758)
 
 
 state 302
@@ -3214,7 +3214,7 @@ state 302
 	unsigned: .    (245)
 
 	UNSIGNED  shift 438
-	.  reduce 245 (src line 1950)
+	.  reduce 245 (src line 1954)
 
 	unsigned  goto 437
 
@@ -3227,7 +3227,7 @@ state 303
 	LONG  shift 68
 	SHORT  shift 69
 	SMALL  shift 70
-	.  reduce 248 (src line 1964)
+	.  reduce 248 (src line 1968)
 
 	integer_size  goto 170
 
@@ -3253,49 +3253,49 @@ state 304
 state 305
 	boolean_type:  BOOLEAN.    (241)
 
-	.  reduce 241 (src line 1926)
+	.  reduce 241 (src line 1930)
 
 
 state 306
 	byte_type:  BYTE.    (242)
 
-	.  reduce 242 (src line 1932)
+	.  reduce 242 (src line 1936)
 
 
 state 307
 	void_type:  VOID.    (243)
 
-	.  reduce 243 (src line 1938)
+	.  reduce 243 (src line 1942)
 
 
 state 308
 	handle_type:  HANDLE_T.    (244)
 
-	.  reduce 244 (src line 1944)
+	.  reduce 244 (src line 1948)
 
 
 state 309
 	wchar_type:  WCHAR_T.    (240)
 
-	.  reduce 240 (src line 1919)
+	.  reduce 240 (src line 1923)
 
 
 state 310
 	international_character_type:  ISO_LATIN_1.    (359)
 
-	.  reduce 359 (src line 2740)
+	.  reduce 359 (src line 2744)
 
 
 state 311
 	international_character_type:  ISO_MULTILINGUAL.    (360)
 
-	.  reduce 360 (src line 2744)
+	.  reduce 360 (src line 2748)
 
 
 state 312
 	international_character_type:  ISO_UCS.    (361)
 
-	.  reduce 361 (src line 2748)
+	.  reduce 361 (src line 2752)
 
 
 state 313
@@ -3336,19 +3336,19 @@ state 313
 state 314
 	unsigned_integer:  UNSIGNED integer_size int.    (229)
 
-	.  reduce 229 (src line 1822)
+	.  reduce 229 (src line 1826)
 
 
 state 315
 	signed_integer:  SIGNED integer_size int.    (226)
 
-	.  reduce 226 (src line 1787)
+	.  reduce 226 (src line 1791)
 
 
 state 316
 	unsigned_integer:  integer_size UNSIGNED int.    (228)
 
-	.  reduce 228 (src line 1811)
+	.  reduce 228 (src line 1815)
 
 
 state 317
@@ -3750,25 +3750,25 @@ state 335
 state 336
 	unary_exp:  '+' primary_exp.    (179)
 
-	.  reduce 179 (src line 1491)
+	.  reduce 179 (src line 1495)
 
 
 state 337
 	unary_exp:  '-' primary_exp.    (180)
 
-	.  reduce 180 (src line 1500)
+	.  reduce 180 (src line 1504)
 
 
 state 338
 	unary_exp:  '~' primary_exp.    (181)
 
-	.  reduce 181 (src line 1509)
+	.  reduce 181 (src line 1513)
 
 
 state 339
 	unary_exp:  '!' primary_exp.    (182)
 
-	.  reduce 182 (src line 1518)
+	.  reduce 182 (src line 1522)
 
 
 state 340
@@ -3798,7 +3798,7 @@ state 340
 	UNION  shift 296
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -3836,7 +3836,7 @@ state 340
 state 341
 	primary_exp:  '*' IDENT.    (186)
 
-	.  reduce 186 (src line 1550)
+	.  reduce 186 (src line 1554)
 
 
 state 342
@@ -3849,7 +3849,7 @@ state 342
 state 343
 	pragma_declarator:  PRAGMA_CPP_QUOTE '(' STRING_LITERAL ')'.    (133)
 
-	.  reduce 133 (src line 1151)
+	.  reduce 133 (src line 1155)
 
 
 state 344
@@ -3876,7 +3876,7 @@ state 345
 state 346
 	member_list:  member.    (264)
 
-	.  reduce 264 (src line 2050)
+	.  reduce 264 (src line 2054)
 
 
 state 347
@@ -3913,7 +3913,7 @@ state 348
 	UNION  shift 296
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -3958,7 +3958,7 @@ state 349
 state 350
 	union_name:  IDENT.    (285)
 
-	.  reduce 285 (src line 2210)
+	.  reduce 285 (src line 2214)
 
 
 state 351
@@ -3991,13 +3991,13 @@ state 352
 state 353
 	union_body_n_e:  union_case_n_e.    (290)
 
-	.  reduce 290 (src line 2236)
+	.  reduce 290 (src line 2240)
 
 
 state 354
 	union_body_c:  union_arm.    (288)
 
-	.  reduce 288 (src line 2226)
+	.  reduce 288 (src line 2230)
 
 
 state 355
@@ -4016,13 +4016,13 @@ state 355
 state 356
 	union_case_n_e:  default_case_n_e.    (297)
 
-	.  reduce 297 (src line 2278)
+	.  reduce 297 (src line 2282)
 
 
 state 357
 	union_arm:  ';'.    (304)
 
-	.  reduce 304 (src line 2319)
+	.  reduce 304 (src line 2323)
 
 
 state 358
@@ -4093,7 +4093,7 @@ state 359
 	SAFEARRAY  shift 132
 	PAD  shift 133
 	GOEXT_LAYOUT  shift 134
-	GOEXT_NULL_IF  shift 87
+	GOEXT_DEFAULT_NULL  shift 87
 	CALL_AS  shift 129
 	ANNOTATION  shift 128
 	WIRE_MARSHAL  shift 130
@@ -4121,7 +4121,7 @@ state 360
 	BOOLEAN  shift 305
 	ENUM  shift 409
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	switch_type_spec  goto 478
 	type_ident  goto 408
@@ -4140,14 +4140,14 @@ state 361
 	comma: .    (314)
 
 	','  shift 480
-	.  reduce 314 (src line 2424)
+	.  reduce 314 (src line 2428)
 
 	comma  goto 479
 
 state 362
 	enumeration1:  identifier_tag.    (312)
 
-	.  reduce 312 (src line 2414)
+	.  reduce 312 (src line 2418)
 
 
 state 363
@@ -4155,7 +4155,7 @@ state 363
 	identifier_tag:  IDENT.'=' integer_const_exp 
 
 	'='  shift 481
-	.  reduce 316 (src line 2428)
+	.  reduce 316 (src line 2432)
 
 
 state 364
@@ -4182,13 +4182,13 @@ state 366
 state 367
 	attr_var_list:  attr_var.    (336)
 
-	.  reduce 336 (src line 2581)
+	.  reduce 336 (src line 2585)
 
 
 state 368
 	attr_var:  integer_const_exp.    (339)
 
-	.  reduce 339 (src line 2597)
+	.  reduce 339 (src line 2601)
 
 
 state 369
@@ -4246,7 +4246,7 @@ state 374
 
 
 state 375
-	attribute:  GOEXT_NULL_IF '(' attr_var.')' 
+	attribute:  GOEXT_DEFAULT_NULL '(' attr_var.')' 
 
 	')'  shift 490
 	.  error
@@ -4262,31 +4262,31 @@ state 376
 state 377
 	format_attribute:  FORMAT_UTF8.    (328)
 
-	.  reduce 328 (src line 2526)
+	.  reduce 328 (src line 2530)
 
 
 state 378
 	format_attribute:  FORMAT_NULL_TERMINATED.    (329)
 
-	.  reduce 329 (src line 2530)
+	.  reduce 329 (src line 2534)
 
 
 state 379
 	format_attribute:  FORMAT_MULTI_SIZE.    (330)
 
-	.  reduce 330 (src line 2534)
+	.  reduce 330 (src line 2538)
 
 
 state 380
 	format_attribute:  FORMAT_RUNE.    (331)
 
-	.  reduce 331 (src line 2538)
+	.  reduce 331 (src line 2542)
 
 
 state 381
 	format_attribute:  FORMAT_HEX.    (332)
 
-	.  reduce 332 (src line 2542)
+	.  reduce 332 (src line 2546)
 
 
 state 382
@@ -4299,7 +4299,7 @@ state 382
 state 383
 	xmit_type:  simple_type_spec.    (333)
 
-	.  reduce 333 (src line 2548)
+	.  reduce 333 (src line 2552)
 
 
 state 384
@@ -4314,7 +4314,7 @@ state 385
 	version:  INT_LITERAL.'.' INT_LITERAL 
 
 	'.'  shift 494
-	.  reduce 108 (src line 958)
+	.  reduce 108 (src line 962)
 
 
 state 386
@@ -4329,13 +4329,13 @@ state 386
 state 387
 	port_spec1:  port_spec.    (110)
 
-	.  reduce 110 (src line 968)
+	.  reduce 110 (src line 972)
 
 
 state 388
 	port_spec:  STRING_LITERAL.    (114)
 
-	.  reduce 114 (src line 988)
+	.  reduce 114 (src line 992)
 
 
 state 389
@@ -4350,13 +4350,13 @@ state 389
 state 390
 	excep_name1:  excep_name.    (112)
 
-	.  reduce 112 (src line 978)
+	.  reduce 112 (src line 982)
 
 
 state 391
 	excep_name:  IDENT.    (115)
 
-	.  reduce 115 (src line 994)
+	.  reduce 115 (src line 998)
 
 
 state 392
@@ -4453,25 +4453,25 @@ state 404
 state 405
 	switch_type_spec:  primitive_integer_type.    (276)
 
-	.  reduce 276 (src line 2138)
+	.  reduce 276 (src line 2142)
 
 
 state 406
 	switch_type_spec:  char_type.    (277)
 
-	.  reduce 277 (src line 2142)
+	.  reduce 277 (src line 2146)
 
 
 state 407
 	switch_type_spec:  boolean_type.    (278)
 
-	.  reduce 278 (src line 2146)
+	.  reduce 278 (src line 2150)
 
 
 state 408
 	switch_type_spec:  type_ident.    (279)
 
-	.  reduce 279 (src line 2150)
+	.  reduce 279 (src line 2154)
 
 
 state 409
@@ -4489,7 +4489,7 @@ state 410
 	LONG  shift 68
 	SHORT  shift 69
 	SMALL  shift 70
-	.  reduce 248 (src line 1964)
+	.  reduce 248 (src line 1968)
 
 	integer_size  goto 170
 
@@ -4503,13 +4503,13 @@ state 411
 state 412
 	interface_component1:  interface_component1 interface_component.    (118)
 
-	.  reduce 118 (src line 1020)
+	.  reduce 118 (src line 1024)
 
 
 state 413
 	interface_component:  op_declarator ';'.    (123)
 
-	.  reduce 123 (src line 1071)
+	.  reduce 123 (src line 1075)
 
 
 state 414
@@ -4540,7 +4540,7 @@ state 417
 
 	DEFAULT  shift 261
 	SOURCE  shift 262
-	.  reduce 315 (src line 2425)
+	.  reduce 315 (src line 2429)
 
 	coclass_attribute  goto 517
 
@@ -4611,7 +4611,7 @@ state 422
 	ISO_UCS  shift 312
 	WCHAR_T  shift 309
 	IDENT  shift 294
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	simple_type_spec  goto 414
 	type_ident  goto 278
@@ -4650,13 +4650,13 @@ state 425
 	declarators:  declarators.',' declarator 
 
 	','  shift 520
-	.  reduce 188 (src line 1565)
+	.  reduce 188 (src line 1569)
 
 
 state 426
 	declarators:  declarator.    (197)
 
-	.  reduce 197 (src line 1629)
+	.  reduce 197 (src line 1633)
 
 
 state 427
@@ -4677,25 +4677,25 @@ state 428
 	pointer_opt:  pointer_opt.'*' 
 
 	'*'  shift 528
-	.  reduce 341 (src line 2607)
+	.  reduce 341 (src line 2611)
 
 
 state 429
 	pointer_opt:  '*'.    (342)
 
-	.  reduce 342 (src line 2613)
+	.  reduce 342 (src line 2617)
 
 
 state 430
 	type_spec:  simple_type_spec CONST.    (191)
 
-	.  reduce 191 (src line 1591)
+	.  reduce 191 (src line 1595)
 
 
 state 431
 	type_spec:  CONST simple_type_spec.    (190)
 
-	.  reduce 190 (src line 1587)
+	.  reduce 190 (src line 1591)
 
 
 state 432
@@ -4716,7 +4716,7 @@ state 433
 	union_name: .    (284)
 
 	IDENT  shift 350
-	.  reduce 284 (src line 2203)
+	.  reduce 284 (src line 2207)
 
 	union_name  goto 530
 
@@ -4751,7 +4751,7 @@ state 435
 state 436
 	pipe_type:  PIPE type_spec.    (318)
 
-	.  reduce 318 (src line 2440)
+	.  reduce 318 (src line 2444)
 
 
 state 437
@@ -4759,14 +4759,14 @@ state 437
 	int: .    (252)
 
 	INT  shift 175
-	.  reduce 252 (src line 1978)
+	.  reduce 252 (src line 1982)
 
 	int  goto 534
 
 state 438
 	unsigned:  UNSIGNED.    (246)
 
-	.  reduce 246 (src line 1954)
+	.  reduce 246 (src line 1958)
 
 
 state 439
@@ -4774,20 +4774,20 @@ state 439
 	int: .    (252)
 
 	INT  shift 175
-	.  reduce 252 (src line 1978)
+	.  reduce 252 (src line 1982)
 
 	int  goto 535
 
 state 440
 	char_type:  sign CHAR.    (239)
 
-	.  reduce 239 (src line 1907)
+	.  reduce 239 (src line 1911)
 
 
 state 441
 	const_declarator:  CONST const_type_spec IDENT '=' const_exp.    (131)
 
-	.  reduce 131 (src line 1111)
+	.  reduce 131 (src line 1115)
 
 
 state 442
@@ -4802,7 +4802,7 @@ state 443
 	logical_and_exp:  logical_and_exp.LOGICAL_AND inclusive_or_exp 
 
 	LOGICAL_AND  shift 319
-	.  reduce 151 (src line 1269)
+	.  reduce 151 (src line 1273)
 
 
 state 444
@@ -4810,7 +4810,7 @@ state 444
 	inclusive_or_exp:  inclusive_or_exp.OR exclusive_or_exp 
 
 	OR  shift 320
-	.  reduce 153 (src line 1284)
+	.  reduce 153 (src line 1288)
 
 
 state 445
@@ -4818,7 +4818,7 @@ state 445
 	exclusive_or_exp:  exclusive_or_exp.XOR and_exp 
 
 	XOR  shift 321
-	.  reduce 155 (src line 1299)
+	.  reduce 155 (src line 1303)
 
 
 state 446
@@ -4826,7 +4826,7 @@ state 446
 	and_exp:  and_exp.AND equality_exp 
 
 	AND  shift 322
-	.  reduce 157 (src line 1314)
+	.  reduce 157 (src line 1318)
 
 
 state 447
@@ -4836,7 +4836,7 @@ state 447
 
 	EQ  shift 323
 	NE  shift 324
-	.  reduce 159 (src line 1329)
+	.  reduce 159 (src line 1333)
 
 
 state 448
@@ -4850,7 +4850,7 @@ state 448
 	GE  shift 328
 	LT  shift 325
 	GT  shift 326
-	.  reduce 161 (src line 1344)
+	.  reduce 161 (src line 1348)
 
 
 state 449
@@ -4864,7 +4864,7 @@ state 449
 	GE  shift 328
 	LT  shift 325
 	GT  shift 326
-	.  reduce 162 (src line 1353)
+	.  reduce 162 (src line 1357)
 
 
 state 450
@@ -4874,7 +4874,7 @@ state 450
 
 	LSH  shift 329
 	RSH  shift 330
-	.  reduce 164 (src line 1368)
+	.  reduce 164 (src line 1372)
 
 
 state 451
@@ -4884,7 +4884,7 @@ state 451
 
 	LSH  shift 329
 	RSH  shift 330
-	.  reduce 165 (src line 1377)
+	.  reduce 165 (src line 1381)
 
 
 state 452
@@ -4894,7 +4894,7 @@ state 452
 
 	LSH  shift 329
 	RSH  shift 330
-	.  reduce 166 (src line 1386)
+	.  reduce 166 (src line 1390)
 
 
 state 453
@@ -4904,7 +4904,7 @@ state 453
 
 	LSH  shift 329
 	RSH  shift 330
-	.  reduce 167 (src line 1395)
+	.  reduce 167 (src line 1399)
 
 
 state 454
@@ -4914,7 +4914,7 @@ state 454
 
 	'+'  shift 332
 	'-'  shift 331
-	.  reduce 169 (src line 1410)
+	.  reduce 169 (src line 1414)
 
 
 state 455
@@ -4924,7 +4924,7 @@ state 455
 
 	'+'  shift 332
 	'-'  shift 331
-	.  reduce 170 (src line 1419)
+	.  reduce 170 (src line 1423)
 
 
 state 456
@@ -4936,7 +4936,7 @@ state 456
 	'*'  shift 333
 	'/'  shift 334
 	'%'  shift 335
-	.  reduce 172 (src line 1434)
+	.  reduce 172 (src line 1438)
 
 
 state 457
@@ -4948,25 +4948,25 @@ state 457
 	'*'  shift 333
 	'/'  shift 334
 	'%'  shift 335
-	.  reduce 173 (src line 1443)
+	.  reduce 173 (src line 1447)
 
 
 state 458
 	multiplicative_exp:  multiplicative_exp '*' unary_exp.    (175)
 
-	.  reduce 175 (src line 1458)
+	.  reduce 175 (src line 1462)
 
 
 state 459
 	multiplicative_exp:  multiplicative_exp '/' unary_exp.    (176)
 
-	.  reduce 176 (src line 1467)
+	.  reduce 176 (src line 1471)
 
 
 state 460
 	multiplicative_exp:  multiplicative_exp '%' unary_exp.    (177)
 
-	.  reduce 177 (src line 1476)
+	.  reduce 177 (src line 1480)
 
 
 state 461
@@ -4979,7 +4979,7 @@ state 461
 state 462
 	primary_exp:  '(' const_exp ')'.    (187)
 
-	.  reduce 187 (src line 1559)
+	.  reduce 187 (src line 1563)
 
 
 state 463
@@ -4991,19 +4991,19 @@ state 463
 state 464
 	tagged_struct:  STRUCT tag '{' member_list '}'.    (262)
 
-	.  reduce 262 (src line 2033)
+	.  reduce 262 (src line 2037)
 
 
 state 465
 	member_list:  member_list member.    (265)
 
-	.  reduce 265 (src line 2054)
+	.  reduce 265 (src line 2058)
 
 
 state 466
 	member:  field_declarator ';'.    (266)
 
-	.  reduce 266 (src line 2060)
+	.  reduce 266 (src line 2064)
 
 
 state 467
@@ -5011,11 +5011,11 @@ state 467
 	declarators: .    (199)
 	pointer_opt0: .    (340)
 
-	error  reduce 340 (src line 2603)
-	IDENT  reduce 340 (src line 2603)
+	error  reduce 340 (src line 2607)
+	IDENT  reduce 340 (src line 2607)
 	'*'  shift 429
-	'('  reduce 340 (src line 2603)
-	.  reduce 199 (src line 1638)
+	'('  reduce 340 (src line 2607)
+	.  reduce 199 (src line 1642)
 
 	declarator  goto 426
 	declarators  goto 538
@@ -5038,13 +5038,13 @@ state 468
 state 469
 	tagged_union:  UNION tag '{' union_body_n_e '}'.    (282)
 
-	.  reduce 282 (src line 2179)
+	.  reduce 282 (src line 2183)
 
 
 state 470
 	union_body_n_e:  union_body_n_e union_case_n_e.    (291)
 
-	.  reduce 291 (src line 2240)
+	.  reduce 291 (src line 2244)
 
 
 state 471
@@ -5059,25 +5059,25 @@ state 471
 state 472
 	tagged_union:  UNION tag '{' union_body_c '}'.    (283)
 
-	.  reduce 283 (src line 2190)
+	.  reduce 283 (src line 2194)
 
 
 state 473
 	union_body_c:  union_body_c union_arm.    (289)
 
-	.  reduce 289 (src line 2230)
+	.  reduce 289 (src line 2234)
 
 
 state 474
 	union_case_n_e:  union_case_label_n_e union_arm.    (296)
 
-	.  reduce 296 (src line 2270)
+	.  reduce 296 (src line 2274)
 
 
 state 475
 	union_arm:  field_declarator ';'.    (305)
 
-	.  reduce 305 (src line 2323)
+	.  reduce 305 (src line 2327)
 
 
 state 476
@@ -5113,7 +5113,7 @@ state 480
 	comma:  ','.    (315)
 
 	IDENT  shift 363
-	.  reduce 315 (src line 2425)
+	.  reduce 315 (src line 2429)
 
 	identifier_tag  goto 550
 
@@ -5165,7 +5165,7 @@ state 483
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -5216,11 +5216,11 @@ state 488
 state 489
 	attribute:  SIZE_IS '(' '*' ')'.    (107)
 
-	.  reduce 107 (src line 952)
+	.  reduce 107 (src line 956)
 
 
 state 490
-	attribute:  GOEXT_NULL_IF '(' attr_var ')'.    (59)
+	attribute:  GOEXT_DEFAULT_NULL '(' attr_var ')'.    (59)
 
 	.  reduce 59 (src line 736)
 
@@ -5228,19 +5228,19 @@ state 490
 state 491
 	attribute:  FORMAT '(' format_attribute ')'.    (61)
 
-	.  reduce 61 (src line 744)
+	.  reduce 61 (src line 748)
 
 
 state 492
 	attribute:  TRANSMIT_AS '(' xmit_type ')'.    (65)
 
-	.  reduce 65 (src line 760)
+	.  reduce 65 (src line 764)
 
 
 state 493
 	attribute:  VERSION '(' version ')'.    (73)
 
-	.  reduce 73 (src line 792)
+	.  reduce 73 (src line 796)
 
 
 state 494
@@ -5253,7 +5253,7 @@ state 494
 state 495
 	attribute:  ENDPOINT '(' port_spec1 ')'.    (74)
 
-	.  reduce 74 (src line 796)
+	.  reduce 74 (src line 800)
 
 
 state 496
@@ -5267,7 +5267,7 @@ state 496
 state 497
 	attribute:  EXCEPTIONS '(' excep_name1 ')'.    (75)
 
-	.  reduce 75 (src line 800)
+	.  reduce 75 (src line 804)
 
 
 state 498
@@ -5281,85 +5281,85 @@ state 498
 state 499
 	attribute:  POINTER_DEFAULT '(' ptr_attr ')'.    (77)
 
-	.  reduce 77 (src line 808)
+	.  reduce 77 (src line 812)
 
 
 state 500
 	attribute:  IID_IS '(' attr_var ')'.    (85)
 
-	.  reduce 85 (src line 847)
+	.  reduce 85 (src line 851)
 
 
 state 501
 	attribute:  HELP_STRING '(' STRING_LITERAL ')'.    (86)
 
-	.  reduce 86 (src line 851)
+	.  reduce 86 (src line 855)
 
 
 state 502
 	attribute:  ID '(' integer_const_exp ')'.    (91)
 
-	.  reduce 91 (src line 871)
+	.  reduce 91 (src line 875)
 
 
 state 503
 	attribute:  DEFAULT_VALUE '(' const_exp ')'.    (95)
 
-	.  reduce 95 (src line 896)
+	.  reduce 95 (src line 900)
 
 
 state 504
 	attribute:  ANNOTATION '(' STRING_LITERAL ')'.    (100)
 
-	.  reduce 100 (src line 921)
+	.  reduce 100 (src line 925)
 
 
 state 505
 	attribute:  CALL_AS '(' IDENT ')'.    (101)
 
-	.  reduce 101 (src line 925)
+	.  reduce 101 (src line 929)
 
 
 state 506
 	attribute:  WIRE_MARSHAL '(' IDENT ')'.    (102)
 
-	.  reduce 102 (src line 929)
+	.  reduce 102 (src line 933)
 
 
 state 507
 	attribute:  SAFEARRAY '(' type_spec ')'.    (104)
 
-	.  reduce 104 (src line 937)
+	.  reduce 104 (src line 941)
 
 
 state 508
 	attribute:  PAD '(' INT_LITERAL ')'.    (105)
 
-	.  reduce 105 (src line 941)
+	.  reduce 105 (src line 945)
 
 
 state 509
 	attribute:  GOEXT_LAYOUT '(' field_declarator ')'.    (106)
 
-	.  reduce 106 (src line 945)
+	.  reduce 106 (src line 949)
 
 
 state 510
 	union_instance_switch_attr:  SWITCH_IS '(' attr_var ')'.    (307)
 
-	.  reduce 307 (src line 2338)
+	.  reduce 307 (src line 2342)
 
 
 state 511
 	union_type_switch_attr:  SWITCH_TYPE '(' switch_type_spec ')'.    (306)
 
-	.  reduce 306 (src line 2332)
+	.  reduce 306 (src line 2336)
 
 
 state 512
 	switch_type_spec:  ENUM tag.    (280)
 
-	.  reduce 280 (src line 2155)
+	.  reduce 280 (src line 2159)
 
 
 state 513
@@ -5435,7 +5435,7 @@ state 520
 	pointer_opt0: .    (340)
 
 	'*'  shift 429
-	.  reduce 340 (src line 2603)
+	.  reduce 340 (src line 2607)
 
 	declarator  goto 559
 	pointer_opt  goto 428
@@ -5449,13 +5449,13 @@ state 521
 
 	'['  shift 560
 	'('  shift 561
-	.  reduce 200 (src line 1644)
+	.  reduce 200 (src line 1648)
 
 
 state 522
 	direct_declarator:  ident_or_keyword.    (201)
 
-	.  reduce 201 (src line 1653)
+	.  reduce 201 (src line 1657)
 
 
 state 523
@@ -5463,7 +5463,7 @@ state 523
 	pointer_opt0: .    (340)
 
 	'*'  shift 429
-	.  reduce 340 (src line 2603)
+	.  reduce 340 (src line 2607)
 
 	declarator  goto 562
 	pointer_opt  goto 428
@@ -5472,31 +5472,31 @@ state 523
 state 524
 	direct_declarator:  array_declarator.    (203)
 
-	.  reduce 203 (src line 1661)
+	.  reduce 203 (src line 1665)
 
 
 state 525
 	direct_declarator:  function_declarator.    (204)
 
-	.  reduce 204 (src line 1665)
+	.  reduce 204 (src line 1669)
 
 
 state 526
 	ident_or_keyword:  IDENT.    (205)
 
-	.  reduce 205 (src line 1671)
+	.  reduce 205 (src line 1675)
 
 
 state 527
 	ident_or_keyword:  error.    (206)
 
-	.  reduce 206 (src line 1675)
+	.  reduce 206 (src line 1679)
 
 
 state 528
 	pointer_opt:  pointer_opt '*'.    (343)
 
-	.  reduce 343 (src line 2617)
+	.  reduce 343 (src line 2621)
 
 
 state 529
@@ -5553,20 +5553,20 @@ state 533
 	comma: .    (314)
 
 	','  shift 480
-	.  reduce 314 (src line 2424)
+	.  reduce 314 (src line 2428)
 
 	comma  goto 567
 
 state 534
 	integer_type:  HYPER unsigned int.    (221)
 
-	.  reduce 221 (src line 1758)
+	.  reduce 221 (src line 1762)
 
 
 state 535
 	integer_type:  UNSIGNED HYPER int.    (222)
 
-	.  reduce 222 (src line 1767)
+	.  reduce 222 (src line 1771)
 
 
 state 536
@@ -5600,7 +5600,7 @@ state 536
 state 537
 	primary_exp:  SIZEOF '(' type_spec ')'.    (184)
 
-	.  reduce 184 (src line 1533)
+	.  reduce 184 (src line 1537)
 
 
 state 538
@@ -5610,7 +5610,7 @@ state 538
 
 	','  shift 520
 	'='  shift 570
-	.  reduce 268 (src line 2077)
+	.  reduce 268 (src line 2081)
 
 	field_attr_var  goto 569
 
@@ -5631,7 +5631,7 @@ state 539
 state 540
 	union_body:  union_case.    (286)
 
-	.  reduce 286 (src line 2216)
+	.  reduce 286 (src line 2220)
 
 
 state 541
@@ -5653,13 +5653,13 @@ state 541
 state 542
 	union_case:  default_case.    (293)
 
-	.  reduce 293 (src line 2254)
+	.  reduce 293 (src line 2258)
 
 
 state 543
 	union_case_label1:  union_case_label.    (294)
 
-	.  reduce 294 (src line 2260)
+	.  reduce 294 (src line 2264)
 
 
 state 544
@@ -5763,43 +5763,43 @@ state 548
 state 549
 	tagged_enumeration:  ENUM tag '{' enumeration1 comma '}'.    (311)
 
-	.  reduce 311 (src line 2384)
+	.  reduce 311 (src line 2388)
 
 
 state 550
 	enumeration1:  enumeration1 ',' identifier_tag.    (313)
 
-	.  reduce 313 (src line 2418)
+	.  reduce 313 (src line 2422)
 
 
 state 551
 	identifier_tag:  IDENT '=' integer_const_exp.    (317)
 
-	.  reduce 317 (src line 2433)
+	.  reduce 317 (src line 2437)
 
 
 state 552
 	attr_var_list:  attr_var_list ',' attr_var.    (337)
 
-	.  reduce 337 (src line 2585)
+	.  reduce 337 (src line 2589)
 
 
 state 553
 	version:  INT_LITERAL '.' INT_LITERAL.    (109)
 
-	.  reduce 109 (src line 962)
+	.  reduce 109 (src line 966)
 
 
 state 554
 	port_spec1:  port_spec1 ',' port_spec.    (111)
 
-	.  reduce 111 (src line 972)
+	.  reduce 111 (src line 976)
 
 
 state 555
 	excep_name1:  excep_name1 ',' excep_name.    (113)
 
-	.  reduce 113 (src line 982)
+	.  reduce 113 (src line 986)
 
 
 state 556
@@ -5839,8 +5839,8 @@ state 557
 	WCHAR_T  shift 309
 	IDENT  shift 294
 	'['  shift 33
-	')'  reduce 250 (src line 1974)
-	.  reduce 247 (src line 1960)
+	')'  reduce 250 (src line 1978)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -5888,7 +5888,7 @@ state 558
 state 559
 	declarators:  declarators ',' declarator.    (198)
 
-	.  reduce 198 (src line 1633)
+	.  reduce 198 (src line 1637)
 
 
 state 560
@@ -5904,7 +5904,7 @@ state 560
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 320 (src line 2472)
+	.  reduce 320 (src line 2476)
 
 	integer_const_exp  goto 592
 	conditional_exp  goto 189
@@ -5954,8 +5954,8 @@ state 561
 	WCHAR_T  shift 309
 	IDENT  shift 294
 	'['  shift 33
-	')'  reduce 250 (src line 1974)
-	.  reduce 247 (src line 1960)
+	')'  reduce 250 (src line 1978)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -6004,7 +6004,7 @@ state 562
 state 563
 	struct_type:  STRUCT '{' member_list '}'.    (261)
 
-	.  reduce 261 (src line 2022)
+	.  reduce 261 (src line 2026)
 
 
 state 564
@@ -6023,13 +6023,13 @@ state 564
 state 565
 	union_type:  UNION '{' union_body_n_e '}'.    (273)
 
-	.  reduce 273 (src line 2108)
+	.  reduce 273 (src line 2112)
 
 
 state 566
 	union_type:  UNION '{' union_body_c '}'.    (274)
 
-	.  reduce 274 (src line 2119)
+	.  reduce 274 (src line 2123)
 
 
 state 567
@@ -6042,13 +6042,13 @@ state 567
 state 568
 	conditional_exp:  logical_or_exp '?' integer_const_exp ':' conditional_exp.    (149)
 
-	.  reduce 149 (src line 1254)
+	.  reduce 149 (src line 1258)
 
 
 state 569
 	field_declarator:  attributes0 type_spec declarators field_attr_var.    (267)
 
-	.  reduce 267 (src line 2066)
+	.  reduce 267 (src line 2070)
 
 
 state 570
@@ -6064,7 +6064,7 @@ state 570
 	'('  shift 210
 	'~'  shift 204
 	'!'  shift 205
-	.  reduce 338 (src line 2593)
+	.  reduce 338 (src line 2597)
 
 	integer_const_exp  goto 368
 	conditional_exp  goto 189
@@ -6085,25 +6085,25 @@ state 570
 state 571
 	tagged_union:  UNION tag union_switch union_name '{' union_body '}'.    (281)
 
-	.  reduce 281 (src line 2168)
+	.  reduce 281 (src line 2172)
 
 
 state 572
 	union_body:  union_body union_case.    (287)
 
-	.  reduce 287 (src line 2220)
+	.  reduce 287 (src line 2224)
 
 
 state 573
 	union_case:  union_case_label1 union_arm.    (292)
 
-	.  reduce 292 (src line 2246)
+	.  reduce 292 (src line 2250)
 
 
 state 574
 	union_case_label1:  union_case_label1 union_case_label.    (295)
 
-	.  reduce 295 (src line 2264)
+	.  reduce 295 (src line 2268)
 
 
 state 575
@@ -6138,25 +6138,25 @@ state 577
 state 578
 	const_exp1:  const_exp.    (300)
 
-	.  reduce 300 (src line 2296)
+	.  reduce 300 (src line 2300)
 
 
 state 579
 	default_case_n_e:  '[' DEFAULT ']' union_arm.    (303)
 
-	.  reduce 303 (src line 2313)
+	.  reduce 303 (src line 2317)
 
 
 state 580
 	union_switch:  SWITCH '(' switch_type_spec IDENT ')'.    (275)
 
-	.  reduce 275 (src line 2132)
+	.  reduce 275 (src line 2136)
 
 
 state 581
 	range_declarator:  '(' integer_const_exp ',' integer_const_exp ')'.    (335)
 
-	.  reduce 335 (src line 2560)
+	.  reduce 335 (src line 2564)
 
 
 state 582
@@ -6178,15 +6178,15 @@ state 583
 state 584
 	param_declarators1:  param_declarator.    (350)
 
-	.  reduce 350 (src line 2663)
+	.  reduce 350 (src line 2667)
 
 
 state 585
 	void_type:  VOID.    (243)
 	void:  VOID.    (251)
 
-	')'  reduce 251 (src line 1975)
-	.  reduce 243 (src line 1938)
+	')'  reduce 251 (src line 1979)
+	.  reduce 243 (src line 1942)
 
 
 state 586
@@ -6218,7 +6218,7 @@ state 586
 	WCHAR_T  shift 309
 	IDENT  shift 294
 	'['  shift 73
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -6258,7 +6258,7 @@ state 587
 	pointer_opt0: .    (340)
 
 	'*'  shift 429
-	.  reduce 340 (src line 2603)
+	.  reduce 340 (src line 2607)
 
 	declarator  goto 607
 	pointer_opt  goto 428
@@ -6276,13 +6276,13 @@ state 589
 	array_bound_pair:  array_bound.RNG array_bound 
 
 	RNG  shift 609
-	.  reduce 321 (src line 2476)
+	.  reduce 321 (src line 2480)
 
 
 state 590
 	array_bounds_declarator:  array_bound_pair.    (322)
 
-	.  reduce 322 (src line 2485)
+	.  reduce 322 (src line 2489)
 
 
 state 591
@@ -6290,13 +6290,13 @@ state 591
 	array_bound:  '*'.    (324)
 
 	IDENT  shift 341
-	.  reduce 324 (src line 2497)
+	.  reduce 324 (src line 2501)
 
 
 state 592
 	array_bound:  integer_const_exp.    (325)
 
-	.  reduce 325 (src line 2501)
+	.  reduce 325 (src line 2505)
 
 
 state 593
@@ -6318,7 +6318,7 @@ state 594
 state 595
 	direct_declarator:  '(' declarator ')'.    (202)
 
-	.  reduce 202 (src line 1657)
+	.  reduce 202 (src line 1661)
 
 
 state 596
@@ -6338,25 +6338,25 @@ state 596
 state 597
 	enumeration_type:  ENUM '{' enumeration1 comma '}'.    (308)
 
-	.  reduce 308 (src line 2344)
+	.  reduce 308 (src line 2348)
 
 
 state 598
 	field_attr_var:  '=' attr_var.    (269)
 
-	.  reduce 269 (src line 2081)
+	.  reduce 269 (src line 2085)
 
 
 state 599
 	default_case:  DEFAULT ':' union_arm.    (302)
 
-	.  reduce 302 (src line 2307)
+	.  reduce 302 (src line 2311)
 
 
 state 600
 	union_case_label:  CASE const_exp ':'.    (298)
 
-	.  reduce 298 (src line 2284)
+	.  reduce 298 (src line 2288)
 
 
 state 601
@@ -6404,7 +6404,7 @@ state 602
 state 603
 	op_declarator:  attributes0 simple_type_spec IDENT '(' param_declarators1 ')'.    (347)
 
-	.  reduce 347 (src line 2641)
+	.  reduce 347 (src line 2645)
 
 
 state 604
@@ -6435,7 +6435,7 @@ state 604
 	WCHAR_T  shift 309
 	IDENT  shift 294
 	'['  shift 33
-	.  reduce 247 (src line 1960)
+	.  reduce 247 (src line 1964)
 
 	struct_type  goto 279
 	union_type  goto 280
@@ -6475,7 +6475,7 @@ state 604
 state 605
 	op_declarator:  attributes0 simple_type_spec IDENT '(' void ')'.    (348)
 
-	.  reduce 348 (src line 2653)
+	.  reduce 348 (src line 2657)
 
 
 state 606
@@ -6483,7 +6483,7 @@ state 606
 	pointer_opt0: .    (340)
 
 	'*'  shift 429
-	.  reduce 340 (src line 2603)
+	.  reduce 340 (src line 2607)
 
 	declarator  goto 616
 	pointer_opt  goto 428
@@ -6492,13 +6492,13 @@ state 606
 state 607
 	param_declarator:  type_spec declarator.    (352)
 
-	.  reduce 352 (src line 2683)
+	.  reduce 352 (src line 2687)
 
 
 state 608
 	array_declarator:  direct_declarator '[' array_bounds_declarator ']'.    (319)
 
-	.  reduce 319 (src line 2446)
+	.  reduce 319 (src line 2450)
 
 
 state 609
@@ -6534,49 +6534,49 @@ state 609
 state 610
 	function_declarator:  direct_declarator '(' param_declarators1 ')'.    (355)
 
-	.  reduce 355 (src line 2701)
+	.  reduce 355 (src line 2705)
 
 
 state 611
 	function_declarator:  direct_declarator '(' void ')'.    (356)
 
-	.  reduce 356 (src line 2710)
+	.  reduce 356 (src line 2714)
 
 
 state 612
 	union_type:  UNION union_switch union_name '{' union_body '}'.    (272)
 
-	.  reduce 272 (src line 2097)
+	.  reduce 272 (src line 2101)
 
 
 state 613
 	union_case_label_n_e:  '[' CASE '(' const_exp1 ')' ']'.    (299)
 
-	.  reduce 299 (src line 2290)
+	.  reduce 299 (src line 2294)
 
 
 state 614
 	const_exp1:  const_exp1 ',' const_exp.    (301)
 
-	.  reduce 301 (src line 2300)
+	.  reduce 301 (src line 2304)
 
 
 state 615
 	param_declarators1:  param_declarators1 ',' param_declarator.    (349)
 
-	.  reduce 349 (src line 2659)
+	.  reduce 349 (src line 2663)
 
 
 state 616
 	param_declarator:  attributes1 type_spec declarator.    (351)
 
-	.  reduce 351 (src line 2669)
+	.  reduce 351 (src line 2673)
 
 
 state 617
 	array_bound_pair:  array_bound RNG array_bound.    (323)
 
-	.  reduce 323 (src line 2491)
+	.  reduce 323 (src line 2495)
 
 
 164 terminals, 144 nonterminals

--- a/msrpc/dcom/imsa/imsadminbase3w/v0/v0.go
+++ b/msrpc/dcom/imsa/imsadminbase3w/v0/v0.go
@@ -300,7 +300,7 @@ func (o *xxx_GetChildPathsOperation) MarshalNDRRequest(ctx context.Context, w nd
 	// pcchMDRequiredBufferSize {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_pcchMDRequiredBufferSize := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RequiredBufferSize); err != nil {
 				return err
@@ -484,7 +484,7 @@ func (o *xxx_GetChildPathsOperation) MarshalNDRResponse(ctx context.Context, w n
 	// pcchMDRequiredBufferSize {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_pcchMDRequiredBufferSize := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RequiredBufferSize); err != nil {
 				return err

--- a/msrpc/dfsnm/netdfs/v3/v3.go
+++ b/msrpc/dfsnm/netdfs/v3/v3.go
@@ -9392,7 +9392,7 @@ func (o *xxx_EnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.Writer)
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -9503,7 +9503,7 @@ func (o *xxx_EnumOperation) MarshalNDRResponse(ctx context.Context, w ndr.Writer
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -13084,7 +13084,7 @@ func (o *xxx_EnumExOperation) MarshalNDRRequest(ctx context.Context, w ndr.Write
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -13201,7 +13201,7 @@ func (o *xxx_EnumExOperation) MarshalNDRResponse(ctx context.Context, w ndr.Writ
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err

--- a/msrpc/drsr/drsuapi/v4/v4.go
+++ b/msrpc/drsr/drsuapi/v4/v4.go
@@ -18001,7 +18001,7 @@ func (o *MessageMoveReplyV1) MarshalNDR(ctx context.Context, w ndr.Writer) error
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pError := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Error); err != nil {
 			return err

--- a/msrpc/even/eventlog/v0/v0.go
+++ b/msrpc/even/eventlog/v0/v0.go
@@ -3588,7 +3588,7 @@ func (o *xxx_ReportEventWOperation) MarshalNDRRequest(ctx context.Context, w ndr
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -3605,7 +3605,7 @@ func (o *xxx_ReportEventWOperation) MarshalNDRRequest(ctx context.Context, w ndr
 	// TimeWritten {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_TimeWritten := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.TimeWritten); err != nil {
 				return err
@@ -3821,7 +3821,7 @@ func (o *xxx_ReportEventWOperation) MarshalNDRResponse(ctx context.Context, w nd
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -3838,7 +3838,7 @@ func (o *xxx_ReportEventWOperation) MarshalNDRResponse(ctx context.Context, w nd
 	// TimeWritten {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_TimeWritten := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.TimeWritten); err != nil {
 				return err
@@ -5898,7 +5898,7 @@ func (o *xxx_ReportEventAOperation) MarshalNDRRequest(ctx context.Context, w ndr
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -5915,7 +5915,7 @@ func (o *xxx_ReportEventAOperation) MarshalNDRRequest(ctx context.Context, w ndr
 	// TimeWritten {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_TimeWritten := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.TimeWritten); err != nil {
 				return err
@@ -6131,7 +6131,7 @@ func (o *xxx_ReportEventAOperation) MarshalNDRResponse(ctx context.Context, w nd
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -6148,7 +6148,7 @@ func (o *xxx_ReportEventAOperation) MarshalNDRResponse(ctx context.Context, w nd
 	// TimeWritten {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_TimeWritten := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.TimeWritten); err != nil {
 				return err
@@ -6881,7 +6881,7 @@ func (o *xxx_ReportEventAndSourceWOperation) MarshalNDRRequest(ctx context.Conte
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -6898,7 +6898,7 @@ func (o *xxx_ReportEventAndSourceWOperation) MarshalNDRRequest(ctx context.Conte
 	// TimeWritten {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_TimeWritten := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.TimeWritten); err != nil {
 				return err
@@ -7126,7 +7126,7 @@ func (o *xxx_ReportEventAndSourceWOperation) MarshalNDRResponse(ctx context.Cont
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -7143,7 +7143,7 @@ func (o *xxx_ReportEventAndSourceWOperation) MarshalNDRResponse(ctx context.Cont
 	// TimeWritten {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_TimeWritten := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.TimeWritten); err != nil {
 				return err
@@ -7597,7 +7597,7 @@ func (o *xxx_ReportEventExWOperation) MarshalNDRRequest(ctx context.Context, w n
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -7800,7 +7800,7 @@ func (o *xxx_ReportEventExWOperation) MarshalNDRResponse(ctx context.Context, w 
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -8227,7 +8227,7 @@ func (o *xxx_ReportEventExAOperation) MarshalNDRRequest(ctx context.Context, w n
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err
@@ -8430,7 +8430,7 @@ func (o *xxx_ReportEventExAOperation) MarshalNDRResponse(ctx context.Context, w 
 	// RecordNumber {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_RecordNumber := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.RecordNumber); err != nil {
 				return err

--- a/msrpc/fax/fax/v4/v4.go
+++ b/msrpc/fax/fax/v4/v4.go
@@ -11369,7 +11369,7 @@ func (o *xxx_AccessCheckOperation) MarshalNDRRequest(ctx context.Context, w ndr.
 	// lpdwRights {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwRights := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Rights); err != nil {
 				return err
@@ -11440,7 +11440,7 @@ func (o *xxx_AccessCheckOperation) MarshalNDRResponse(ctx context.Context, w ndr
 	// lpdwRights {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwRights := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Rights); err != nil {
 				return err
@@ -11738,7 +11738,7 @@ func (o *xxx_CheckServerProtocolSeqOperation) MarshalNDRRequest(ctx context.Cont
 	// lpdwProtSeq {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwProtSeq := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ProtocolSeq); err != nil {
 				return err
@@ -11791,7 +11791,7 @@ func (o *xxx_CheckServerProtocolSeqOperation) MarshalNDRResponse(ctx context.Con
 	// lpdwProtSeq {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwProtSeq := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ProtocolSeq); err != nil {
 				return err
@@ -12028,7 +12028,7 @@ func (o *xxx_SendDocumentExOperation) MarshalNDRRequest(ctx context.Context, w n
 				break
 			}
 			// XXX pointer to primitive type, default behavior is to write non-null pointer.
-			// if this behavior is not desired, use goext_null_if(cond) attribute.
+			// if this behavior is not desired, use goext_default_null([cond]) attribute.
 			_ptr_lpcSenderProfile := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.SenderProfile[i1]); err != nil {
 					return err
@@ -12111,7 +12111,7 @@ func (o *xxx_SendDocumentExOperation) MarshalNDRRequest(ctx context.Context, w n
 	// lpdwJobId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwJobId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.JobID); err != nil {
 				return err
@@ -12272,7 +12272,7 @@ func (o *xxx_SendDocumentExOperation) MarshalNDRResponse(ctx context.Context, w 
 	// lpdwJobId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwJobId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.JobID); err != nil {
 				return err
@@ -28019,7 +28019,7 @@ func (o *xxx_AccessCheckEx2Operation) MarshalNDRRequest(ctx context.Context, w n
 	// lpdwRights {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwRights := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Rights); err != nil {
 				return err
@@ -28090,7 +28090,7 @@ func (o *xxx_AccessCheckEx2Operation) MarshalNDRResponse(ctx context.Context, w 
 	// lpdwRights {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwRights := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Rights); err != nil {
 				return err

--- a/msrpc/mqmp/qmcomm/v1/v1.go
+++ b/msrpc/mqmp/qmcomm/v1/v1.go
@@ -1257,7 +1257,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pClass := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Class); err != nil {
 			return err
@@ -1358,7 +1358,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pSentTime := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.SentTime); err != nil {
 			return err
@@ -1369,7 +1369,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pArrivedTime := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.ArrivedTime); err != nil {
 			return err
@@ -1380,7 +1380,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pPriority := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Priority); err != nil {
 			return err
@@ -1391,7 +1391,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pDelivery := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Delivery); err != nil {
 			return err
@@ -1402,7 +1402,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pAcknowledge := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Acknowledge); err != nil {
 			return err
@@ -1413,7 +1413,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pAuditing := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Auditing); err != nil {
 			return err
@@ -1424,7 +1424,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pApplicationTag := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.ApplicationTag); err != nil {
 			return err
@@ -1498,7 +1498,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pBodySize := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.BodySize); err != nil {
 			return err
@@ -1573,7 +1573,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulTitleBufferSizeInWCHARs := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.ActualTitleBufferSizeInWchars); err != nil {
 			return err
@@ -1587,7 +1587,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulRelativeTimeToQueue := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.ActualRelativeTimeToQueue); err != nil {
 			return err
@@ -1601,7 +1601,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulRelativeTimeToLive := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.ActualRelativeTimeToLive); err != nil {
 			return err
@@ -1612,7 +1612,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pTrace := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Trace); err != nil {
 			return err
@@ -1623,7 +1623,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulSenderIDType := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.SenderIDType); err != nil {
 			return err
@@ -1679,7 +1679,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulSenderIDLenProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.SenderIDLengthProperty); err != nil {
 			return err
@@ -1690,7 +1690,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulPrivLevel := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.PrivLevel); err != nil {
 			return err
@@ -1704,7 +1704,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pAuthenticated := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Authenticated); err != nil {
 			return err
@@ -1715,7 +1715,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulHashAlg := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.HashAlgorithm); err != nil {
 			return err
@@ -1726,7 +1726,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulEncryptAlg := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.EncryptAlgorithm); err != nil {
 			return err
@@ -1785,7 +1785,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulSenderCertLenProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.SenderCertLengthProperty); err != nil {
 			return err
@@ -1848,7 +1848,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulAuthProvNameLenProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.AuthProvNameLengthProperty); err != nil {
 			return err
@@ -1859,7 +1859,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulProvType := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.ProvType); err != nil {
 			return err
@@ -1921,7 +1921,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulSymmKeysSizeProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.SymmetricKeysSizeProperty); err != nil {
 			return err
@@ -1989,7 +1989,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulSignatureSizeProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.SignatureSizeProperty); err != nil {
 			return err
@@ -2114,7 +2114,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pMsgExtensionSize := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.MessageExtensionSize); err != nil {
 			return err
@@ -2158,7 +2158,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulBodyType := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.BodyType); err != nil {
 			return err
@@ -2169,7 +2169,7 @@ func (o *TransferBufferV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulVersion := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.Version); err != nil {
 			return err
@@ -3442,7 +3442,7 @@ func (o *TransferBufferV1_TransferBufferV1_Receive) MarshalNDR(ctx context.Conte
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulResponseFormatNameLenProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.ResponseFormatNameLengthProperty); err != nil {
 			return err
@@ -3505,7 +3505,7 @@ func (o *TransferBufferV1_TransferBufferV1_Receive) MarshalNDR(ctx context.Conte
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulAdminFormatNameLenProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.AdminFormatNameLengthProperty); err != nil {
 			return err
@@ -3568,7 +3568,7 @@ func (o *TransferBufferV1_TransferBufferV1_Receive) MarshalNDR(ctx context.Conte
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulDestFormatNameLenProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.DestinationFormatNameLengthProperty); err != nil {
 			return err
@@ -3631,7 +3631,7 @@ func (o *TransferBufferV1_TransferBufferV1_Receive) MarshalNDR(ctx context.Conte
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pulOrderingFormatNameLenProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.OrderingFormatNameLengthProperty); err != nil {
 			return err
@@ -3952,7 +3952,7 @@ func (o *TransferBufferV2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pbFirstInXact := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.FirstInTransaction); err != nil {
 			return err
@@ -3963,7 +3963,7 @@ func (o *TransferBufferV2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pbLastInXact := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.LastInTransaction); err != nil {
 			return err

--- a/msrpc/msrp/msgsvc/v1/v1.go
+++ b/msrpc/msrp/msgsvc/v1/v1.go
@@ -1445,7 +1445,7 @@ func (o *xxx_MessageNameEnumOperation) MarshalNDRRequest(ctx context.Context, w 
 	// ResumeHandle {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -1553,7 +1553,7 @@ func (o *xxx_MessageNameEnumOperation) MarshalNDRResponse(ctx context.Context, w
 	// ResumeHandle {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err

--- a/msrpc/nrpc/logon/v1/v1.go
+++ b/msrpc/nrpc/logon/v1/v1.go
@@ -18509,7 +18509,7 @@ func (o *OutChainSetClientAttributesV1) MarshalNDR(ctx context.Context, w ndr.Wr
 		}
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_SupportedEncTypes := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.SupportedEncTypes); err != nil {
 			return err

--- a/msrpc/nspi/nspi/v56/v56.go
+++ b/msrpc/nspi/nspi/v56/v56.go
@@ -5739,7 +5739,7 @@ func (o *xxx_UpdateStatOperation) MarshalNDRRequest(ctx context.Context, w ndr.W
 	// plDelta {in, out} (1:{pointer=unique}*(1)(int32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_plDelta := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Delta); err != nil {
 				return err
@@ -5830,7 +5830,7 @@ func (o *xxx_UpdateStatOperation) MarshalNDRResponse(ctx context.Context, w ndr.
 	// plDelta {in, out} (1:{pointer=unique}*(1)(int32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_plDelta := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Delta); err != nil {
 				return err

--- a/msrpc/par/iremotewinspool/v1/v1.go
+++ b/msrpc/par/iremotewinspool/v1/v1.go
@@ -6452,7 +6452,7 @@ func (o *PortInfo255) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pMonitorData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.MonitorData); err != nil {
 			return err

--- a/msrpc/rprn/winspool/v1/v1.go
+++ b/msrpc/rprn/winspool/v1/v1.go
@@ -6688,7 +6688,7 @@ func (o *PortInfo255) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_pMonitorData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.MonitorData); err != nil {
 			return err

--- a/msrpc/rrp/winreg/v1/v1.go
+++ b/msrpc/rrp/winreg/v1/v1.go
@@ -1151,7 +1151,7 @@ func (o *ValueEntry) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 		return err
 	}
 	// XXX pointer to primitive type, default behavior is to write non-null pointer.
-	// if this behavior is not desired, use goext_null_if(cond) attribute.
+	// if this behavior is not desired, use goext_default_null([cond]) attribute.
 	_ptr_ve_valueptr := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 		if err := w.WriteData(o.ValuePointer); err != nil {
 			return err
@@ -3198,7 +3198,7 @@ func (o *xxx_BaseRegCreateKeyOperation) MarshalNDRRequest(ctx context.Context, w
 	// lpdwDisposition {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwDisposition := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Disposition); err != nil {
 				return err
@@ -3327,7 +3327,7 @@ func (o *xxx_BaseRegCreateKeyOperation) MarshalNDRResponse(ctx context.Context, 
 	// lpdwDisposition {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpdwDisposition := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Disposition); err != nil {
 				return err
@@ -4444,7 +4444,7 @@ func (o *xxx_BaseRegEnumValueOperation) MarshalNDRRequest(ctx context.Context, w
 	// lpType {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpType := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Type); err != nil {
 				return err
@@ -4512,7 +4512,7 @@ func (o *xxx_BaseRegEnumValueOperation) MarshalNDRRequest(ctx context.Context, w
 	// lpcbData {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpcbData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.DataLength); err != nil {
 				return err
@@ -4529,7 +4529,7 @@ func (o *xxx_BaseRegEnumValueOperation) MarshalNDRRequest(ctx context.Context, w
 	// lpcbLen {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpcbLen := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Length); err != nil {
 				return err
@@ -4704,7 +4704,7 @@ func (o *xxx_BaseRegEnumValueOperation) MarshalNDRResponse(ctx context.Context, 
 	// lpType {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpType := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Type); err != nil {
 				return err
@@ -4772,7 +4772,7 @@ func (o *xxx_BaseRegEnumValueOperation) MarshalNDRResponse(ctx context.Context, 
 	// lpcbData {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpcbData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.DataLength); err != nil {
 				return err
@@ -4789,7 +4789,7 @@ func (o *xxx_BaseRegEnumValueOperation) MarshalNDRResponse(ctx context.Context, 
 	// lpcbLen {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpcbLen := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Length); err != nil {
 				return err
@@ -6390,7 +6390,7 @@ func (o *xxx_BaseRegQueryValueOperation) MarshalNDRRequest(ctx context.Context, 
 	// lpType {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpType := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Type); err != nil {
 				return err
@@ -6458,7 +6458,7 @@ func (o *xxx_BaseRegQueryValueOperation) MarshalNDRRequest(ctx context.Context, 
 	// lpcbData {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpcbData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.DataLength); err != nil {
 				return err
@@ -6475,7 +6475,7 @@ func (o *xxx_BaseRegQueryValueOperation) MarshalNDRRequest(ctx context.Context, 
 	// lpcbLen {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpcbLen := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Length); err != nil {
 				return err
@@ -6629,7 +6629,7 @@ func (o *xxx_BaseRegQueryValueOperation) MarshalNDRResponse(ctx context.Context,
 	// lpType {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpType := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Type); err != nil {
 				return err
@@ -6697,7 +6697,7 @@ func (o *xxx_BaseRegQueryValueOperation) MarshalNDRResponse(ctx context.Context,
 	// lpcbData {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpcbData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.DataLength); err != nil {
 				return err
@@ -6714,7 +6714,7 @@ func (o *xxx_BaseRegQueryValueOperation) MarshalNDRResponse(ctx context.Context,
 	// lpcbLen {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpcbLen := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Length); err != nil {
 				return err

--- a/msrpc/scmr/svcctl/v2/v2.go
+++ b/msrpc/scmr/svcctl/v2/v2.go
@@ -13156,7 +13156,7 @@ func (o *xxx_EnumServicesStatusWOperation) MarshalNDRRequest(ctx context.Context
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -13272,7 +13272,7 @@ func (o *xxx_EnumServicesStatusWOperation) MarshalNDRResponse(ctx context.Contex
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -17268,7 +17268,7 @@ func (o *xxx_EnumServicesStatusAOperation) MarshalNDRRequest(ctx context.Context
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -17384,7 +17384,7 @@ func (o *xxx_EnumServicesStatusAOperation) MarshalNDRResponse(ctx context.Contex
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -19505,7 +19505,7 @@ func (o *xxx_EnumServiceGroupWOperation) MarshalNDRRequest(ctx context.Context, 
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -19658,7 +19658,7 @@ func (o *xxx_EnumServiceGroupWOperation) MarshalNDRResponse(ctx context.Context,
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -21258,7 +21258,7 @@ func (o *xxx_EnumServicesStatusExAOperation) MarshalNDRRequest(ctx context.Conte
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -21417,7 +21417,7 @@ func (o *xxx_EnumServicesStatusExAOperation) MarshalNDRResponse(ctx context.Cont
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -21753,7 +21753,7 @@ func (o *xxx_EnumServicesStatusExWOperation) MarshalNDRRequest(ctx context.Conte
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err
@@ -21912,7 +21912,7 @@ func (o *xxx_EnumServicesStatusExWOperation) MarshalNDRResponse(ctx context.Cont
 	// lpResumeIndex {in, out} (1:{pointer=unique, alias=LPBOUNDED_DWORD_256K}*(1))(2:{range=(0,262144), alias=BOUNDED_DWORD_256K, names=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_lpResumeIndex := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ResumeIndex); err != nil {
 				return err

--- a/msrpc/scmr/svcctl/v2/v2.go
+++ b/msrpc/scmr/svcctl/v2/v2.go
@@ -11355,7 +11355,7 @@ func (o *xxx_ChangeServiceConfigWOperation) MarshalNDRRequest(ctx context.Contex
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -11709,7 +11709,7 @@ func (o *xxx_ChangeServiceConfigWOperation) MarshalNDRResponse(ctx context.Conte
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -12147,7 +12147,7 @@ func (o *xxx_CreateServiceWOperation) MarshalNDRRequest(ctx context.Context, w n
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -12482,7 +12482,7 @@ func (o *xxx_CreateServiceWOperation) MarshalNDRResponse(ctx context.Context, w 
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -15466,7 +15466,7 @@ func (o *xxx_ChangeServiceConfigAOperation) MarshalNDRRequest(ctx context.Contex
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -15820,7 +15820,7 @@ func (o *xxx_ChangeServiceConfigAOperation) MarshalNDRResponse(ctx context.Conte
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -16257,7 +16257,7 @@ func (o *xxx_CreateServiceAOperation) MarshalNDRRequest(ctx context.Context, w n
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -16592,7 +16592,7 @@ func (o *xxx_CreateServiceAOperation) MarshalNDRResponse(ctx context.Context, w 
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -22327,7 +22327,7 @@ func (o *xxx_CreateServiceWOW64AOperation) MarshalNDRRequest(ctx context.Context
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -22662,7 +22662,7 @@ func (o *xxx_CreateServiceWOW64AOperation) MarshalNDRResponse(ctx context.Contex
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -23112,7 +23112,7 @@ func (o *xxx_CreateServiceWOW64WOperation) MarshalNDRRequest(ctx context.Context
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -23447,7 +23447,7 @@ func (o *xxx_CreateServiceWOW64WOperation) MarshalNDRResponse(ctx context.Contex
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -25477,7 +25477,7 @@ func (o *xxx_CreateWOWServiceOperation) MarshalNDRRequest(ctx context.Context, w
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err
@@ -25824,7 +25824,7 @@ func (o *xxx_CreateWOWServiceOperation) MarshalNDRResponse(ctx context.Context, 
 	}
 	// lpdwTagId {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
-		if !(o.TagID == 0) {
+		if o.TagID != uint32(0) {
 			_ptr_lpdwTagId := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 				if err := w.WriteData(o.TagID); err != nil {
 					return err

--- a/msrpc/srvs/srvsvc/v3/v3.go
+++ b/msrpc/srvs/srvsvc/v3/v3.go
@@ -19403,7 +19403,7 @@ func (o *xxx_ConnectionEnumOperation) MarshalNDRRequest(ctx context.Context, w n
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -19527,7 +19527,7 @@ func (o *xxx_ConnectionEnumOperation) MarshalNDRResponse(ctx context.Context, w 
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -19830,7 +19830,7 @@ func (o *xxx_FileEnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.Wri
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -19970,7 +19970,7 @@ func (o *xxx_FileEnumOperation) MarshalNDRResponse(ctx context.Context, w ndr.Wr
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -20729,7 +20729,7 @@ func (o *xxx_SessionEnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -20869,7 +20869,7 @@ func (o *xxx_SessionEnumOperation) MarshalNDRResponse(ctx context.Context, w ndr
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -21393,7 +21393,7 @@ func (o *xxx_ShareAddOperation) MarshalNDRRequest(ctx context.Context, w ndr.Wri
 	// ParmErr {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ParmErr := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ParameterError); err != nil {
 				return err
@@ -21481,7 +21481,7 @@ func (o *xxx_ShareAddOperation) MarshalNDRResponse(ctx context.Context, w ndr.Wr
 	// ParmErr {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ParmErr := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ParameterError); err != nil {
 				return err
@@ -21711,7 +21711,7 @@ func (o *xxx_ShareEnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.Wr
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -21819,7 +21819,7 @@ func (o *xxx_ShareEnumOperation) MarshalNDRResponse(ctx context.Context, w ndr.W
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -22355,7 +22355,7 @@ func (o *xxx_ShareSetInfoOperation) MarshalNDRRequest(ctx context.Context, w ndr
 	// ParmErr {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ParmErr := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ParameterError); err != nil {
 				return err
@@ -22449,7 +22449,7 @@ func (o *xxx_ShareSetInfoOperation) MarshalNDRResponse(ctx context.Context, w nd
 	// ParmErr {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ParmErr := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ParameterError); err != nil {
 				return err
@@ -23570,7 +23570,7 @@ func (o *xxx_SetInfoOperation) MarshalNDRRequest(ctx context.Context, w ndr.Writ
 	// ParmErr {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ParmErr := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ParameterError); err != nil {
 				return err
@@ -23658,7 +23658,7 @@ func (o *xxx_SetInfoOperation) MarshalNDRResponse(ctx context.Context, w ndr.Wri
 	// ParmErr {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ParmErr := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ParameterError); err != nil {
 				return err
@@ -23989,7 +23989,7 @@ func (o *xxx_DiskEnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.Wri
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -24103,7 +24103,7 @@ func (o *xxx_DiskEnumOperation) MarshalNDRResponse(ctx context.Context, w ndr.Wr
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -24878,7 +24878,7 @@ func (o *xxx_TransportEnumOperation) MarshalNDRRequest(ctx context.Context, w nd
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -24986,7 +24986,7 @@ func (o *xxx_TransportEnumOperation) MarshalNDRResponse(ctx context.Context, w n
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -27329,7 +27329,7 @@ func (o *xxx_ShareEnumStickyOperation) MarshalNDRRequest(ctx context.Context, w 
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -27437,7 +27437,7 @@ func (o *xxx_ShareEnumStickyOperation) MarshalNDRResponse(ctx context.Context, w
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -31819,7 +31819,7 @@ func (o *xxx_AliasEnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.Wr
 	// ResumeHandle {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -31927,7 +31927,7 @@ func (o *xxx_AliasEnumOperation) MarshalNDRResponse(ctx context.Context, w ndr.W
 	// ResumeHandle {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err

--- a/msrpc/tsch/atsvc/v1/v1.go
+++ b/msrpc/tsch/atsvc/v1/v1.go
@@ -765,7 +765,7 @@ func (o *xxx_JobEnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.Writ
 	// pResumeHandle {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_pResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -873,7 +873,7 @@ func (o *xxx_JobEnumOperation) MarshalNDRResponse(ctx context.Context, w ndr.Wri
 	// pResumeHandle {in, out} (1:{pointer=unique, alias=LPDWORD}*(1))(2:{alias=DWORD}(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_pResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err

--- a/msrpc/wkst/wkssvc/v1/v1.go
+++ b/msrpc/wkst/wkssvc/v1/v1.go
@@ -6672,7 +6672,7 @@ func (o *xxx_SetInfoOperation) MarshalNDRRequest(ctx context.Context, w ndr.Writ
 	// ErrorParameter {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ErrorParameter := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ErrorParameter); err != nil {
 				return err
@@ -6760,7 +6760,7 @@ func (o *xxx_SetInfoOperation) MarshalNDRResponse(ctx context.Context, w ndr.Wri
 	// ErrorParameter {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ErrorParameter := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ErrorParameter); err != nil {
 				return err
@@ -6990,7 +6990,7 @@ func (o *xxx_UserEnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.Wri
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -7098,7 +7098,7 @@ func (o *xxx_UserEnumOperation) MarshalNDRResponse(ctx context.Context, w ndr.Wr
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -7342,7 +7342,7 @@ func (o *xxx_TransportEnumOperation) MarshalNDRRequest(ctx context.Context, w nd
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -7450,7 +7450,7 @@ func (o *xxx_TransportEnumOperation) MarshalNDRResponse(ctx context.Context, w n
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -7694,7 +7694,7 @@ func (o *xxx_TransportAddOperation) MarshalNDRRequest(ctx context.Context, w ndr
 	// ErrorParameter {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ErrorParameter := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ErrorParameter); err != nil {
 				return err
@@ -7781,7 +7781,7 @@ func (o *xxx_TransportAddOperation) MarshalNDRResponse(ctx context.Context, w nd
 	// ErrorParameter {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ErrorParameter := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ErrorParameter); err != nil {
 				return err
@@ -8245,7 +8245,7 @@ func (o *xxx_UseAddOperation) MarshalNDRRequest(ctx context.Context, w ndr.Write
 	// ErrorParameter {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ErrorParameter := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ErrorParameter); err != nil {
 				return err
@@ -8333,7 +8333,7 @@ func (o *xxx_UseAddOperation) MarshalNDRResponse(ctx context.Context, w ndr.Writ
 	// ErrorParameter {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ErrorParameter := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.ErrorParameter); err != nil {
 				return err
@@ -9053,7 +9053,7 @@ func (o *xxx_UseEnumOperation) MarshalNDRRequest(ctx context.Context, w ndr.Writ
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err
@@ -9161,7 +9161,7 @@ func (o *xxx_UseEnumOperation) MarshalNDRResponse(ctx context.Context, w ndr.Wri
 	// ResumeHandle {in, out} (1:{pointer=unique}*(1)(uint32))
 	{
 		// XXX pointer to primitive type, default behavior is to write non-null pointer.
-		// if this behavior is not desired, use goext_null_if(cond) attribute.
+		// if this behavior is not desired, use goext_default_null([cond]) attribute.
 		_ptr_ResumeHandle := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
 			if err := w.WriteData(o.Resume); err != nil {
 				return err


### PR DESCRIPTION
pick nicer name for the goext_null_if, use goext_default_null([cond]) when condition is empty, zero value comparison is being checked.