### PR TITLE
ndr64: fix trailing gap / fix int3264 alignment

### DIFF
--- a/codegen/gen/gen.go
+++ b/codegen/gen/gen.go
@@ -288,6 +288,12 @@ func (p *Generator) GenType(ctx context.Context, t *midl.Type) {
 	}
 }
 
+func (p *Generator) GenDoTrailingGapMarshalNDR(ctx context.Context, gap int) {
+	if gap > 1 {
+		p.CheckErr(p.B("w.WriteTrailingGap", gap))
+	}
+}
+
 func (p *Generator) GenDoAlignmentMarshalNDR(ctx context.Context, alignment int) {
 	if alignment > 1 {
 		p.CheckErr(p.B("w.WriteAlign", alignment))
@@ -297,6 +303,12 @@ func (p *Generator) GenDoAlignmentMarshalNDR(ctx context.Context, alignment int)
 func (p *Generator) GenDoUnionAlignemntMarshalNDR(ctx context.Context, alignment int) {
 	if alignment > 1 {
 		p.CheckErr(p.B("w.WriteUnionAlign", alignment))
+	}
+}
+
+func (p *Generator) GenDoTrailingGapUnmarshalNDR(ctx context.Context, gap int) {
+	if gap > 1 {
+		p.CheckErr(p.B("w.ReadTrailingGap", gap))
 	}
 }
 

--- a/codegen/gen/scopes.go
+++ b/codegen/gen/scopes.go
@@ -227,6 +227,7 @@ func (i *Scopes) Alignment() int {
 	if a != 5 {
 		return a
 	}
+
 	return a + i.alignment(true)
 }
 

--- a/midl/types.go
+++ b/midl/types.go
@@ -781,7 +781,7 @@ func PrimitiveTypeSize(kind Kind) int {
 	case TypeFloat64, TypeUint64, TypeInt64:
 		ret = 8
 	case TypeInt32_64, TypeUint32_64:
-		return 5
+		return 4
 	}
 
 	return ret

--- a/msrpc/adts/adts.go
+++ b/msrpc/adts/adts.go
@@ -275,6 +275,9 @@ func (o *PACCredentialInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PACCredentialInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -293,6 +296,9 @@ func (o *PACCredentialInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		if err := w.ReadData(&o.SerializedData[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -458,6 +464,9 @@ func (o *PACCredentialData) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(o.CredentialCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Credentials {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -495,6 +504,9 @@ func (o *PACCredentialData) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.CredentialCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -565,6 +577,9 @@ func (o *PACClientInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PACClientInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -586,6 +601,9 @@ func (o *PACClientInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Name[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -647,6 +665,9 @@ func (o *NTLMSupplementalCredential) MarshalNDR(ctx context.Context, w ndr.Write
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *NTLMSupplementalCredential) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -672,6 +693,9 @@ func (o *NTLMSupplementalCredential) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		if err := w.ReadData(&o.NTPassword[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -818,6 +842,9 @@ func (o *KerberosSIDAndAttributes) MarshalNDR(ctx context.Context, w ndr.Writer)
 	if err := w.WriteData(o.Attributes); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *KerberosSIDAndAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -838,6 +865,9 @@ func (o *KerberosSIDAndAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	if err := w.ReadData(&o.Attributes); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/cmrp/clusapi2/v2/v2.go
+++ b/msrpc/cmrp/clusapi2/v2/v2.go
@@ -865,6 +865,9 @@ func (o *SecurityDescriptor) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.OutSecurityDescriptorLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityDescriptor) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -908,6 +911,9 @@ func (o *SecurityDescriptor) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.OutSecurityDescriptorLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -963,6 +969,9 @@ func (o *SecurityAttributes) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.InheritHandle); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -979,6 +988,9 @@ func (o *SecurityAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.InheritHandle); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1450,6 +1462,9 @@ func (o *EnumList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.EntryCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Entry {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -1487,6 +1502,9 @@ func (o *EnumList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.EntryCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/cmrp/clusapi3/v3/v3.go
+++ b/msrpc/cmrp/clusapi3/v3/v3.go
@@ -1935,6 +1935,9 @@ func (o *SecurityDescriptor) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.OutSecurityDescriptorLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityDescriptor) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1978,6 +1981,9 @@ func (o *SecurityDescriptor) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.OutSecurityDescriptorLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2033,6 +2039,9 @@ func (o *SecurityAttributes) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.InheritHandle); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2049,6 +2058,9 @@ func (o *SecurityAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.InheritHandle); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2647,6 +2659,9 @@ func (o *EnumList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.EntryCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Entry {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -2684,6 +2699,9 @@ func (o *EnumList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.EntryCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -3327,6 +3345,9 @@ func (o *GroupEnumList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.EntryCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Entry {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -3364,6 +3385,9 @@ func (o *GroupEnumList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.EntryCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -3437,6 +3461,9 @@ func (o *ResourceEnumList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.EntryCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Entry {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -3474,6 +3501,9 @@ func (o *ResourceEnumList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.EntryCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -3752,6 +3782,9 @@ func (o *NotificationDataRPC) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *NotificationDataRPC) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3834,6 +3867,9 @@ func (o *NotificationDataRPC) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 	})
 	_s_Type := func(ptr interface{}) { o.Type = *ptr.(*string) }
 	if err := w.ReadPointer(&o.Type, _s_Type, _ptr_Type); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dcetypes/dcetypes.go
+++ b/msrpc/dcetypes/dcetypes.go
@@ -290,6 +290,9 @@ func (o *InterfaceID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.VersMinor); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *InterfaceID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -306,6 +309,9 @@ func (o *InterfaceID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.VersMinor); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -353,6 +359,9 @@ func (o *InterfaceIDVector) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 		return err
 	}
 	if err := w.WriteData(o.Count); err != nil {
+		return err
+	}
+	if err := w.WriteTrailingGap(9); err != nil {
 		return err
 	}
 	for i1 := range o.InterfaceID {
@@ -404,6 +413,9 @@ func (o *InterfaceIDVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/dcom/csra/csra.go
+++ b/msrpc/dcom/csra/csra.go
@@ -829,6 +829,9 @@ func (o *CertViewRestriction) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 	if err := w.WriteData(o.ValueLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CertViewRestriction) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -874,6 +877,9 @@ func (o *CertViewRestriction) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 		return err
 	}
 	if err := w.ReadData(&o.ValueLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dcom/csvp/csvp.go
+++ b/msrpc/dcom/csvp/csvp.go
@@ -504,6 +504,9 @@ func (o *ClusterSCSIAddress) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.LUN); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClusterSCSIAddress) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -523,6 +526,9 @@ func (o *ClusterSCSIAddress) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.LUN); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -1119,6 +1125,9 @@ func (o *DiskPropertiesEx) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DiskPropertiesEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1211,6 +1220,9 @@ func (o *DiskPropertiesEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		o.PoolID = &dtyp.GUID{}
 	}
 	if err := o.PoolID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1609,6 +1621,9 @@ func (o *RouteLossAndState) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteEnum(uint16(o.Status)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RouteLossAndState) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1619,6 +1634,9 @@ func (o *RouteLossAndState) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.Status)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -1701,6 +1719,9 @@ func (o *AddRoutesReply) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.RouteUnavailable); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(6); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AddRoutesReply) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1734,6 +1755,9 @@ func (o *AddRoutesReply) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.RouteUnavailable); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(6); err != nil {
 		return err
 	}
 	return nil
@@ -1888,6 +1912,9 @@ func (o *ClusterCert) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClusterCert) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1920,6 +1947,9 @@ func (o *ClusterCert) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.ClusterSecret[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }

--- a/msrpc/dcom/dcom.go
+++ b/msrpc/dcom/dcom.go
@@ -97,6 +97,9 @@ func (o *ClassID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClassID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -118,6 +121,9 @@ func (o *ClassID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -165,6 +171,9 @@ func (o *IID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *IID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -186,6 +195,9 @@ func (o *IID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -233,6 +245,9 @@ func (o *IPID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *IPID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -254,6 +269,9 @@ func (o *IPID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -301,6 +319,9 @@ func (o *CID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -322,6 +343,9 @@ func (o *CID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2142,6 +2166,9 @@ func (o *StdObjectReference) MarshalNDR(ctx context.Context, w ndr.Writer) error
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *StdObjectReference) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2164,6 +2191,9 @@ func (o *StdObjectReference) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		o.IPID = &IPID{}
 	}
 	if err := o.IPID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2267,6 +2297,9 @@ func (o *ObjectReferenceStandard) MarshalNDR(ctx context.Context, w ndr.Writer) 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ObjectReferenceStandard) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2290,6 +2323,9 @@ func (o *ObjectReferenceStandard) UnmarshalNDR(ctx context.Context, w ndr.Reader
 	})
 	_s_saResAddr := func(ptr interface{}) { o.ResolverAddr = *ptr.(**DualStringArray) }
 	if err := w.ReadPointer(&o.ResolverAddr, _s_saResAddr, _ptr_saResAddr); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2387,6 +2423,9 @@ func (o *ObjectReferenceHandler) MarshalNDR(ctx context.Context, w ndr.Writer) e
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ObjectReferenceHandler) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2416,6 +2455,9 @@ func (o *ObjectReferenceHandler) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 	})
 	_s_saResAddr := func(ptr interface{}) { o.ResolverAddr = *ptr.(**DualStringArray) }
 	if err := w.ReadPointer(&o.ResolverAddr, _s_saResAddr, _ptr_saResAddr); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2714,6 +2756,9 @@ func (o *ObjectReferenceExtended) MarshalNDR(ctx context.Context, w ndr.Writer) 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ObjectReferenceExtended) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2786,6 +2831,9 @@ func (o *ObjectReferenceExtended) UnmarshalNDR(ctx context.Context, w ndr.Reader
 	})
 	_s_ElmArray := func(ptr interface{}) { o.ElementArray = *ptr.(*[]*DataElement) }
 	if err := w.ReadPointer(&o.ElementArray, _s_ElmArray, _ptr_ElmArray); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4204,6 +4252,9 @@ func (o *COMServerInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *COMServerInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4240,6 +4291,9 @@ func (o *COMServerInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved dwReserved2
 	var _dwReserved2 uint32
 	if err := w.ReadData(&_dwReserved2); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4448,6 +4502,9 @@ func (o *CustomRemoteReplySCMInfo) MarshalNDR(ctx context.Context, w ndr.Writer)
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CustomRemoteReplySCMInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4483,6 +4540,9 @@ func (o *CustomRemoteReplySCMInfo) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		o.ServerVersion = &COMVersion{}
 	}
 	if err := o.ServerVersion.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4658,6 +4718,9 @@ func (o *InstantiationInfoData) MarshalNDR(ctx context.Context, w ndr.Writer) er
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *InstantiationInfoData) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4726,6 +4789,9 @@ func (o *InstantiationInfoData) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 	if err := o.ClientCOMVersion.UnmarshalNDR(ctx, w); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4786,6 +4852,9 @@ func (o *LocationInfoData) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ContextID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *LocationInfoData) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4809,6 +4878,9 @@ func (o *LocationInfoData) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.ContextID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6081,6 +6153,9 @@ func (o *SpecialPropertiesData) MarshalNDR(ctx context.Context, w ndr.Writer) er
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SpecialPropertiesData) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6135,6 +6210,9 @@ func (o *SpecialPropertiesData) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 		if err := w.ReadData(&_Reserved3[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
 	}
 	return nil
 }

--- a/msrpc/dcom/dfsrh/dfsrh.go
+++ b/msrpc/dcom/dfsrh/dfsrh.go
@@ -224,6 +224,9 @@ func (o *ADAttributeData) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Length); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ADAttributeData) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -263,6 +266,9 @@ func (o *ADAttributeData) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.Length); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dcom/dmrp/dmrp.go
+++ b/msrpc/dcom/dmrp/dmrp.go
@@ -1035,6 +1035,9 @@ func (o *VolumeInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.VolumeFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *VolumeInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1069,6 +1072,9 @@ func (o *VolumeInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.VolumeFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -1612,6 +1618,9 @@ func (o *DiskInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DiskInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1838,6 +1847,9 @@ func (o *DiskInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_dgName := func(ptr interface{}) { o.DiskGroupName = *ptr.(*string) }
 	if err := w.ReadPointer(&o.DiskGroupName, _s_dgName, _ptr_dgName); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2073,6 +2085,9 @@ func (o *RegionInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.CurrentPartitionNumber); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RegionInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2119,6 +2134,9 @@ func (o *RegionInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.CurrentPartitionNumber); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2201,6 +2219,9 @@ func (o *DriveLetterInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.DriveLetterFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DriveLetterInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2223,6 +2244,9 @@ func (o *DriveLetterInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.DriveLetterFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2380,6 +2404,9 @@ func (o *FileSystemInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FileSystemInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2445,6 +2472,9 @@ func (o *FileSystemInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_label := func(ptr interface{}) { o.Label = *ptr.(*string) }
 	if err := w.ReadPointer(&o.Label, _s_label, _ptr_label); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2790,6 +2820,9 @@ func (o *TaskInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TaskFlag); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TaskInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2821,6 +2854,9 @@ func (o *TaskInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TaskFlag); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2906,6 +2942,9 @@ func (o *CountedString) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CountedString) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2950,6 +2989,9 @@ func (o *CountedString) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_sstring := func(ptr interface{}) { o.String = *ptr.(*string) }
 	if err := w.ReadPointer(&o.String, _s_sstring, _ptr_sstring); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -3609,6 +3651,9 @@ func (o *DiskInfoEx) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DiskInfoEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3885,6 +3930,9 @@ func (o *DiskInfoEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_devInstId := func(ptr interface{}) { o.DevInstanceID = *ptr.(*string) }
 	if err := w.ReadPointer(&o.DevInstanceID, _s_devInstId, _ptr_devInstId); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4317,6 +4365,9 @@ func (o *RegionInfoEx) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RegionInfoEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4401,6 +4452,9 @@ func (o *RegionInfoEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_name := func(ptr interface{}) { o.Name = *ptr.(*string) }
 	if err := w.ReadPointer(&o.Name, _s_name, _ptr_name); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4620,6 +4674,9 @@ func (o *RegionInfoEx_RegionInfoEx_MBR) MarshalNDR(ctx context.Context, w ndr.Wr
 	if err := w.WriteData(o.IsActive); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RegionInfoEx_RegionInfoEx_MBR) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4630,6 +4687,9 @@ func (o *RegionInfoEx_RegionInfoEx_MBR) UnmarshalNDR(ctx context.Context, w ndr.
 		return err
 	}
 	if err := w.ReadData(&o.IsActive); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dcom/fsrm/fsrm.go
+++ b/msrpc/dcom/fsrm/fsrm.go
@@ -410,6 +410,9 @@ func (o *ObjectID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ObjectID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -431,6 +434,9 @@ func (o *ObjectID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }

--- a/msrpc/dcom/imsa/imsa.go
+++ b/msrpc/dcom/imsa/imsa.go
@@ -379,6 +379,9 @@ func (o *MetadataRecord) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.DataTag); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MetadataRecord) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -430,6 +433,9 @@ func (o *MetadataRecord) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.DataTag); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dcom/oaut/oaut.go
+++ b/msrpc/dcom/oaut/oaut.go
@@ -5702,6 +5702,9 @@ func (o *SafeArrayHaveIID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SafeArrayHaveIID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5754,6 +5757,9 @@ func (o *SafeArrayHaveIID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		o.IID = &dcom.IID{}
 	}
 	if err := o.IID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7161,6 +7167,9 @@ func (o *DispatchParams) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.NamedArgsCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DispatchParams) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7241,6 +7250,9 @@ func (o *DispatchParams) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.NamedArgsCount); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7300,7 +7312,7 @@ func (o *ExceptionInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(o.Code); err != nil {
@@ -7386,10 +7398,13 @@ func (o *ExceptionInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.HResult); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ExceptionInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData(&o.Code); err != nil {
@@ -7453,6 +7468,9 @@ func (o *ExceptionInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.HResult); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7500,6 +7518,9 @@ func (o *TypeDesc) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.VT); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TypeDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7514,6 +7535,9 @@ func (o *TypeDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.VT); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7851,6 +7875,9 @@ func (o *ArrayDesc) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.DimsCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Bounds {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7894,6 +7921,9 @@ func (o *ArrayDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.DimsCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -8046,6 +8076,9 @@ func (o *ParamDesc) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ParamFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(7); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ParamDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8066,6 +8099,9 @@ func (o *ParamDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ParamFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(7); err != nil {
 		return err
 	}
 	return nil
@@ -8277,6 +8313,9 @@ func (o *FuncDesc) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.FuncFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FuncDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8377,6 +8416,9 @@ func (o *FuncDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.FuncFlags); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8454,6 +8496,9 @@ func (o *VarDesc) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint32(o.VarKind)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *VarDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8492,6 +8537,9 @@ func (o *VarDesc) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint32)(&o.VarKind)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8941,6 +8989,9 @@ func (o *TypeAttribute) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint16(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TypeAttribute) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9029,6 +9080,9 @@ func (o *TypeAttribute) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&_wReserved6); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -9100,6 +9154,9 @@ func (o *TypeLibAttribute) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.LibFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TypeLibAttribute) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9125,6 +9182,9 @@ func (o *TypeLibAttribute) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.LibFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dcom/rdpesc/type_scard_pack/v1/v1.go
+++ b/msrpc/dcom/rdpesc/type_scard_pack/v1/v1.go
@@ -1222,6 +1222,9 @@ func (o *ListReaderGroupsCall) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.GroupsLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ListReaderGroupsCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1238,6 +1241,9 @@ func (o *ListReaderGroupsCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.GroupsLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1356,6 +1362,9 @@ func (o *ListReadersCall) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ReadersLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ListReadersCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1404,6 +1413,9 @@ func (o *ListReadersCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.ReadersLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1469,6 +1481,9 @@ func (o *ReaderStateCommonCall) MarshalNDR(ctx context.Context, w ndr.Writer) er
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReaderStateCommonCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1490,6 +1505,9 @@ func (o *ReaderStateCommonCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 		if err := w.ReadData(&o.Attribute[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1545,6 +1563,9 @@ func (o *ReaderStateA) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReaderStateA) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1565,6 +1586,9 @@ func (o *ReaderStateA) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.Common = &ReaderStateCommonCall{}
 	}
 	if err := o.Common.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1621,6 +1645,9 @@ func (o *ReaderStateW) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReaderStateW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1641,6 +1668,9 @@ func (o *ReaderStateW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.Common = &ReaderStateCommonCall{}
 	}
 	if err := o.Common.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1705,6 +1735,9 @@ func (o *ReaderStateReturn) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReaderStateReturn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1726,6 +1759,9 @@ func (o *ReaderStateReturn) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		if err := w.ReadData(&o.Attribute[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2372,6 +2408,9 @@ func (o *LocateCardsAttributeMask) MarshalNDR(ctx context.Context, w ndr.Writer)
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *LocateCardsAttributeMask) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2394,6 +2433,9 @@ func (o *LocateCardsAttributeMask) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		if err := w.ReadData(&o.Mask[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -3283,6 +3325,9 @@ func (o *ConnectCommon) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.PreferredProtocols); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ConnectCommon) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3299,6 +3344,9 @@ func (o *ConnectCommon) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.PreferredProtocols); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3501,6 +3549,9 @@ func (o *ConnectReturn) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ActiveProtocol); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ConnectReturn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3517,6 +3568,9 @@ func (o *ConnectReturn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ActiveProtocol); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3585,6 +3639,9 @@ func (o *ReconnectCall) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Initialization); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReconnectCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3604,6 +3661,9 @@ func (o *ReconnectCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Initialization); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3713,6 +3773,9 @@ func (o *CardAndDispositionCall) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(o.Disposition); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CardAndDispositionCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3726,6 +3789,9 @@ func (o *CardAndDispositionCall) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		return err
 	}
 	if err := w.ReadData(&o.Disposition); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3796,6 +3862,9 @@ func (o *StateCall) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AttributeLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *StateCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3812,6 +3881,9 @@ func (o *StateCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.AttributeLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4024,6 +4096,9 @@ func (o *StatusCall) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AttributeLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *StatusCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4043,6 +4118,9 @@ func (o *StatusCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.AttributeLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4171,6 +4249,9 @@ func (o *StatusReturn) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AttributeLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *StatusReturn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4226,6 +4307,9 @@ func (o *StatusReturn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		}
 	}
 	if err := w.ReadData(&o.AttributeLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4491,6 +4575,9 @@ func (o *TransmitCall) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.RecvLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TransmitCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4558,6 +4645,9 @@ func (o *TransmitCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.RecvLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4930,6 +5020,9 @@ func (o *ControlCall) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.OutBufferLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ControlCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4981,6 +5074,9 @@ func (o *ControlCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.OutBufferLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5174,6 +5270,9 @@ func (o *GetAttributeCall) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AttributeLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *GetAttributeCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5193,6 +5292,9 @@ func (o *GetAttributeCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.AttributeLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5529,6 +5631,9 @@ func (o *ReadCacheCommon) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.DataLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReadCacheCommon) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5561,6 +5666,9 @@ func (o *ReadCacheCommon) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.DataLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dcom/vds/vds.go
+++ b/msrpc/dcom/vds/vds.go
@@ -176,6 +176,9 @@ func (o *ObjectID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ObjectID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -197,6 +200,9 @@ func (o *ObjectID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2009,6 +2015,9 @@ func (o *ServiceNotification) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 	if err := w.WriteEnum(uint16(o.Action)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServiceNotification) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2019,6 +2028,9 @@ func (o *ServiceNotification) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.Action)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -2902,6 +2914,9 @@ func (o *AsyncOutput_AsyncOutput_CreatePartition) MarshalNDR(ctx context.Context
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AsyncOutput_AsyncOutput_CreatePartition) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2915,6 +2930,9 @@ func (o *AsyncOutput_AsyncOutput_CreatePartition) UnmarshalNDR(ctx context.Conte
 		o.VolumeID = &ObjectID{}
 	}
 	if err := o.VolumeID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -3438,6 +3456,9 @@ func (o *PartitionInfoGPT) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PartitionInfoGPT) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3465,6 +3486,9 @@ func (o *PartitionInfoGPT) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		if err := w.ReadData(&o.Name[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
 	}
 	return nil
 }
@@ -4294,6 +4318,9 @@ func (o *FileSystemProperty) MarshalNDR(ctx context.Context, w ndr.Writer) error
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FileSystemProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4329,6 +4356,9 @@ func (o *FileSystemProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 	})
 	_s_pwszLabel := func(ptr interface{}) { o.Label = *ptr.(*string) }
 	if err := w.ReadPointer(&o.Label, _s_pwszLabel, _ptr_pwszLabel); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4415,6 +4445,9 @@ func (o *FileSystemFormatSupportProperty) MarshalNDR(ctx context.Context, w ndr.
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FileSystemFormatSupportProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4443,6 +4476,9 @@ func (o *FileSystemFormatSupportProperty) UnmarshalNDR(ctx context.Context, w nd
 		if err := w.ReadData(&o.Name[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -4525,6 +4561,9 @@ func (o *DiskExtent) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.MemberIndex); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DiskExtent) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4559,6 +4598,9 @@ func (o *DiskExtent) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.MemberIndex); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4955,6 +4997,9 @@ func (o *InputDisk) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.MemberIndex); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *InputDisk) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4977,6 +5022,9 @@ func (o *InputDisk) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.MemberIndex); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -5339,6 +5387,9 @@ func (o *CreatePartitionParameters_CreatePartitionParameters_GPTPartitionInfo) M
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CreatePartitionParameters_CreatePartitionParameters_GPTPartitionInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5366,6 +5417,9 @@ func (o *CreatePartitionParameters_CreatePartitionParameters_GPTPartitionInfo) U
 		if err := w.ReadData(&o.Name[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
 	}
 	return nil
 }
@@ -7356,6 +7410,9 @@ func (o *ISCSISharedSecret) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(o.SharedSecretSize); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ISCSISharedSecret) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7392,6 +7449,9 @@ func (o *ISCSISharedSecret) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.SharedSecretSize); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7442,6 +7502,9 @@ func (o *ServiceProperty) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServiceProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7459,6 +7522,9 @@ func (o *ServiceProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7838,6 +7904,9 @@ func (o *ProviderProperty) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.RebuildPriority); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ProviderProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7886,6 +7955,9 @@ func (o *ProviderProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.RebuildPriority); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7954,6 +8026,9 @@ func (o *PackProperty) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PackProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7980,6 +8055,9 @@ func (o *PackProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8223,6 +8301,9 @@ func (o *DiskProperty) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DiskProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8326,6 +8407,9 @@ func (o *DiskProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_pwszDevicePath := func(ptr interface{}) { o.DevicePath = *ptr.(*string) }
 	if err := w.ReadPointer(&o.DevicePath, _s_pwszDevicePath, _ptr_pwszDevicePath); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -8768,6 +8852,9 @@ func (o *DiskProperty2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DiskProperty2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8881,6 +8968,9 @@ func (o *DiskProperty2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_pwszLocationPath := func(ptr interface{}) { o.LocationPath = *ptr.(*string) }
 	if err := w.ReadPointer(&o.LocationPath, _s_pwszLocationPath, _ptr_pwszLocationPath); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -9278,6 +9368,9 @@ func (o *AdvancedDiskProperty) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.DeviceType); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AdvancedDiskProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9418,6 +9511,9 @@ func (o *AdvancedDiskProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.DeviceType); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -9676,6 +9772,9 @@ func (o *VolumeProperty) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *VolumeProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9717,6 +9816,9 @@ func (o *VolumeProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_pwszName := func(ptr interface{}) { o.Name = *ptr.(*string) }
 	if err := w.ReadPointer(&o.Name, _s_pwszName, _ptr_pwszName); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -9856,6 +9958,9 @@ func (o *VolumeProperty2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *VolumeProperty2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9929,6 +10034,9 @@ func (o *VolumeProperty2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 	})
 	_s_pUniqueId := func(ptr interface{}) { o.UniqueID = *ptr.(*[]byte) }
 	if err := w.ReadPointer(&o.UniqueID, _s_pUniqueId, _ptr_pUniqueId); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -10017,6 +10125,9 @@ func (o *VolumePlexProperty) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.NumberOfMembers); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *VolumePlexProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10048,6 +10159,9 @@ func (o *VolumePlexProperty) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.NumberOfMembers); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -10217,6 +10331,9 @@ func (o *CreateVDiskParameters) MarshalNDR(ctx context.Context, w ndr.Writer) er
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CreateVDiskParameters) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10256,6 +10373,9 @@ func (o *CreateVDiskParameters) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 	})
 	_s_pSourcePath := func(ptr interface{}) { o.SourcePath = *ptr.(*string) }
 	if err := w.ReadPointer(&o.SourcePath, _s_pSourcePath, _ptr_pSourcePath); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -10684,6 +10804,9 @@ func (o *VDiskProperties) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *VDiskProperties) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10747,6 +10870,9 @@ func (o *VDiskProperties) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 	})
 	_s_pParentPath := func(ptr interface{}) { o.ParentPath = *ptr.(*string) }
 	if err := w.ReadPointer(&o.ParentPath, _s_pParentPath, _ptr_pParentPath); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dcom/wmi/wmi.go
+++ b/msrpc/dcom/wmi/wmi.go
@@ -894,6 +894,9 @@ func (o *RefreshInfoRemote) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RefreshInfoRemote) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -930,6 +933,9 @@ func (o *RefreshInfoRemote) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		o.GUID = &dtyp.GUID{}
 	}
 	if err := o.GUID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1316,6 +1322,9 @@ func (o *RefreshInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.CancelID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RefreshInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1333,6 +1342,9 @@ func (o *RefreshInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.CancelID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1387,6 +1399,9 @@ func (o *RefresherID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RefresherID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1410,6 +1425,9 @@ func (o *RefresherID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.RefresherID = &dtyp.GUID{}
 	}
 	if err := o.RefresherID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dfsnm/netdfs/v3/v3.go
+++ b/msrpc/dfsnm/netdfs/v3/v3.go
@@ -970,6 +970,9 @@ func (o *TargetPriority) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint16(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TargetPriority) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -985,6 +988,9 @@ func (o *TargetPriority) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved Reserved
 	var _Reserved uint16
 	if err := w.ReadData(&_Reserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -1174,6 +1180,9 @@ func (o *StorageInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *StorageInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1207,6 +1216,9 @@ func (o *StorageInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.TargetPriority = &TargetPriority{}
 	}
 	if err := o.TargetPriority.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1329,6 +1341,9 @@ func (o *RootList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.EntriesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Entry {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -1366,6 +1381,9 @@ func (o *RootList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.EntriesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -1687,6 +1705,9 @@ func (o *Info2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.NumberOfStorages); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Info2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1717,6 +1738,9 @@ func (o *Info2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.NumberOfStorages); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2242,6 +2266,9 @@ func (o *Info5) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.NumberOfStorages); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Info5) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2287,6 +2314,9 @@ func (o *Info5) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.NumberOfStorages); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2721,6 +2751,9 @@ func (o *Info8) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.NumberOfStorages); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Info8) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2798,6 +2831,9 @@ func (o *Info8) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.NumberOfStorages); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3610,6 +3646,9 @@ func (o *Info105) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.PropertyFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Info105) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3636,6 +3675,9 @@ func (o *Info105) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.PropertyFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dhcpm/dhcpm.go
+++ b/msrpc/dhcpm/dhcpm.go
@@ -1064,6 +1064,9 @@ func (o *SubnetInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint16(o.SubnetState)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SubnetInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1103,6 +1106,9 @@ func (o *SubnetInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.SubnetState)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2994,6 +3000,9 @@ func (o *Option) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint16(o.OptionType)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Option) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3030,6 +3039,9 @@ func (o *Option) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.OptionType)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5025,6 +5037,9 @@ func (o *ServerConfigInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.DebugFlag); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerConfigInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5079,6 +5094,9 @@ func (o *ServerConfigInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 	if err := w.ReadData(&o.DebugFlag); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -5118,6 +5136,9 @@ func (o *ScanItem) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint16(o.ScanFlag)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ScanItem) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5128,6 +5149,9 @@ func (o *ScanItem) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.ScanFlag)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -5327,6 +5351,9 @@ func (o *IPReservationV4) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AllowedClientTypes); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *IPReservationV4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5350,6 +5377,9 @@ func (o *IPReservationV4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.AllowedClientTypes); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6163,6 +6193,9 @@ func (o *ClientInfoV4) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ClientType); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClientInfoV4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6214,6 +6247,9 @@ func (o *ClientInfoV4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ClientType); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6873,6 +6909,9 @@ func (o *ServerConfigInfoV4) MarshalNDR(ctx context.Context, w ndr.Writer) error
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerConfigInfoV4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6969,6 +7008,9 @@ func (o *ServerConfigInfoV4) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	o.AuditLog = _bAuditLog != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7304,6 +7346,9 @@ func (o *ServerConfigInfoVQ) MarshalNDR(ctx context.Context, w ndr.Writer) error
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerConfigInfoVQ) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7413,6 +7458,9 @@ func (o *ServerConfigInfoVQ) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	o.QuarantineRuntimeStatus = _bQuarantineRuntimeStatus != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8087,6 +8135,9 @@ func (o *ClientInfoVQ) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClientInfoVQ) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8157,6 +8208,9 @@ func (o *ClientInfoVQ) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	o.QuarantineCapable = _bQuarantineCapable != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8860,6 +8914,9 @@ func (o *ClientInfoV5) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AddressState); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClientInfoV5) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8914,6 +8971,9 @@ func (o *ClientInfoV5) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.AddressState); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -9197,6 +9257,9 @@ func (o *MScopeInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TTL); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MScopeInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9258,6 +9321,9 @@ func (o *MScopeInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TTL); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -9524,6 +9590,9 @@ func (o *MADCAPClientInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AddressState); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MADCAPClientInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9574,6 +9643,9 @@ func (o *MADCAPClientInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.AddressState); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -11009,6 +11081,9 @@ func (o *MScopeMIBInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.PendingOffersLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MScopeMIBInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -11035,6 +11110,9 @@ func (o *MScopeMIBInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.PendingOffersLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -13238,6 +13316,9 @@ func (o *AddrPattern) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AddrPattern) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13266,6 +13347,9 @@ func (o *AddrPattern) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Pattern[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -13330,6 +13414,9 @@ func (o *FilterAddInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint16(o.ListType)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FilterAddInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13353,6 +13440,9 @@ func (o *FilterAddInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.ListType)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -13736,6 +13826,9 @@ func (o *SubnetInfoV6) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ScopeID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SubnetInfoV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13778,6 +13871,9 @@ func (o *SubnetInfoV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ScopeID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -14034,6 +14130,9 @@ func (o *IPReservationV6) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.InterfaceID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *IPReservationV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14060,6 +14159,9 @@ func (o *IPReservationV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.InterfaceID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -14665,6 +14767,9 @@ func (o *HostInfoV6) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *HostInfoV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14695,6 +14800,9 @@ func (o *HostInfoV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_HostName := func(ptr interface{}) { o.HostName = *ptr.(*string) }
 	if err := w.ReadPointer(&o.HostName, _s_HostName, _ptr_HostName); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -15659,6 +15767,9 @@ func (o *BindElementV6) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *BindElementV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15728,6 +15839,9 @@ func (o *BindElementV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_IfId := func(ptr interface{}) { o.InterfaceID = *ptr.(*[]byte) }
 	if err := w.ReadPointer(&o.InterfaceID, _s_IfId, _ptr_IfId); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -16723,6 +16837,9 @@ func (o *ClientFilterStatusInfo) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(o.FilterStatus); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClientFilterStatusInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -16794,6 +16911,9 @@ func (o *ClientFilterStatusInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 	}
 	o.QuarantineCapable = _bQuarantineCapable != 0
 	if err := w.ReadData(&o.FilterStatus); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -17881,6 +18001,9 @@ func (o *FailoverClientInfoV4) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FailoverClientInfoV4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -17983,6 +18106,9 @@ func (o *FailoverClientInfoV4) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -18104,6 +18230,9 @@ func (o *IPReservationInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(o.OptionsPresent); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *IPReservationInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -18143,6 +18272,9 @@ func (o *IPReservationInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.OptionsPresent); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -18813,6 +18945,9 @@ func (o *PolicyCondition) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ValueLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PolicyCondition) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -18874,6 +19009,9 @@ func (o *PolicyCondition) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.ValueLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -19028,6 +19166,9 @@ func (o *PolicyExpr) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint16(o.Operator)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PolicyExpr) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -19038,6 +19179,9 @@ func (o *PolicyExpr) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.Operator)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -19445,6 +19589,9 @@ func (o *Policy) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Policy) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -19526,6 +19673,9 @@ func (o *Policy) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	o.Enabled = _bEnabled != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/msrpc/dltm/dltm.go
+++ b/msrpc/dltm/dltm.go
@@ -1472,6 +1472,9 @@ func (o *SyncVolume) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SyncVolume) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1515,6 +1518,9 @@ func (o *SyncVolume) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.Machine = &dltw.MachineID{}
 	}
 	if err := o.Machine.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dnsp/dnsp.go
+++ b/msrpc/dnsp/dnsp.go
@@ -346,6 +346,9 @@ func (o *StatHeader) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint8(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *StatHeader) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -364,6 +367,9 @@ func (o *StatHeader) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved fReserved
 	var _fReserved uint8
 	if err := w.ReadData(&_fReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -1557,6 +1563,9 @@ func (o *ServerInfoW2K) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerInfoW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1797,6 +1806,9 @@ func (o *ServerInfoW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&_fReserveArray[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2265,6 +2277,9 @@ func (o *ServerInfo_NET) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerInfo_NET) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2542,6 +2557,9 @@ func (o *ServerInfo_NET) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&_fReserveArray[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2970,6 +2988,9 @@ func (o *ServerInfoLonghorn) MarshalNDR(ctx context.Context, w ndr.Writer) error
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerInfoLonghorn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3250,6 +3271,9 @@ func (o *ServerInfoLonghorn) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		if err := w.ReadData(&_fReserveArray[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -3688,6 +3712,9 @@ func (o *ServerInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3968,6 +3995,9 @@ func (o *ServerInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&_fReserveArray[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -4429,6 +4459,9 @@ func (o *ZoneW2K) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Version); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4452,6 +4485,9 @@ func (o *ZoneW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Version); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4810,6 +4846,9 @@ func (o *ZoneListW2K) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ZoneCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.ZoneArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -4859,6 +4898,9 @@ func (o *ZoneListW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ZoneCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -4978,6 +5020,9 @@ func (o *ZoneList_NET) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ZoneCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.ZoneArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -5035,6 +5080,9 @@ func (o *ZoneList_NET) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ZoneCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -5139,6 +5187,9 @@ func (o *ZoneList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ZoneCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.ZoneArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -5196,6 +5247,9 @@ func (o *ZoneList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ZoneCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -5450,6 +5504,9 @@ func (o *TrustPoint) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TrustPoint) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5492,6 +5549,9 @@ func (o *TrustPoint) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -5560,6 +5620,9 @@ func (o *TrustPointList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TrustPointCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.TrustPointArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -5617,6 +5680,9 @@ func (o *TrustPointList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TrustPointCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -5814,6 +5880,9 @@ func (o *SKD) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SKD) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5884,6 +5953,9 @@ func (o *SKD) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6146,6 +6218,9 @@ func (o *SKDStateEx) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint16(o.NextKeyScope)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SKDStateEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6252,6 +6327,9 @@ func (o *SKDStateEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.NextKeyScope)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6509,6 +6587,9 @@ func (o *SKDState) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SKDState) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6580,6 +6661,9 @@ func (o *SKDState) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7006,6 +7090,9 @@ func (o *ZoneDNSSECSettings) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.ZoneSKDArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7188,6 +7275,9 @@ func (o *ZoneDNSSECSettings) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -7390,6 +7480,9 @@ func (o *TrustAnchor) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.RRData {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7449,6 +7542,9 @@ func (o *TrustAnchor) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -7532,6 +7628,9 @@ func (o *TrustAnchorList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TrustAnchorCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.TrustAnchorArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7589,6 +7688,9 @@ func (o *TrustAnchorList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.TrustAnchorCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -7678,6 +7780,9 @@ func (o *DPEnum) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ZoneCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DPEnum) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7706,6 +7811,9 @@ func (o *DPEnum) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ZoneCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7776,6 +7884,9 @@ func (o *DPList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.DPCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.DPArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7833,6 +7944,9 @@ func (o *DPList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.DPCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -8108,6 +8222,9 @@ func (o *DPInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ReplicaCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.ArrayReplica {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -8227,6 +8344,9 @@ func (o *DPInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.ReplicaCount); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	// XXX: for opaque unmarshaling
 	if o.ReplicaCount > 0 && sizeInfo[0] == 0 {
 		sizeInfo[0] = uint64(o.ReplicaCount)
@@ -8339,6 +8459,9 @@ func (o *EnlistDP) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Operation); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *EnlistDP) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8364,6 +8487,9 @@ func (o *EnlistDP) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Operation); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -9646,6 +9772,9 @@ func (o *ZoneInfoW2K) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneInfoW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9787,6 +9916,9 @@ func (o *ZoneInfoW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved pvReserved4
 	var _pvReserved4 uint32
 	if err := w.ReadData(&_pvReserved4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -10785,6 +10917,9 @@ func (o *ZoneInfoLonghorn) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.LastXFRResult); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneInfoLonghorn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10979,6 +11114,9 @@ func (o *ZoneInfoLonghorn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.LastXFRResult); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -11314,6 +11452,9 @@ func (o *ZoneInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.LastXFRResult); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -11508,6 +11649,9 @@ func (o *ZoneInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.LastXFRResult); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -11826,6 +11970,9 @@ func (o *ZoneCreateInfoW2K) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneCreateInfoW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -12046,6 +12193,9 @@ func (o *ZoneCreateInfoW2K) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 	// reserved dwReserved8
 	var _dwReserved8 uint32
 	if err := w.ReadData(&_dwReserved8); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -12274,6 +12424,9 @@ func (o *ZoneCreateInfo_NET) MarshalNDR(ctx context.Context, w ndr.Writer) error
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneCreateInfo_NET) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -12395,6 +12548,9 @@ func (o *ZoneCreateInfo_NET) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		if err := w.ReadData(&_dwReserved[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -12625,6 +12781,9 @@ func (o *ZoneCreateInfoLonghorn) MarshalNDR(ctx context.Context, w ndr.Writer) e
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneCreateInfoLonghorn) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -12746,6 +12905,9 @@ func (o *ZoneCreateInfoLonghorn) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		if err := w.ReadData(&_dwReserved[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -12958,6 +13120,9 @@ func (o *ZoneCreateInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneCreateInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13080,6 +13245,9 @@ func (o *ZoneCreateInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 			return err
 		}
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -13148,6 +13316,9 @@ func (o *SKDList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.SKDArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -13205,6 +13376,9 @@ func (o *SKDList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -13308,6 +13482,9 @@ func (o *SigningValidationError) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SigningValidationError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13344,6 +13521,9 @@ func (o *SigningValidationError) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -14929,6 +15109,9 @@ func (o *PolicyContent) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Weight); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PolicyContent) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14946,6 +15129,9 @@ func (o *PolicyContent) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Weight); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -15004,6 +15190,9 @@ func (o *PolicyContentList) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(o.ContentCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Content {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -15053,6 +15242,9 @@ func (o *PolicyContentList) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.ContentCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -15320,6 +15512,9 @@ func (o *Policy) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.CriteriaCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.CriteriaList {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -15427,6 +15622,9 @@ func (o *Policy) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.CriteriaCount); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
+	}
 	// XXX: for opaque unmarshaling
 	if o.CriteriaCount > 0 && sizeInfo[0] == 0 {
 		sizeInfo[0] = uint64(o.CriteriaCount)
@@ -15518,6 +15716,9 @@ func (o *PolicyName) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ProcessingOrder); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PolicyName) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15543,6 +15744,9 @@ func (o *PolicyName) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	}
 	o.Enabled = _bEnabled != 0
 	if err := w.ReadData(&o.ProcessingOrder); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -15601,6 +15805,9 @@ func (o *EnumeratePolicyList) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 	if err := w.WriteData(o.PolicyCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.PolicyArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -15650,6 +15857,9 @@ func (o *EnumeratePolicyList) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 		return err
 	}
 	if err := w.ReadData(&o.PolicyCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -16224,6 +16434,9 @@ func (o *EnumVirtualizationInstanceList) MarshalNDR(ctx context.Context, w ndr.W
 	if err := w.WriteData(o.VirtualizationInstanceCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.VirtualizationInstanceArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -16276,6 +16489,9 @@ func (o *EnumVirtualizationInstanceList) UnmarshalNDR(ctx context.Context, w ndr
 		return err
 	}
 	if err := w.ReadData(&o.VirtualizationInstanceCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -16764,6 +16980,9 @@ func (o *ZoneStats) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneStats) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -16809,6 +17028,9 @@ func (o *ZoneStats) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.ZoneRRLStats = &ZoneRRLStats{}
 	}
 	if err := o.ZoneRRLStats.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -17016,6 +17238,9 @@ func (o *EnumZoneScopeList) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(o.ZoneScopeCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.ZoneScopeArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -17062,6 +17287,9 @@ func (o *EnumZoneScopeList) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.ZoneScopeCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -17921,6 +18149,9 @@ func (o *ZoneStatsV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ZoneStatsV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -17966,6 +18197,9 @@ func (o *ZoneStatsV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.ZoneRRLStats = &ZoneRRLStats{}
 	}
 	if err := o.ZoneRRLStats.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -18202,6 +18436,9 @@ func (o *EnumScopeList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ScopeCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.ScopeArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -18248,6 +18485,9 @@ func (o *EnumScopeList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ScopeCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/dnsp/record/record.go
+++ b/msrpc/dnsp/record/record.go
@@ -4632,6 +4632,9 @@ func (o *RecordRRSIG) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RecordRRSIG) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4678,6 +4681,9 @@ func (o *RecordRRSIG) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.SignatureInfo[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -4801,6 +4807,9 @@ func (o *RecordSIG) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RecordSIG) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4847,6 +4856,9 @@ func (o *RecordSIG) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.SignatureInfo[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -4911,6 +4923,9 @@ func (o *RecordKEY) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(2); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RecordKEY) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4932,6 +4947,9 @@ func (o *RecordKEY) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Key[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(2); err != nil {
+		return err
 	}
 	return nil
 }
@@ -4996,6 +5014,9 @@ func (o *RecordDNSKEY) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(2); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RecordDNSKEY) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5017,6 +5038,9 @@ func (o *RecordDNSKEY) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Key[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(2); err != nil {
+		return err
 	}
 	return nil
 }
@@ -5312,6 +5336,9 @@ func (o *RecordNSEC) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(7); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RecordNSEC) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5337,6 +5364,9 @@ func (o *RecordNSEC) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.NSECBitmap[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(7); err != nil {
+		return err
 	}
 	return nil
 }
@@ -5549,6 +5579,9 @@ func (o *RecordNSEC3) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(7); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RecordNSEC3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5634,6 +5667,9 @@ func (o *RecordNSEC3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Bitmaps[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(7); err != nil {
+		return err
 	}
 	return nil
 }
@@ -6206,6 +6242,9 @@ func (o *RecordDS) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(2); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RecordDS) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6227,6 +6266,9 @@ func (o *RecordDS) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Digest[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(2); err != nil {
+		return err
 	}
 	return nil
 }

--- a/msrpc/drsr/drsuapi/v4/v4.go
+++ b/msrpc/drsr/drsuapi/v4/v4.go
@@ -894,6 +894,9 @@ func (o *EncryptedPayload) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *EncryptedPayload) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -916,6 +919,9 @@ func (o *EncryptedPayload) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		if err := w.ReadData(&o.EncryptedData[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1378,6 +1384,9 @@ func (o *UpToDateVectorV1Ext) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Cursors {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -1428,6 +1437,9 @@ func (o *UpToDateVectorV1Ext) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 	// reserved dwReserved2
 	var _dwReserved2 uint32
 	if err := w.ReadData(&_dwReserved2); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -2600,6 +2612,9 @@ func (o *PropertyMetadataExtVector) MarshalNDR(ctx context.Context, w ndr.Writer
 	if err := w.WriteData(o.PropertiesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Metadata {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -2637,6 +2652,9 @@ func (o *PropertyMetadataExtVector) UnmarshalNDR(ctx context.Context, w ndr.Read
 		return err
 	}
 	if err := w.ReadData(&o.PropertiesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -2972,6 +2990,9 @@ func (o *UpToDateVectorV2Ext) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Cursors {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -3022,6 +3043,9 @@ func (o *UpToDateVectorV2Ext) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 	// reserved dwReserved2
 	var _dwReserved2 uint32
 	if err := w.ReadData(&_dwReserved2); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -3833,6 +3857,9 @@ func (o *DSDomainControllerInfoV1) MarshalNDR(ctx context.Context, w ndr.Writer)
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSDomainControllerInfoV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3899,6 +3926,9 @@ func (o *DSDomainControllerInfoV1) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	o.DSEnabled = _bDSEnabled != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4125,6 +4155,9 @@ func (o *DSDomainControllerInfoV2) MarshalNDR(ctx context.Context, w ndr.Writer)
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSDomainControllerInfoV2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4238,6 +4271,9 @@ func (o *DSDomainControllerInfoV2) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		o.NTDSDSAObjectGUID = &dtyp.GUID{}
 	}
 	if err := o.NTDSDSAObjectGUID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4474,6 +4510,9 @@ func (o *DSDomainControllerInfoV3) MarshalNDR(ctx context.Context, w ndr.Writer)
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSDomainControllerInfoV3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4592,6 +4631,9 @@ func (o *DSDomainControllerInfoV3) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		o.NTDSDSAObjectGUID = &dtyp.GUID{}
 	}
 	if err := o.NTDSDSAObjectGUID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5494,6 +5536,9 @@ func (o *ContinuationReferral) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Choice); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ContinuationReferral) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5563,6 +5608,9 @@ func (o *ContinuationReferral) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 	}
 	o.NewChoice = _bNewChoice != 0
 	if err := w.ReadData(&o.Choice); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5680,6 +5728,9 @@ func (o *SecurityError) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Problem); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5696,6 +5747,9 @@ func (o *SecurityError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Problem); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -5742,6 +5796,9 @@ func (o *ServiceError) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Problem); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServiceError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5758,6 +5815,9 @@ func (o *ServiceError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Problem); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -5804,6 +5864,9 @@ func (o *UpdateError) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Problem); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UpdateError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5820,6 +5883,9 @@ func (o *UpdateError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Problem); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -5866,6 +5932,9 @@ func (o *SystemError) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Problem); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SystemError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5882,6 +5951,9 @@ func (o *SystemError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Problem); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -6533,6 +6605,9 @@ func (o *DSReplicationNeighbor) MarshalNDR(ctx context.Context, w ndr.Writer) er
 	if err := w.WriteData(o.ConsecutiveSyncFailuresCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationNeighbor) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6635,6 +6710,9 @@ func (o *DSReplicationNeighbor) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 	if err := w.ReadData(&o.ConsecutiveSyncFailuresCount); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -6693,6 +6771,9 @@ func (o *DSReplicationNeighbors) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Neighbor {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -6735,6 +6816,9 @@ func (o *DSReplicationNeighbors) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -6870,6 +6954,9 @@ func (o *DSReplicationCursors) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Cursor {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -6912,6 +6999,9 @@ func (o *DSReplicationCursors) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -7126,6 +7216,9 @@ func (o *DSReplicationKCCDSAFailure) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.LastResult); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationKCCDSAFailure) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7158,6 +7251,9 @@ func (o *DSReplicationKCCDSAFailure) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.LastResult); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7219,6 +7315,9 @@ func (o *DSReplicationKCCDSAFailures) MarshalNDR(ctx context.Context, w ndr.Writ
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.DSAFailure {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7261,6 +7360,9 @@ func (o *DSReplicationKCCDSAFailures) UnmarshalNDR(ctx context.Context, w ndr.Re
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -7339,6 +7441,9 @@ func (o *DSReplicationObjectMetadata) MarshalNDR(ctx context.Context, w ndr.Writ
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Metadata {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7381,6 +7486,9 @@ func (o *DSReplicationObjectMetadata) UnmarshalNDR(ctx context.Context, w ndr.Re
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -7566,6 +7674,9 @@ func (o *DSReplicationOperation) MarshalNDR(ctx context.Context, w ndr.Writer) e
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationOperation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7632,6 +7743,9 @@ func (o *DSReplicationOperation) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 	if err := o.DSAObjectGUID.UnmarshalNDR(ctx, w); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7695,6 +7809,9 @@ func (o *DSReplicationPendingOperations) MarshalNDR(ctx context.Context, w ndr.W
 	if err := w.WriteData(o.PendingOperationsCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.PendingOperation {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7738,6 +7855,9 @@ func (o *DSReplicationPendingOperations) UnmarshalNDR(ctx context.Context, w ndr
 		return err
 	}
 	if err := w.ReadData(&o.PendingOperationsCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -8075,6 +8195,9 @@ func (o *DSReplicationAttributeValueMetadata) MarshalNDR(ctx context.Context, w 
 	if err := w.WriteData(o.EnumerationContext); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Metadata {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -8115,6 +8238,9 @@ func (o *DSReplicationAttributeValueMetadata) UnmarshalNDR(ctx context.Context, 
 		return err
 	}
 	if err := w.ReadData(&o.EnumerationContext); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -8188,6 +8314,9 @@ func (o *DSReplicationCursor2) MarshalNDR(ctx context.Context, w ndr.Writer) err
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationCursor2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8207,6 +8336,9 @@ func (o *DSReplicationCursor2) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		o.LastSyncSuccess = &dtyp.Filetime{}
 	}
 	if err := o.LastSyncSuccess.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -8270,6 +8402,9 @@ func (o *DSReplicationCursors2) MarshalNDR(ctx context.Context, w ndr.Writer) er
 	if err := w.WriteData(o.EnumerationContext); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Cursor {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -8310,6 +8445,9 @@ func (o *DSReplicationCursors2) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 		return err
 	}
 	if err := w.ReadData(&o.EnumerationContext); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -8400,6 +8538,9 @@ func (o *DSReplicationCursorV3) MarshalNDR(ctx context.Context, w ndr.Writer) er
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationCursorV3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8429,6 +8570,9 @@ func (o *DSReplicationCursorV3) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 	})
 	_s_pszSourceDsaDN := func(ptr interface{}) { o.SourceDSADN = *ptr.(*string) }
 	if err := w.ReadPointer(&o.SourceDSADN, _s_pszSourceDsaDN, _ptr_pszSourceDsaDN); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -8492,6 +8636,9 @@ func (o *DSReplicationCursorsV3) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(o.EnumerationContext); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Cursor {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -8532,6 +8679,9 @@ func (o *DSReplicationCursorsV3) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		return err
 	}
 	if err := w.ReadData(&o.EnumerationContext); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -8651,6 +8801,9 @@ func (o *DSReplicationAttributeMetadata2) MarshalNDR(ctx context.Context, w ndr.
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationAttributeMetadata2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8696,6 +8849,9 @@ func (o *DSReplicationAttributeMetadata2) UnmarshalNDR(ctx context.Context, w nd
 	})
 	_s_pszLastOriginatingDsaDN := func(ptr interface{}) { o.LastOriginatingDSADN = *ptr.(*string) }
 	if err := w.ReadPointer(&o.LastOriginatingDSADN, _s_pszLastOriginatingDsaDN, _ptr_pszLastOriginatingDsaDN); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -8757,6 +8913,9 @@ func (o *DSReplicationObjectMetadata2) MarshalNDR(ctx context.Context, w ndr.Wri
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Metadata {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -8799,6 +8958,9 @@ func (o *DSReplicationObjectMetadata2) UnmarshalNDR(ctx context.Context, w ndr.R
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -9002,6 +9164,9 @@ func (o *DSReplicationValueMetadata2) MarshalNDR(ctx context.Context, w ndr.Writ
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationValueMetadata2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9103,6 +9268,9 @@ func (o *DSReplicationValueMetadata2) UnmarshalNDR(ctx context.Context, w ndr.Re
 	if err := w.ReadPointer(&o.LastOriginatingDSADN, _s_pszLastOriginatingDsaDN, _ptr_pszLastOriginatingDsaDN); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -9164,6 +9332,9 @@ func (o *DSReplicationAttributeValueMetadata2) MarshalNDR(ctx context.Context, w
 	if err := w.WriteData(o.EnumerationContext); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Metadata {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -9204,6 +9375,9 @@ func (o *DSReplicationAttributeValueMetadata2) UnmarshalNDR(ctx context.Context,
 		return err
 	}
 	if err := w.ReadData(&o.EnumerationContext); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -9787,6 +9961,9 @@ func (o *MessageGetNCChangesRequestV3) MarshalNDR(ctx context.Context, w ndr.Wri
 	if err := w.WriteData(o.ExtendedOperation); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetNCChangesRequestV3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9866,6 +10043,9 @@ func (o *MessageGetNCChangesRequestV3) UnmarshalNDR(ctx context.Context, w ndr.R
 		return err
 	}
 	if err := w.ReadData(&o.ExtendedOperation); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -10101,6 +10281,9 @@ func (o *MessageGetNCChangesRequestV7) MarshalNDR(ctx context.Context, w ndr.Wri
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetNCChangesRequestV7) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10162,6 +10345,9 @@ func (o *MessageGetNCChangesRequestV7) UnmarshalNDR(ctx context.Context, w ndr.R
 		o.PrefixTableDestination = &SchemaPrefixTable{}
 	}
 	if err := o.PrefixTableDestination.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -10341,6 +10527,9 @@ func (o *MessageGetNCChangesReplyV1) MarshalNDR(ctx context.Context, w ndr.Write
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetNCChangesReplyV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10430,6 +10619,9 @@ func (o *MessageGetNCChangesReplyV1) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	o.MoreData = _bMoreData != 0
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -10674,6 +10866,9 @@ func (o *MessageGetNCChangesReplyV6) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.DRSError); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetNCChangesReplyV6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10805,6 +11000,9 @@ func (o *MessageGetNCChangesReplyV6) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.DRSError); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -11055,6 +11253,9 @@ func (o *MessageGetNCChangesReplyV9) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.DRSError); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetNCChangesReplyV9) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -11186,6 +11387,9 @@ func (o *MessageGetNCChangesReplyV9) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.DRSError); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -11702,6 +11906,9 @@ func (o *MessageGetNCChangesRequestV8) MarshalNDR(ctx context.Context, w ndr.Wri
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetNCChangesRequestV8) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -11800,6 +12007,9 @@ func (o *MessageGetNCChangesRequestV8) UnmarshalNDR(ctx context.Context, w ndr.R
 		o.PrefixTableDestination = &SchemaPrefixTable{}
 	}
 	if err := o.PrefixTableDestination.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -12003,6 +12213,9 @@ func (o *MessageGetNCChangesRequestV10) MarshalNDR(ctx context.Context, w ndr.Wr
 	if err := w.WriteData(o.MoreFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetNCChangesRequestV10) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -12104,6 +12317,9 @@ func (o *MessageGetNCChangesRequestV10) UnmarshalNDR(ctx context.Context, w ndr.
 		return err
 	}
 	if err := w.ReadData(&o.MoreFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -12426,6 +12642,9 @@ func (o *MessageGetNCChangesRequestV11) MarshalNDR(ctx context.Context, w ndr.Wr
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetNCChangesRequestV11) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -12546,6 +12765,9 @@ func (o *MessageGetNCChangesRequestV11) UnmarshalNDR(ctx context.Context, w ndr.
 	})
 	_s_pReservedBuffer := func(ptr interface{}) { o.ReservedBuffer = *ptr.(**VarSizeBufferWithVersion) }
 	if err := w.ReadPointer(&o.ReservedBuffer, _s_pReservedBuffer, _ptr_pReservedBuffer); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -13514,6 +13736,9 @@ func (o *MessageReplicaSyncV1) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Options); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageReplicaSyncV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13550,6 +13775,9 @@ func (o *MessageReplicaSyncV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.Options); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -13974,6 +14202,9 @@ func (o *MessageUpdateReferencesV1) MarshalNDR(ctx context.Context, w ndr.Writer
 	if err := w.WriteData(o.Options); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageUpdateReferencesV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14010,6 +14241,9 @@ func (o *MessageUpdateReferencesV1) UnmarshalNDR(ctx context.Context, w ndr.Read
 		return err
 	}
 	if err := w.ReadData(&o.Options); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -14435,6 +14669,9 @@ func (o *MessageAddReplicaV1) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 	if err := w.WriteData(o.Options); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageAddReplicaV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14471,6 +14708,9 @@ func (o *MessageAddReplicaV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 		return err
 	}
 	if err := w.ReadData(&o.Options); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -14602,6 +14842,9 @@ func (o *MessageAddReplicaV2) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 	if err := w.WriteData(o.Options); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageAddReplicaV2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14664,6 +14907,9 @@ func (o *MessageAddReplicaV2) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 		return err
 	}
 	if err := w.ReadData(&o.Options); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -15202,6 +15448,9 @@ func (o *MessageDeleteReplicaV1) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(o.Options); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageDeleteReplicaV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15232,6 +15481,9 @@ func (o *MessageDeleteReplicaV1) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		return err
 	}
 	if err := w.ReadData(&o.Options); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -15474,6 +15726,9 @@ func (o *MessageModifyReplicaV1) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(o.Options); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageModifyReplicaV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15522,6 +15777,9 @@ func (o *MessageModifyReplicaV1) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		return err
 	}
 	if err := w.ReadData(&o.Options); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -17175,6 +17433,9 @@ func (o *MessageMoveRequestV1) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageMoveRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -17224,6 +17485,9 @@ func (o *MessageMoveRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -17668,6 +17932,9 @@ func (o *MessageMoveRequestV2) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageMoveRequestV2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -17746,6 +18013,9 @@ func (o *MessageMoveRequestV2) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -19399,6 +19669,9 @@ func (o *MessageNT4ChangeLogReplyV1) MarshalNDR(ctx context.Context, w ndr.Write
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageNT4ChangeLogReplyV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -19476,6 +19749,9 @@ func (o *MessageNT4ChangeLogReplyV1) UnmarshalNDR(ctx context.Context, w ndr.Rea
 	})
 	_s_pLog := func(ptr interface{}) { o.Log = *ptr.(*[]byte) }
 	if err := w.ReadPointer(&o.Log, _s_pLog, _ptr_pLog); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -20132,6 +20408,9 @@ func (o *MessageRemoveServerRequestV1) MarshalNDR(ctx context.Context, w ndr.Wri
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageRemoveServerRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -20163,6 +20442,9 @@ func (o *MessageRemoveServerRequestV1) UnmarshalNDR(ctx context.Context, w ndr.R
 		return err
 	}
 	o.Commit = _bCommit != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -20858,6 +21140,9 @@ func (o *MessageDCInfoRequestV1) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(o.InfoLevel); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageDCInfoRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -20875,6 +21160,9 @@ func (o *MessageDCInfoRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		return err
 	}
 	if err := w.ReadData(&o.InfoLevel); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -22283,6 +22571,9 @@ func (o *MessageAddEntryReplyV1) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(o.Problem); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageAddEntryReplyV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -22314,6 +22605,9 @@ func (o *MessageAddEntryReplyV1) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		return err
 	}
 	if err := w.ReadData(&o.Problem); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -22363,6 +22657,9 @@ func (o *AddEntryReplyInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AddEntryReplyInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -22379,6 +22676,9 @@ func (o *AddEntryReplyInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		o.ObjectSID = &NT4SID{}
 	}
 	if err := o.ObjectSID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -23478,6 +23778,9 @@ func (o *DSReplicationClientContext) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.PID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationClientContext) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -23508,6 +23811,9 @@ func (o *DSReplicationClientContext) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.PID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -23571,6 +23877,9 @@ func (o *DSReplicationClientContexts) MarshalNDR(ctx context.Context, w ndr.Writ
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Context {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -23613,6 +23922,9 @@ func (o *DSReplicationClientContexts) UnmarshalNDR(ctx context.Context, w ndr.Re
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -23772,6 +24084,9 @@ func (o *DSReplicationServerOutgoingCall) MarshalNDR(ctx context.Context, w ndr.
 	if err := w.WriteData(o.CallType); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSReplicationServerOutgoingCall) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -23813,6 +24128,9 @@ func (o *DSReplicationServerOutgoingCall) UnmarshalNDR(ctx context.Context, w nd
 		return err
 	}
 	if err := w.ReadData(&o.CallType); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -23876,6 +24194,9 @@ func (o *DSReplicationServerOutgoingCalls) MarshalNDR(ctx context.Context, w ndr
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Call {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -23918,6 +24239,9 @@ func (o *DSReplicationServerOutgoingCalls) UnmarshalNDR(ctx context.Context, w n
 	// reserved dwReserved
 	var _dwReserved uint32
 	if err := w.ReadData(&_dwReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -23996,6 +24320,9 @@ func (o *MessageGetReplicationInfoRequestV1) MarshalNDR(ctx context.Context, w n
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetReplicationInfoRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -24019,6 +24346,9 @@ func (o *MessageGetReplicationInfoRequestV1) UnmarshalNDR(ctx context.Context, w
 		o.SourceDSAObjectGUID = &dtyp.UUID{}
 	}
 	if err := o.SourceDSAObjectGUID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -24138,6 +24468,9 @@ func (o *MessageGetReplicationInfoRequestV2) MarshalNDR(ctx context.Context, w n
 	if err := w.WriteData(o.EnumerationContext); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageGetReplicationInfoRequestV2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -24187,6 +24520,9 @@ func (o *MessageGetReplicationInfoRequestV2) UnmarshalNDR(ctx context.Context, w
 		return err
 	}
 	if err := w.ReadData(&o.EnumerationContext); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -26822,6 +27158,9 @@ func (o *MessageVerifyReplyObjectV1) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.Options); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageVerifyReplyObjectV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -26848,6 +27187,9 @@ func (o *MessageVerifyReplyObjectV1) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.Options); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -27077,6 +27419,9 @@ func (o *MessageExistRequestV1) MarshalNDR(ctx context.Context, w ndr.Writer) er
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageExistRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -27124,6 +27469,9 @@ func (o *MessageExistRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 		if err := w.ReadData(&o.MD5Digest[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -27604,6 +27952,9 @@ func (o *MessageQuerySitesRequestV1) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageQuerySitesRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -27660,6 +28011,9 @@ func (o *MessageQuerySitesRequestV1) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -27918,6 +28272,9 @@ func (o *MessageQuerySitesReplyV1) MarshalNDR(ctx context.Context, w ndr.Writer)
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageQuerySitesReplyV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -27960,6 +28317,9 @@ func (o *MessageQuerySitesReplyV1) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dssp/dssetup/v0/v0.go
+++ b/msrpc/dssp/dssetup/v0/v0.go
@@ -246,6 +246,9 @@ func (o *UpgradeStatusInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteEnum(uint16(o.PreviousServerState)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UpgradeStatusInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -256,6 +259,9 @@ func (o *UpgradeStatusInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.PreviousServerState)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -455,6 +461,9 @@ func (o *PrimaryDomainInfoBasic) MarshalNDR(ctx context.Context, w ndr.Writer) e
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrimaryDomainInfoBasic) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -501,6 +510,9 @@ func (o *PrimaryDomainInfoBasic) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		o.DomainGUID = &dtyp.GUID{}
 	}
 	if err := o.DomainGUID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/dtyp/dtyp.go
+++ b/msrpc/dtyp/dtyp.go
@@ -554,6 +554,9 @@ func (o *GUID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *GUID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -575,6 +578,9 @@ func (o *GUID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -625,6 +631,9 @@ func (o *UUID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UUID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -646,6 +655,9 @@ func (o *UUID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -693,6 +705,9 @@ func (o *ClassID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClassID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -714,6 +729,9 @@ func (o *ClassID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1009,6 +1027,9 @@ func (o *EventHeader) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *EventHeader) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1056,6 +1077,9 @@ func (o *EventHeader) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.ActivityID = &GUID{}
 	}
 	if err := o.ActivityID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -1210,6 +1234,9 @@ func (o *Multistring) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.CharCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Multistring) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1227,6 +1254,9 @@ func (o *Multistring) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.CharCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6711,6 +6741,9 @@ func (o *SID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	for i1 := range o.SubAuthority {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -6751,6 +6784,9 @@ func (o *SID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.IDAuthority = &SIDIDAuthority{}
 	}
 	if err := o.IDAuthority.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -6931,6 +6967,9 @@ func (o *ACL) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.SBZ2); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(7); err != nil {
+		return err
+	}
 	for i1 := range o.ACEEntries {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -6992,6 +7031,9 @@ func (o *ACL) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.SBZ2); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(7); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/eerr/extendederror/v1/v1.go
+++ b/msrpc/eerr/extendederror/v1/v1.go
@@ -1230,6 +1230,9 @@ func (o *ExtendedErrorInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(o.Length); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.Params {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -1304,6 +1307,9 @@ func (o *ExtendedErrorInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.Length); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/even6/ieventservice/v1/v1.go
+++ b/msrpc/even6/ieventservice/v1/v1.go
@@ -2246,6 +2246,9 @@ func (o *QueryChannelInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Status); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *QueryChannelInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2263,6 +2266,9 @@ func (o *QueryChannelInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.Status); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/fasp/fasp.go
+++ b/msrpc/fasp/fasp.go
@@ -3509,6 +3509,9 @@ func (o *ObjectMetadata) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ObjectMetadata) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3548,6 +3551,9 @@ func (o *ObjectMetadata) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_pEnforcementStates := func(ptr interface{}) { o.EnforcementStates = *ptr.(*[]EnforcementState) }
 	if err := w.ReadPointer(&o.EnforcementStates, _s_pEnforcementStates, _ptr_pEnforcementStates); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4619,6 +4625,9 @@ func (o *Rule20) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.MetadataReserved); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Rule20) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4787,6 +4796,9 @@ func (o *Rule20) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.MetadataReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6316,6 +6328,9 @@ func (o *Rule220) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TrustTupleKeywords); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Rule220) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6555,6 +6570,9 @@ func (o *Rule220) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TrustTupleKeywords); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8252,6 +8270,9 @@ func (o *Rule225) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags2); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Rule225) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8510,6 +8531,9 @@ func (o *Rule225) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Flags2); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -10260,6 +10284,9 @@ func (o *Rule227) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.CompartmentID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Rule227) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10537,6 +10564,9 @@ func (o *Rule227) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.CompartmentID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -12680,6 +12710,9 @@ func (o *Network) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint32(o.ProfileType)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Network) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -12697,6 +12730,9 @@ func (o *Network) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint32)(&o.ProfileType)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -12754,6 +12790,9 @@ func (o *Adapter) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Adapter) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -12774,6 +12813,9 @@ func (o *Adapter) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.GUID = &dtyp.GUID{}
 	}
 	if err := o.GUID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -13610,6 +13652,9 @@ func (o *CSRule20) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint32(o.Status)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CSRule20) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13787,6 +13832,9 @@ func (o *CSRule20) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint32)(&o.Status)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -17019,6 +17067,9 @@ func (o *AuthSet210) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AuthSetFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AuthSet210) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -17136,6 +17187,9 @@ func (o *AuthSet210) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.AuthSetFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -17387,6 +17441,9 @@ func (o *AuthSet) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AuthSetFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AuthSet) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -17504,6 +17561,9 @@ func (o *AuthSet) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.AuthSetFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -18303,6 +18363,9 @@ func (o *CryptoSet) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.CryptoSetFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CryptoSet) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -18392,6 +18455,9 @@ func (o *CryptoSet) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.CryptoSetFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -18633,6 +18699,9 @@ func (o *CryptoSet_CryptoSet_Phase1) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.TimeoutSessions); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CryptoSet_CryptoSet_Phase1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -18681,6 +18750,9 @@ func (o *CryptoSet_CryptoSet_Phase1) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.TimeoutSessions); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -19088,6 +19160,9 @@ func (o *CertInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.CertFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CertInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -19101,6 +19176,9 @@ func (o *CertInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.CertFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -19154,6 +19232,9 @@ func (o *AuthInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AuthInfoFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AuthInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -19171,6 +19252,9 @@ func (o *AuthInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.AuthInfoFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -19610,6 +19694,9 @@ func (o *Endpoints) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Endpoints) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -19638,6 +19725,9 @@ func (o *Endpoints) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.DestinationV6Address[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -19787,6 +19877,9 @@ func (o *Phase1SADetails) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.P1SAFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Phase1SADetails) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -19853,6 +19946,9 @@ func (o *Phase1SADetails) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.P1SAFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -19999,6 +20095,9 @@ func (o *Phase2SADetails) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.P2SAFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Phase2SADetails) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -20042,6 +20141,9 @@ func (o *Phase2SADetails) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.P2SAFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -21778,6 +21880,9 @@ func (o *Query) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteEnum(uint32(o.Status)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Query) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -21823,6 +21928,9 @@ func (o *Query) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadEnum((*uint32)(&o.Status)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/fax/fax.go
+++ b/msrpc/fax/fax.go
@@ -696,7 +696,7 @@ func (o *JobParamW) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(o.StructureSize); err != nil {
@@ -861,10 +861,13 @@ func (o *JobParamW) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *JobParamW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData(&o.StructureSize); err != nil {
@@ -983,6 +986,9 @@ func (o *JobParamW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData((*ndr.Uint3264)(&_Reserved[i1])); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1482,6 +1488,9 @@ func (o *ReceiptsConfigW) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReceiptsConfigW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1557,6 +1566,9 @@ func (o *ReceiptsConfigW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	o.IsToUseForMsRouteThroughEmailMethod = _bIsToUseForMsRouteThroughEmailMethod != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2156,7 +2168,7 @@ func (o *JobParamExW) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(o.StructureSize); err != nil {
@@ -2222,10 +2234,13 @@ func (o *JobParamExW) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.PageCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *JobParamExW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData(&o.StructureSize); err != nil {
@@ -2279,6 +2294,9 @@ func (o *JobParamExW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.PageCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2421,6 +2439,9 @@ func (o *OutboundRoutingGroupw) MarshalNDR(ctx context.Context, w ndr.Writer) er
 	if err := w.WriteEnum(uint16(o.Status)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *OutboundRoutingGroupw) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2473,6 +2494,9 @@ func (o *OutboundRoutingGroupw) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.Status)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3145,6 +3169,9 @@ func (o *OutboundRoutingRuleW) MarshalNDR(ctx context.Context, w ndr.Writer) err
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *OutboundRoutingRuleW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3188,6 +3215,9 @@ func (o *OutboundRoutingRuleW) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	o.UseGroup = _bUseGroup != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4176,6 +4206,9 @@ func (o *ReassignInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReassignInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4227,6 +4260,9 @@ func (o *ReassignInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	o.HasCoverPage = _bHasCoverPage != 0
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/msrpc/irp/inetinfo/v2/v2.go
+++ b/msrpc/irp/inetinfo/v2/v2.go
@@ -885,6 +885,9 @@ func (o *InetLogConfiguration) MarshalNDR(ctx context.Context, w ndr.Writer) err
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *InetLogConfiguration) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -934,6 +937,9 @@ func (o *InetLogConfiguration) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		if err := w.ReadData(&o.Password[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1220,6 +1226,9 @@ func (o *VirtualRootEntry) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Error); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *VirtualRootEntry) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1279,6 +1288,9 @@ func (o *VirtualRootEntry) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 	if err := w.ReadData(&o.Error); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1333,6 +1345,9 @@ func (o *VirtualRootList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.EntriesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.VirtRootEntry {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -1370,6 +1385,9 @@ func (o *VirtualRootList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.EntriesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -1937,6 +1955,9 @@ func (o *SiteEntry) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Instance); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SiteEntry) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1954,6 +1975,9 @@ func (o *SiteEntry) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Instance); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2009,6 +2033,9 @@ func (o *SiteList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.EntriesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.SiteEntry {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -2046,6 +2073,9 @@ func (o *SiteList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.EntriesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -2288,6 +2318,9 @@ func (o *CacheStatistics) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TotalBlobFlushed); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CacheStatistics) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2355,6 +2388,9 @@ func (o *CacheStatistics) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.TotalBlobFlushed); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2503,6 +2539,9 @@ func (o *Statistics0) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Statistics0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2530,6 +2569,9 @@ func (o *Statistics0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Counters[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
 	}
 	return nil
 }
@@ -2998,6 +3040,9 @@ func (o *W3Statistics1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *W3Statistics1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3172,6 +3217,9 @@ func (o *W3Statistics1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Counters[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
 	}
 	return nil
 }
@@ -3461,6 +3509,9 @@ func (o *FTPStatistics0) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TimeOfLastClear); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FTPStatistics0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3534,6 +3585,9 @@ func (o *FTPStatistics0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TimeOfLastClear); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -3756,6 +3810,9 @@ func (o *IISUserInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Connect); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *IISUserInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3784,6 +3841,9 @@ func (o *IISUserInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Connect); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/lsad/lsarpc/v0/v0.go
+++ b/msrpc/lsad/lsarpc/v0/v0.go
@@ -1979,6 +1979,9 @@ func (o *SecurityQualityOfService) MarshalNDR(ctx context.Context, w ndr.Writer)
 	if err := w.WriteData(o.EffectiveOnly); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityQualityOfService) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1995,6 +1998,9 @@ func (o *SecurityQualityOfService) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	if err := w.ReadData(&o.EffectiveOnly); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -2654,6 +2660,9 @@ func (o *PolicyAuditLogInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.NextAuditRecordID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PolicyAuditLogInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2682,6 +2691,9 @@ func (o *PolicyAuditLogInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.NextAuditRecordID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -3512,6 +3524,9 @@ func (o *ForestTrustRecord) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ForestTrustRecord) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3535,6 +3550,9 @@ func (o *ForestTrustRecord) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 	}
 	_swForestTrustData := uint16(o.ForestTrustType)
 	if err := o.ForestTrustData.UnmarshalUnionNDR(ctx, w, _swForestTrustData); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4695,6 +4713,9 @@ func (o *PolicyPrivilegeDefinition) MarshalNDR(ctx context.Context, w ndr.Writer
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PolicyPrivilegeDefinition) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4711,6 +4732,9 @@ func (o *PolicyPrivilegeDefinition) UnmarshalNDR(ctx context.Context, w ndr.Read
 		o.LocalValue = &dtyp.LUID{}
 	}
 	if err := o.LocalValue.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5624,6 +5648,9 @@ func (o *PolicyAuditEventsInfo) MarshalNDR(ctx context.Context, w ndr.Writer) er
 	if err := w.WriteData(o.MaximumAuditEventCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PolicyAuditEventsInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5663,6 +5690,9 @@ func (o *PolicyAuditEventsInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 		return err
 	}
 	if err := w.ReadData(&o.MaximumAuditEventCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7383,6 +7413,9 @@ func (o *TrustedDomainInformationEx) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.TrustAttributes); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TrustedDomainInformationEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7421,6 +7454,9 @@ func (o *TrustedDomainInformationEx) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.TrustAttributes); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7551,6 +7587,9 @@ func (o *AuthInformation) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AuthInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7596,6 +7635,9 @@ func (o *AuthInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 	})
 	_s_AuthInfo := func(ptr interface{}) { o.AuthInfo = *ptr.(*[]byte) }
 	if err := w.ReadPointer(&o.AuthInfo, _s_AuthInfo, _ptr_AuthInfo); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/lsat/lsarpc/v0/v0.go
+++ b/msrpc/lsat/lsarpc/v0/v0.go
@@ -1025,6 +1025,9 @@ func (o *SecurityQualityOfService) MarshalNDR(ctx context.Context, w ndr.Writer)
 	if err := w.WriteData(o.EffectiveOnly); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityQualityOfService) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1041,6 +1044,9 @@ func (o *SecurityQualityOfService) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	if err := w.ReadData(&o.EffectiveOnly); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -1419,6 +1425,9 @@ func (o *ReferencedDomainList) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.MaxEntries); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ReferencedDomainList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1461,6 +1470,9 @@ func (o *ReferencedDomainList) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.MaxEntries); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2040,6 +2052,9 @@ func (o *TranslatedName) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.DomainIndex); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TranslatedName) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2056,6 +2071,9 @@ func (o *TranslatedName) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.DomainIndex); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2251,6 +2269,9 @@ func (o *TranslatedNameEx) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TranslatedNameEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2270,6 +2291,9 @@ func (o *TranslatedNameEx) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2685,6 +2709,9 @@ func (o *TranslatedSIDEx2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TranslatedSIDEx2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2711,6 +2738,9 @@ func (o *TranslatedSIDEx2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/negoex/negoex.go
+++ b/msrpc/negoex/negoex.go
@@ -181,6 +181,9 @@ func (o *AuthSchemeVector) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AuthSchemeCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AuthSchemeVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -191,6 +194,9 @@ func (o *AuthSchemeVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.AuthSchemeCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -232,6 +238,9 @@ func (o *ExtensionVector) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ExtensionCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ExtensionVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -242,6 +251,9 @@ func (o *ExtensionVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.ExtensionCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -427,6 +439,9 @@ func (o *AuthScheme) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AuthScheme) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -448,6 +463,9 @@ func (o *AuthScheme) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -495,6 +513,9 @@ func (o *ConversationID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ConversationID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -516,6 +537,9 @@ func (o *ConversationID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }
@@ -647,6 +671,9 @@ func (o *MessageHeader) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *MessageHeader) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -672,6 +699,9 @@ func (o *MessageHeader) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.ConversationID = &ConversationID{}
 	}
 	if err := o.ConversationID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -770,6 +800,9 @@ func (o *NegoMessage) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *NegoMessage) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -802,6 +835,9 @@ func (o *NegoMessage) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.Extensions = &ExtensionVector{}
 	}
 	if err := o.Extensions.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -870,6 +906,9 @@ func (o *ExchangeMessage) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ExchangeMessage) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -892,6 +931,9 @@ func (o *ExchangeMessage) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		o.Exchange = &ByteVector{}
 	}
 	if err := o.Exchange.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -957,6 +999,9 @@ func (o *VerifyMessage) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *VerifyMessage) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -979,6 +1024,9 @@ func (o *VerifyMessage) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.Checksum = &Checksum{}
 	}
 	if err := o.Checksum.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -1122,6 +1170,9 @@ func (o *AlertVector) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AlertCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AlertVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1132,6 +1183,9 @@ func (o *AlertVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.AlertCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -1202,6 +1256,9 @@ func (o *AlertMessage) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *AlertMessage) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1227,6 +1284,9 @@ func (o *AlertMessage) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.Alerts = &AlertVector{}
 	}
 	if err := o.Alerts.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/nrpc/logon/v1/v1.go
+++ b/msrpc/nrpc/logon/v1/v1.go
@@ -2595,6 +2595,9 @@ func (o *DeltaUser) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaUser) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2818,6 +2821,9 @@ func (o *DeltaUser) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&_DummyLong4); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3009,6 +3015,9 @@ func (o *DeltaGroup) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaGroup) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3118,6 +3127,9 @@ func (o *DeltaGroup) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3255,6 +3267,9 @@ func (o *DeltaGroupMember) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaGroupMember) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3340,6 +3355,9 @@ func (o *DeltaGroupMember) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3492,6 +3510,9 @@ func (o *DeltaAlias) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaAlias) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3592,6 +3613,9 @@ func (o *DeltaAlias) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&_DummyLong4); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3655,6 +3679,9 @@ func (o *DeltaAliasMember) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaAliasMember) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3685,6 +3712,9 @@ func (o *DeltaAliasMember) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3906,6 +3936,9 @@ func (o *DeltaDomain) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaDomain) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4043,6 +4076,9 @@ func (o *DeltaDomain) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&_DummyLong4); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4143,6 +4179,9 @@ func (o *RenameGroup) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RenameGroup) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4211,6 +4250,9 @@ func (o *RenameGroup) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4313,6 +4355,9 @@ func (o *RenameUser) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RenameUser) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4381,6 +4426,9 @@ func (o *RenameUser) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4483,6 +4531,9 @@ func (o *RenameAlias) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RenameAlias) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4551,6 +4602,9 @@ func (o *RenameAlias) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4829,6 +4883,9 @@ func (o *DeltaPolicy) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaPolicy) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5001,6 +5058,9 @@ func (o *DeltaPolicy) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5197,6 +5257,9 @@ func (o *DeltaTrustedDomains) MarshalNDR(ctx context.Context, w ndr.Writer) erro
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaTrustedDomains) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5327,6 +5390,9 @@ func (o *DeltaTrustedDomains) UnmarshalNDR(ctx context.Context, w ndr.Reader) er
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5620,6 +5686,9 @@ func (o *DeltaAccounts) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaAccounts) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5787,6 +5856,9 @@ func (o *DeltaAccounts) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5966,6 +6038,9 @@ func (o *DeltaSecret) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaSecret) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6083,6 +6158,9 @@ func (o *DeltaSecret) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&_DummyLong4); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -6179,6 +6257,9 @@ func (o *DeltaDeleteGroup) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaDeleteGroup) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6245,6 +6326,9 @@ func (o *DeltaDeleteGroup) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6342,6 +6426,9 @@ func (o *DeltaDeleteUser) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DeltaDeleteUser) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6408,6 +6495,9 @@ func (o *DeltaDeleteUser) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8542,6 +8632,9 @@ func (o *InteractiveInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *InteractiveInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8564,6 +8657,9 @@ func (o *InteractiveInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		o.NTOWFPassword = &NTOWFPassword{}
 	}
 	if err := o.NTOWFPassword.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8686,6 +8782,9 @@ func (o *ServiceInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServiceInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8708,6 +8807,9 @@ func (o *ServiceInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.NTOWFPassword = &NTOWFPassword{}
 	}
 	if err := o.NTOWFPassword.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -9882,6 +9984,9 @@ func (o *SIDAndAttributes) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Attributes); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SIDAndAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9902,6 +10007,9 @@ func (o *SIDAndAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.Attributes); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -10195,6 +10303,9 @@ func (o *ValidationSAMInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ValidationSAMInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10360,6 +10471,9 @@ func (o *ValidationSAMInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		if err := w.ReadData(&o.ExpansionRoom[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -12651,6 +12765,9 @@ func (o *Info2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TCConnectionStatus); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Info2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -12674,6 +12791,9 @@ func (o *Info2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TCConnectionStatus); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -13702,6 +13822,9 @@ func (o *OneDomainInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *OneDomainInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13793,6 +13916,9 @@ func (o *OneDomainInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -13978,6 +14104,9 @@ func (o *DomainInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DomainInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14075,6 +14204,9 @@ func (o *DomainInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -14486,6 +14618,9 @@ func (o *WorkstationInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *WorkstationInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14608,6 +14743,9 @@ func (o *WorkstationInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 	// reserved DummyLong4
 	var _DummyLong4 uint32
 	if err := w.ReadData(&_DummyLong4); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -14897,6 +15035,9 @@ func (o *SocketAddress) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.SockaddrLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SocketAddress) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14933,6 +15074,9 @@ func (o *SocketAddress) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.SockaddrLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -15266,6 +15410,9 @@ func (o *DSDomainTrustsw) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DSDomainTrustsw) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15321,6 +15468,9 @@ func (o *DSDomainTrustsw) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		o.DomainGUID = &dtyp.GUID{}
 	}
 	if err := o.DomainGUID.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -15963,6 +16113,9 @@ func (o *ValidationUASInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ValidationUASInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -16047,6 +16200,9 @@ func (o *ValidationUASInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 	if err := w.ReadData(&_usrlog1_reserved1); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -16077,6 +16233,9 @@ func (o *LogoffUASInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.LogonCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *LogoffUASInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -16087,6 +16246,9 @@ func (o *LogoffUASInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.LogonCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -17318,6 +17480,9 @@ func (o *ForestTrustRecord) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ForestTrustRecord) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -17341,6 +17506,9 @@ func (o *ForestTrustRecord) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 	}
 	_swForestTrustData := uint16(o.ForestTrustType)
 	if err := o.ForestTrustData.UnmarshalUnionNDR(ctx, w, _swForestTrustData); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -17843,6 +18011,9 @@ func (o *DNSNameInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Status); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DNSNameInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -17878,6 +18049,9 @@ func (o *DNSNameInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Status); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -18111,6 +18285,9 @@ func (o *OSVersionInfoV1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint8(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *OSVersionInfoV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -18154,6 +18331,9 @@ func (o *OSVersionInfoV1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 	// reserved wReserved
 	var _wReserved uint8
 	if err := w.ReadData(&_wReserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/nspi/nspi/v56/v56.go
+++ b/msrpc/nspi/nspi/v56/v56.go
@@ -405,6 +405,9 @@ func (o *PropertyTagArray) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ValuesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	dimLength1 := uint64(o.ValuesCount)
 	if dimLength1 > sizeInfo[0] {
 		dimLength1 = sizeInfo[0]
@@ -448,6 +451,9 @@ func (o *PropertyTagArray) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.ValuesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	for sz1 := range sizeInfo {
@@ -1695,6 +1701,9 @@ func (o *PropertyRowSet) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.RowsCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Row {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -1732,6 +1741,9 @@ func (o *PropertyRowSet) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.RowsCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -3276,6 +3288,9 @@ func (o *PropertyName) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PropertyName) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3301,6 +3316,9 @@ func (o *PropertyName) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.ID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3359,6 +3377,9 @@ func (o *PropertyNameSet) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.NamesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Names {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -3396,6 +3417,9 @@ func (o *PropertyNameSet) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.NamesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/pac/pac.go
+++ b/msrpc/pac/pac.go
@@ -251,6 +251,9 @@ func (o *KerberosSIDAndAttributes) MarshalNDR(ctx context.Context, w ndr.Writer)
 	if err := w.WriteData(o.Attributes); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *KerberosSIDAndAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -271,6 +274,9 @@ func (o *KerberosSIDAndAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	if err := w.ReadData(&o.Attributes); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1907,6 +1913,9 @@ func (o *PACCredentialData) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(o.CredentialCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Credentials {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -1944,6 +1953,9 @@ func (o *PACCredentialData) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.CredentialCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -2192,6 +2204,9 @@ func (o *NTLMSupplementalCredential) MarshalNDR(ctx context.Context, w ndr.Write
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *NTLMSupplementalCredential) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2217,6 +2232,9 @@ func (o *NTLMSupplementalCredential) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		if err := w.ReadData(&o.NTPassword[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }

--- a/msrpc/pan/irpcasyncnotify/v1/v1.go
+++ b/msrpc/pan/irpcasyncnotify/v1/v1.go
@@ -586,6 +586,9 @@ func (o *NotificationType) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *NotificationType) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -607,6 +610,9 @@ func (o *NotificationType) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		if err := w.ReadData(&o.Data4[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
+		return err
 	}
 	return nil
 }

--- a/msrpc/par/iremotewinspool/v1/v1.go
+++ b/msrpc/par/iremotewinspool/v1/v1.go
@@ -3463,6 +3463,9 @@ func (o *DriverInfo6) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DriverInfo6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3667,6 +3670,9 @@ func (o *DriverInfo6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_pProvider := func(ptr interface{}) { o.Provider = *ptr.(*string) }
 	if err := w.ReadPointer(&o.Provider, _s_pProvider, _ptr_pProvider); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4591,6 +4597,9 @@ func (o *FormInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FormInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4620,6 +4629,9 @@ func (o *FormInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.ImageableArea = &Rectangle{}
 	}
 	if err := o.ImageableArea.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4744,6 +4756,9 @@ func (o *FormInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.LangID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FormInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4812,6 +4827,9 @@ func (o *FormInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.LangID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4966,6 +4984,9 @@ func (o *JobInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *JobInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5054,6 +5075,9 @@ func (o *JobInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.Submitted = &dtyp.SystemTime{}
 	}
 	if err := o.Submitted.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5332,6 +5356,9 @@ func (o *JobInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.PagesPrinted); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *JobInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5498,6 +5525,9 @@ func (o *JobInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.PagesPrinted); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5832,6 +5862,9 @@ func (o *JobInfo4) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.SizeHigh); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *JobInfo4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6001,6 +6034,9 @@ func (o *JobInfo4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.SizeHigh); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6296,6 +6332,9 @@ func (o *PortInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PortInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6338,6 +6377,9 @@ func (o *PortInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved Reserved
 	var _Reserved uint32
 	if err := w.ReadData(&_Reserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6386,6 +6428,9 @@ func (o *PortInfo3) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Severity); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PortInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6406,6 +6451,9 @@ func (o *PortInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Severity); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6661,6 +6709,9 @@ func (o *PrinterInfoStress) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfoStress) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6773,6 +6824,9 @@ func (o *PrinterInfoStress) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 	// reserved dwReserved3
 	var _dwReserved3 uint32
 	if err := w.ReadData(&_dwReserved3); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7162,6 +7216,9 @@ func (o *PrinterInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AveragePpm); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7328,6 +7385,9 @@ func (o *PrinterInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.AveragePpm); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7449,6 +7509,9 @@ func (o *PrinterInfo4) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Attributes); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfo4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7476,6 +7539,9 @@ func (o *PrinterInfo4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Attributes); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7544,6 +7610,9 @@ func (o *PrinterInfo5) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TransmissionRetryTimeout); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfo5) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7577,6 +7646,9 @@ func (o *PrinterInfo5) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TransmissionRetryTimeout); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7656,6 +7728,9 @@ func (o *PrinterInfo7) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Action); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfo7) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7673,6 +7748,9 @@ func (o *PrinterInfo7) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Action); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7875,6 +7953,9 @@ func (o *ClientInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ProcessorArchitecture); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClientInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7916,6 +7997,9 @@ func (o *ClientInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.ProcessorArchitecture); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7936,7 +8020,7 @@ func (o *ClientInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(4); err != nil {
 		return err
 	}
 	if err := w.WriteData(ndr.Int3264(o.NotUsed)); err != nil {
@@ -7945,7 +8029,7 @@ func (o *ClientInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	return nil
 }
 func (o *ClientInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(4); err != nil {
 		return err
 	}
 	if err := w.ReadData((*ndr.Int3264)(&o.NotUsed)); err != nil {
@@ -11953,6 +12037,9 @@ func (o *BIDIRequestContainer) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Data {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -11996,6 +12083,9 @@ func (o *BIDIRequestContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -12070,6 +12160,9 @@ func (o *BIDIResponseContainer) MarshalNDR(ctx context.Context, w ndr.Writer) er
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Data {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -12113,6 +12206,9 @@ func (o *BIDIResponseContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -13486,6 +13582,9 @@ func (o *V2NotifyInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Data {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -13529,6 +13628,9 @@ func (o *V2NotifyInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -13802,6 +13904,9 @@ func (o *BranchOfficeJobDataPrinted) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.TotalPages); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *BranchOfficeJobDataPrinted) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13867,6 +13972,9 @@ func (o *BranchOfficeJobDataPrinted) UnmarshalNDR(ctx context.Context, w ndr.Rea
 	if err := w.ReadData(&o.TotalPages); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -13917,6 +14025,9 @@ func (o *BranchOfficeJobDataRendered) MarshalNDR(ctx context.Context, w ndr.Writ
 	if err := w.WriteData(o.TTOption); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *BranchOfficeJobDataRendered) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13942,6 +14053,9 @@ func (o *BranchOfficeJobDataRendered) UnmarshalNDR(ctx context.Context, w ndr.Re
 		return err
 	}
 	if err := w.ReadData(&o.TTOption); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -14098,6 +14212,9 @@ func (o *BranchOfficeJobDataError) MarshalNDR(ctx context.Context, w ndr.Writer)
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *BranchOfficeJobDataError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14187,6 +14304,9 @@ func (o *BranchOfficeJobDataError) UnmarshalNDR(ctx context.Context, w ndr.Reade
 	})
 	_s_pErrorDescription := func(ptr interface{}) { o.ErrorDescription = *ptr.(*string) }
 	if err := w.ReadPointer(&o.ErrorDescription, _s_pErrorDescription, _ptr_pErrorDescription); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -14793,6 +14913,9 @@ func (o *BranchOfficeJobDataContainer) MarshalNDR(ctx context.Context, w ndr.Wri
 	if err := w.WriteData(o.JobDataEntriesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.JobData {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -14830,6 +14953,9 @@ func (o *BranchOfficeJobDataContainer) UnmarshalNDR(ctx context.Context, w ndr.R
 		return err
 	}
 	if err := w.ReadData(&o.JobDataEntriesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -16029,6 +16155,9 @@ func (o *CorePrinterDriver) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CorePrinterDriver) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -16056,6 +16185,9 @@ func (o *CorePrinterDriver) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		if err := w.ReadData(&o.PackageID[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
 	}
 	return nil
 }

--- a/msrpc/raa/authzr/v0/v0.go
+++ b/msrpc/raa/authzr/v0/v0.go
@@ -761,6 +761,9 @@ func (o *SIDAndAttributes) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Attributes); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SIDAndAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -781,6 +784,9 @@ func (o *SIDAndAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.Attributes); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -884,6 +890,9 @@ func (o *TokenGroups) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.GroupCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Groups {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -921,6 +930,9 @@ func (o *TokenGroups) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.GroupCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/raiw/raiw.go
+++ b/msrpc/raiw/raiw.go
@@ -491,6 +491,9 @@ func (o *RecordAction) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(ndr.Uint3264(o.Timestamp)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *RecordAction) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -595,6 +598,9 @@ func (o *RecordAction) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData((*ndr.Uint3264)(&o.Timestamp)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -1378,6 +1384,9 @@ func (o *Results) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Results) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1425,6 +1434,9 @@ func (o *Results) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.WINSStat = &Stat{}
 	}
 	if err := o.WINSStat.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -1575,6 +1587,9 @@ func (o *ResultsNew) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ResultsNew) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1644,6 +1659,9 @@ func (o *ResultsNew) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.WINSStat = &Stat{}
 	}
 	if err := o.WINSStat.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -1765,6 +1783,9 @@ func (o *Records) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TotalNumberOfRecords); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *Records) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1810,6 +1831,9 @@ func (o *Records) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TotalNumberOfRecords); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/rpcl/rpcl.go
+++ b/msrpc/rpcl/rpcl.go
@@ -198,6 +198,9 @@ func (o *SyntaxID) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SyntaxID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -214,6 +217,9 @@ func (o *SyntaxID) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.SyntaxVersion = &Version{}
 	}
 	if err := o.SyntaxVersion.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -414,6 +420,9 @@ func (o *BindingVector) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Binding {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -451,6 +460,9 @@ func (o *BindingVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -521,6 +533,9 @@ func (o *UUIDVector) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.UUID {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -570,6 +585,9 @@ func (o *UUIDVector) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/rprn/winspool/v1/v1.go
+++ b/msrpc/rprn/winspool/v1/v1.go
@@ -3485,6 +3485,9 @@ func (o *DriverInfo6) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DriverInfo6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3689,6 +3692,9 @@ func (o *DriverInfo6) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_pProvider := func(ptr interface{}) { o.Provider = *ptr.(*string) }
 	if err := w.ReadPointer(&o.Provider, _s_pProvider, _ptr_pProvider); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -4636,6 +4642,9 @@ func (o *FormInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FormInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4665,6 +4674,9 @@ func (o *FormInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.ImageableArea = &Rectangle{}
 	}
 	if err := o.ImageableArea.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4829,6 +4841,9 @@ func (o *FormInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.LangID); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *FormInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4897,6 +4912,9 @@ func (o *FormInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.LangID); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5072,6 +5090,9 @@ func (o *JobInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *JobInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5162,6 +5183,9 @@ func (o *JobInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := o.Submitted.UnmarshalNDR(ctx, w); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -5225,7 +5249,7 @@ func (o *JobInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(o.JobID); err != nil {
@@ -5423,10 +5447,13 @@ func (o *JobInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.PagesPrinted); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *JobInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData(&o.JobID); err != nil {
@@ -5569,6 +5596,9 @@ func (o *JobInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.PagesPrinted); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5714,7 +5744,7 @@ func (o *JobInfo4) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(o.JobID); err != nil {
@@ -5915,10 +5945,13 @@ func (o *JobInfo4) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.SizeHigh); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *JobInfo4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData(&o.JobID); err != nil {
@@ -6064,6 +6097,9 @@ func (o *JobInfo4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.SizeHigh); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6469,6 +6505,9 @@ func (o *PortInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PortInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6511,6 +6550,9 @@ func (o *PortInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved Reserved
 	var _Reserved uint32
 	if err := w.ReadData(&_Reserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6613,6 +6655,9 @@ func (o *PortInfo3) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Severity); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PortInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6633,6 +6678,9 @@ func (o *PortInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Severity); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6959,6 +7007,9 @@ func (o *PrinterInfoStress) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfoStress) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7071,6 +7122,9 @@ func (o *PrinterInfoStress) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 	// reserved dwReserved3
 	var _dwReserved3 uint32
 	if err := w.ReadData(&_dwReserved3); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7303,7 +7357,7 @@ func (o *PrinterInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if o.ServerName != "" {
@@ -7501,10 +7555,13 @@ func (o *PrinterInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.AveragePpm); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	_ptr_pServerName := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
@@ -7647,6 +7704,9 @@ func (o *PrinterInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.AveragePpm); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7688,7 +7748,7 @@ func (o *PrinterInfo3) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(4); err != nil {
 		return err
 	}
 	if err := w.WriteData(ndr.Uint3264(o.SecurityDescriptor)); err != nil {
@@ -7697,7 +7757,7 @@ func (o *PrinterInfo3) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	return nil
 }
 func (o *PrinterInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(4); err != nil {
 		return err
 	}
 	if err := w.ReadData((*ndr.Uint3264)(&o.SecurityDescriptor)); err != nil {
@@ -7782,6 +7842,9 @@ func (o *PrinterInfo4) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Attributes); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfo4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7809,6 +7872,9 @@ func (o *PrinterInfo4) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Attributes); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -7906,6 +7972,9 @@ func (o *PrinterInfo5) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.TransmissionRetryTimeout); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfo5) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7939,6 +8008,9 @@ func (o *PrinterInfo5) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.TransmissionRetryTimeout); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8097,6 +8169,9 @@ func (o *PrinterInfo7) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Action); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PrinterInfo7) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8114,6 +8189,9 @@ func (o *PrinterInfo7) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Action); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8159,7 +8237,7 @@ func (o *PrinterInfo8) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(4); err != nil {
 		return err
 	}
 	if err := w.WriteData(ndr.Uint3264(o.DevMode)); err != nil {
@@ -8168,7 +8246,7 @@ func (o *PrinterInfo8) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	return nil
 }
 func (o *PrinterInfo8) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(4); err != nil {
 		return err
 	}
 	if err := w.ReadData((*ndr.Uint3264)(&o.DevMode)); err != nil {
@@ -8196,7 +8274,7 @@ func (o *PrinterInfo9) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(4); err != nil {
 		return err
 	}
 	if err := w.WriteData(ndr.Uint3264(o.DevMode)); err != nil {
@@ -8205,7 +8283,7 @@ func (o *PrinterInfo9) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	return nil
 }
 func (o *PrinterInfo9) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(4); err != nil {
 		return err
 	}
 	if err := w.ReadData((*ndr.Uint3264)(&o.DevMode)); err != nil {
@@ -8291,6 +8369,9 @@ func (o *ClientInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ProcessorArchitecture); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ClientInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8332,6 +8413,9 @@ func (o *ClientInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.ProcessorArchitecture); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8356,7 +8440,7 @@ func (o *ClientInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(4); err != nil {
 		return err
 	}
 	if err := w.WriteData(ndr.Int3264(o.NotUsed)); err != nil {
@@ -8365,7 +8449,7 @@ func (o *ClientInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	return nil
 }
 func (o *ClientInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(4); err != nil {
 		return err
 	}
 	if err := w.ReadData((*ndr.Int3264)(&o.NotUsed)); err != nil {
@@ -12597,6 +12681,9 @@ func (o *BIDIRequestContainer) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Data {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -12640,6 +12727,9 @@ func (o *BIDIRequestContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -12725,6 +12815,9 @@ func (o *BIDIResponseContainer) MarshalNDR(ctx context.Context, w ndr.Writer) er
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Data {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -12768,6 +12861,9 @@ func (o *BIDIResponseContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -14269,6 +14365,9 @@ func (o *V2NotifyInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Data {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -14312,6 +14411,9 @@ func (o *V2NotifyInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Count); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -14577,6 +14679,9 @@ func (o *CorePrinterDriver) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *CorePrinterDriver) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -14604,6 +14709,9 @@ func (o *CorePrinterDriver) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		if err := w.ReadData(&o.PackageID[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
 	}
 	return nil
 }
@@ -15356,6 +15464,9 @@ func (o *BranchOfficeJobDataPrinted) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.TotalPages); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *BranchOfficeJobDataPrinted) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15419,6 +15530,9 @@ func (o *BranchOfficeJobDataPrinted) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.TotalPages); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -15490,6 +15604,9 @@ func (o *BranchOfficeJobDataRendered) MarshalNDR(ctx context.Context, w ndr.Writ
 	if err := w.WriteData(o.TTOption); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *BranchOfficeJobDataRendered) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15515,6 +15632,9 @@ func (o *BranchOfficeJobDataRendered) UnmarshalNDR(ctx context.Context, w ndr.Re
 		return err
 	}
 	if err := w.ReadData(&o.TTOption); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -15702,6 +15822,9 @@ func (o *BranchOfficeJobDataError) MarshalNDR(ctx context.Context, w ndr.Writer)
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *BranchOfficeJobDataError) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15791,6 +15914,9 @@ func (o *BranchOfficeJobDataError) UnmarshalNDR(ctx context.Context, w ndr.Reade
 	})
 	_s_pErrorDescription := func(ptr interface{}) { o.ErrorDescription = *ptr.(*string) }
 	if err := w.ReadPointer(&o.ErrorDescription, _s_pErrorDescription, _ptr_pErrorDescription); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -16453,6 +16579,9 @@ func (o *BranchOfficeJobDataContainer) MarshalNDR(ctx context.Context, w ndr.Wri
 	if err := w.WriteData(o.JobDataEntriesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	for i1 := range o.JobData {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -16490,6 +16619,9 @@ func (o *BranchOfficeJobDataContainer) UnmarshalNDR(ctx context.Context, w ndr.R
 		return err
 	}
 	if err := w.ReadData(&o.JobDataEntriesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/rrp/winreg/v1/v1.go
+++ b/msrpc/rrp/winreg/v1/v1.go
@@ -1164,6 +1164,9 @@ func (o *ValueEntry) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Type); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ValueEntry) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1197,6 +1200,9 @@ func (o *ValueEntry) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Type); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1287,6 +1293,9 @@ func (o *SecurityDescriptor) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.OutSecurityDescriptorLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityDescriptor) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1330,6 +1339,9 @@ func (o *SecurityDescriptor) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.OutSecurityDescriptorLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1379,6 +1391,9 @@ func (o *SecurityAttributes) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.InheritHandle); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SecurityAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1395,6 +1410,9 @@ func (o *SecurityAttributes) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.InheritHandle); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/samr/samr/v1/v1.go
+++ b/msrpc/samr/samr/v1/v1.go
@@ -1011,6 +1011,9 @@ func (o *KerberosKeyData) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.KeyOffset); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *KerberosKeyData) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1039,6 +1042,9 @@ func (o *KerberosKeyData) UnmarshalNDR(ctx context.Context, w ndr.Reader) error 
 		return err
 	}
 	if err := w.ReadData(&o.KeyOffset); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -1552,6 +1558,9 @@ func (o *KerberosKeyDataNew) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.KeyOffset); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(4); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *KerberosKeyDataNew) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1583,6 +1592,9 @@ func (o *KerberosKeyDataNew) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.KeyOffset); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(4); err != nil {
 		return err
 	}
 	return nil
@@ -3229,6 +3241,9 @@ func (o *UserProperties) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint8(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UserProperties) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3344,6 +3359,9 @@ func (o *UserProperties) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	// reserved Reserved5
 	var _Reserved5 uint8
 	if err := w.ReadData(&_Reserved5); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5781,6 +5799,9 @@ func (o *DomainGeneralInformation) MarshalNDR(ctx context.Context, w ndr.Writer)
 	if err := w.WriteData(o.AliasCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DomainGeneralInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5833,6 +5854,9 @@ func (o *DomainGeneralInformation) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	if err := w.ReadData(&o.AliasCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5896,6 +5920,9 @@ func (o *DomainGeneralInformation2) MarshalNDR(ctx context.Context, w ndr.Writer
 	if err := w.WriteData(o.LockoutThreshold); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DomainGeneralInformation2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5921,6 +5948,9 @@ func (o *DomainGeneralInformation2) UnmarshalNDR(ctx context.Context, w ndr.Read
 		return err
 	}
 	if err := w.ReadData(&o.LockoutThreshold); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -6117,6 +6147,9 @@ func (o *DomainLockoutInformation) MarshalNDR(ctx context.Context, w ndr.Writer)
 	if err := w.WriteData(o.LockoutThreshold); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *DomainLockoutInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6136,6 +6169,9 @@ func (o *DomainLockoutInformation) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	if err := w.ReadData(&o.LockoutThreshold); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -10020,6 +10056,9 @@ func (o *UserAllInformation) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.PrivateDataSensitive); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UserAllInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10188,6 +10227,9 @@ func (o *UserAllInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 	if err := w.ReadData(&o.PrivateDataSensitive); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -10342,6 +10384,9 @@ func (o *UserPreferencesInformation) MarshalNDR(ctx context.Context, w ndr.Write
 	if err := w.WriteData(o.CodePage); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(7); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UserPreferencesInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10366,6 +10411,9 @@ func (o *UserPreferencesInformation) UnmarshalNDR(ctx context.Context, w ndr.Rea
 		return err
 	}
 	if err := w.ReadData(&o.CodePage); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(7); err != nil {
 		return err
 	}
 	return nil
@@ -10592,6 +10640,9 @@ func (o *UserLogonInformation) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.UserAccountControl); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UserLogonInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10689,6 +10740,9 @@ func (o *UserLogonInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.UserAccountControl); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -10867,6 +10921,9 @@ func (o *UserAccountInformation) MarshalNDR(ctx context.Context, w ndr.Writer) e
 	if err := w.WriteData(o.UserAccountControl); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UserAccountInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -10964,6 +11021,9 @@ func (o *UserAccountInformation) UnmarshalNDR(ctx context.Context, w ndr.Reader)
 		return err
 	}
 	if err := w.ReadData(&o.UserAccountControl); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -11564,6 +11624,9 @@ func (o *UserInternal4Information) MarshalNDR(ctx context.Context, w ndr.Writer)
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UserInternal4Information) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -11580,6 +11643,9 @@ func (o *UserInternal4Information) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		o.UserPassword = &EncryptedUserPassword{}
 	}
 	if err := o.UserPassword.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -11631,6 +11697,9 @@ func (o *UserInternal4InformationNew) MarshalNDR(ctx context.Context, w ndr.Writ
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UserInternal4InformationNew) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -11647,6 +11716,9 @@ func (o *UserInternal4InformationNew) UnmarshalNDR(ctx context.Context, w ndr.Re
 		o.UserPassword = &EncryptedUserPasswordNew{}
 	}
 	if err := o.UserPassword.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -13489,6 +13561,9 @@ func (o *SAMValidatePersistedFields) MarshalNDR(ctx context.Context, w ndr.Write
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SAMValidatePersistedFields) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13552,6 +13627,9 @@ func (o *SAMValidatePersistedFields) UnmarshalNDR(ctx context.Context, w ndr.Rea
 	})
 	_s_PasswordHistory := func(ptr interface{}) { o.PasswordHistory = *ptr.(*[]*SAMValidatePasswordHash) }
 	if err := w.ReadPointer(&o.PasswordHistory, _s_PasswordHistory, _ptr_PasswordHistory); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -13655,6 +13733,9 @@ func (o *SAMValidateStandardOutputArg) MarshalNDR(ctx context.Context, w ndr.Wri
 	if err := w.WriteEnum(uint16(o.ValidationStatus)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SAMValidateStandardOutputArg) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13668,6 +13749,9 @@ func (o *SAMValidateStandardOutputArg) UnmarshalNDR(ctx context.Context, w ndr.R
 		return err
 	}
 	if err := w.ReadEnum((*uint16)(&o.ValidationStatus)); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -13712,6 +13796,9 @@ func (o *SAMValidateAuthenticationInputArg) MarshalNDR(ctx context.Context, w nd
 	if err := w.WriteData(o.PasswordMatched); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SAMValidateAuthenticationInputArg) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13725,6 +13812,9 @@ func (o *SAMValidateAuthenticationInputArg) UnmarshalNDR(ctx context.Context, w 
 		return err
 	}
 	if err := w.ReadData(&o.PasswordMatched); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -13811,6 +13901,9 @@ func (o *SAMValidatePasswordChangeInputArg) MarshalNDR(ctx context.Context, w nd
 	if err := w.WriteData(o.PasswordMatch); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SAMValidatePasswordChangeInputArg) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13842,6 +13935,9 @@ func (o *SAMValidatePasswordChangeInputArg) UnmarshalNDR(ctx context.Context, w 
 		return err
 	}
 	if err := w.ReadData(&o.PasswordMatch); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -13926,6 +14022,9 @@ func (o *SAMValidatePasswordResetInputArg) MarshalNDR(ctx context.Context, w ndr
 	if err := w.WriteData(o.ClearLockout); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SAMValidatePasswordResetInputArg) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -13960,6 +14059,9 @@ func (o *SAMValidatePasswordResetInputArg) UnmarshalNDR(ctx context.Context, w n
 		return err
 	}
 	if err := w.ReadData(&o.ClearLockout); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/sch/itaskschedulerservice/v1/v1.go
+++ b/msrpc/sch/itaskschedulerservice/v1/v1.go
@@ -266,6 +266,9 @@ func (o *TaskUserCred) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TaskUserCred) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -293,6 +296,9 @@ func (o *TaskUserCred) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/scmr/svcctl/v2/v2.go
+++ b/msrpc/scmr/svcctl/v2/v2.go
@@ -2536,6 +2536,9 @@ func (o *QueryServiceLockStatusW) MarshalNDR(ctx context.Context, w ndr.Writer) 
 	if err := w.WriteData(o.LockDuration); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *QueryServiceLockStatusW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2556,6 +2559,9 @@ func (o *QueryServiceLockStatusW) UnmarshalNDR(ctx context.Context, w ndr.Reader
 		return err
 	}
 	if err := w.ReadData(&o.LockDuration); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2903,6 +2909,9 @@ func (o *QueryServiceLockStatusA) MarshalNDR(ctx context.Context, w ndr.Writer) 
 	if err := w.WriteData(o.LockDuration); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *QueryServiceLockStatusA) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2923,6 +2932,9 @@ func (o *QueryServiceLockStatusA) UnmarshalNDR(ctx context.Context, w ndr.Reader
 		return err
 	}
 	if err := w.ReadData(&o.LockDuration); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3787,6 +3799,9 @@ func (o *ServicePreferredNodeInfo) MarshalNDR(ctx context.Context, w ndr.Writer)
 	if err := w.WriteData(o.Delete); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(2); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServicePreferredNodeInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3797,6 +3812,9 @@ func (o *ServicePreferredNodeInfo) UnmarshalNDR(ctx context.Context, w ndr.Reade
 		return err
 	}
 	if err := w.ReadData(&o.Delete); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(2); err != nil {
 		return err
 	}
 	return nil
@@ -4421,6 +4439,9 @@ func (o *EnumServiceStatusA) MarshalNDR(ctx context.Context, w ndr.Writer) error
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *EnumServiceStatusA) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4451,6 +4472,9 @@ func (o *EnumServiceStatusA) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		o.ServiceStatus = &ServiceStatus{}
 	}
 	if err := o.ServiceStatus.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4527,6 +4551,9 @@ func (o *EnumServiceStatusW) MarshalNDR(ctx context.Context, w ndr.Writer) error
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *EnumServiceStatusW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4557,6 +4584,9 @@ func (o *EnumServiceStatusW) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		o.ServiceStatus = &ServiceStatus{}
 	}
 	if err := o.ServiceStatus.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4633,6 +4663,9 @@ func (o *EnumServiceStatusProcessA) MarshalNDR(ctx context.Context, w ndr.Writer
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *EnumServiceStatusProcessA) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4663,6 +4696,9 @@ func (o *EnumServiceStatusProcessA) UnmarshalNDR(ctx context.Context, w ndr.Read
 		o.ServiceStatusProcess = &ServiceStatusProcess{}
 	}
 	if err := o.ServiceStatusProcess.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -4739,6 +4775,9 @@ func (o *EnumServiceStatusProcessW) MarshalNDR(ctx context.Context, w ndr.Writer
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *EnumServiceStatusProcessW) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -4769,6 +4808,9 @@ func (o *EnumServiceStatusProcessW) UnmarshalNDR(ctx context.Context, w ndr.Read
 		o.ServiceStatusProcess = &ServiceStatusProcess{}
 	}
 	if err := o.ServiceStatusProcess.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -6771,6 +6813,9 @@ func (o *ServiceNotifyStatusChangeParams1) MarshalNDR(ctx context.Context, w ndr
 	if err := w.WriteData(o.Sequence); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServiceNotifyStatusChangeParams1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -6807,6 +6852,9 @@ func (o *ServiceNotifyStatusChangeParams1) UnmarshalNDR(ctx context.Context, w n
 		return err
 	}
 	if err := w.ReadData(&o.Sequence); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -6962,6 +7010,9 @@ func (o *ServiceNotifyStatusChangeParams2) MarshalNDR(ctx context.Context, w ndr
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServiceNotifyStatusChangeParams2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7011,6 +7062,9 @@ func (o *ServiceNotifyStatusChangeParams2) UnmarshalNDR(ctx context.Context, w n
 	})
 	_s_pszServiceNames := func(ptr interface{}) { o.ServiceNames = *ptr.(*string) }
 	if err := w.ReadPointer(&o.ServiceNames, _s_pszServiceNames, _ptr_pszServiceNames); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -7108,6 +7162,9 @@ func (o *ServiceNotifyStatusChangeParams) MarshalNDR(ctx context.Context, w ndr.
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServiceNotifyStatusChangeParams) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -7157,6 +7214,9 @@ func (o *ServiceNotifyStatusChangeParams) UnmarshalNDR(ctx context.Context, w nd
 	})
 	_s_pszServiceNames := func(ptr interface{}) { o.ServiceNames = *ptr.(*string) }
 	if err := w.ReadPointer(&o.ServiceNames, _s_pszServiceNames, _ptr_pszServiceNames); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -7489,6 +7549,9 @@ func (o *NotifyParamsList) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.ElementsCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.NotifyParamsArray {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -7526,6 +7589,9 @@ func (o *NotifyParamsList) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 		return err
 	}
 	if err := w.ReadData(&o.ElementsCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling

--- a/msrpc/srvs/srvsvc/v3/v3.go
+++ b/msrpc/srvs/srvsvc/v3/v3.go
@@ -2921,6 +2921,9 @@ func (o *SessionInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.UserFlags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SessionInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2957,6 +2960,9 @@ func (o *SessionInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.UserFlags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3419,6 +3425,9 @@ func (o *SessionInfo10) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.IdleTime); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *SessionInfo10) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3449,6 +3458,9 @@ func (o *SessionInfo10) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.IdleTime); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -5904,6 +5916,9 @@ func (o *ShareInfo501) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ShareInfo501) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -5934,6 +5949,9 @@ func (o *ShareInfo501) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8132,6 +8150,9 @@ func (o *ServerInfo103) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Capabilities); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerInfo103) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8201,6 +8222,9 @@ func (o *ServerInfo103) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Capabilities); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -8567,6 +8591,9 @@ func (o *ServerInfo503) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.MaxFreeConnections); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerInfo503) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -8704,6 +8731,9 @@ func (o *ServerInfo503) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.MaxFreeConnections); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -9163,6 +9193,9 @@ func (o *ServerInfo599) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.MaxWorkItemIdleTime); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerInfo599) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -9344,6 +9377,9 @@ func (o *ServerInfo599) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.MaxWorkItemIdleTime); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -15911,6 +15947,9 @@ func (o *ServerTransportInfo2) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerTransportInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -15983,6 +16022,9 @@ func (o *ServerTransportInfo2) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -16280,6 +16322,9 @@ func (o *ServerTransportInfo3) MarshalNDR(ctx context.Context, w ndr.Writer) err
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerTransportInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -16363,6 +16408,9 @@ func (o *ServerTransportInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		if err := w.ReadData(&o.Password[i1]); err != nil {
 			return err
 		}
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
+		return err
 	}
 	return nil
 }
@@ -18029,6 +18077,9 @@ func (o *SiteListInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.SitesCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	for i1 := range o.Site {
 		i1 := i1
 		if uint64(i1) >= sizeInfo[0] {
@@ -18066,6 +18117,9 @@ func (o *SiteListInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.SitesCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	// XXX: for opaque unmarshaling
@@ -18165,6 +18219,9 @@ func (o *ServerAliasInfo0) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(uint32(0)); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ServerAliasInfo0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -18197,6 +18254,9 @@ func (o *ServerAliasInfo0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 	// reserved srvai0_reserved
 	var _srvai0_reserved uint32
 	if err := w.ReadData(&_srvai0_reserved); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/tsch/itaskschedulerservice/v1/v1.go
+++ b/msrpc/tsch/itaskschedulerservice/v1/v1.go
@@ -266,6 +266,9 @@ func (o *TaskUserCred) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *TaskUserCred) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -293,6 +296,9 @@ func (o *TaskUserCred) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/tsch/tsch.go
+++ b/msrpc/tsch/tsch.go
@@ -111,7 +111,7 @@ func (o *ATEnum) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(o.JobID); err != nil {
@@ -147,7 +147,7 @@ func (o *ATEnum) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	return nil
 }
 func (o *ATEnum) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData(&o.JobID); err != nil {
@@ -301,7 +301,7 @@ func (o *ATInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	if err := w.WriteAlign(10); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(ndr.Uint3264(o.JobTime)); err != nil {
@@ -334,7 +334,7 @@ func (o *ATInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	return nil
 }
 func (o *ATInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	if err := w.ReadAlign(10); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData((*ndr.Uint3264)(&o.JobTime)); err != nil {

--- a/msrpc/tsgu/tsproxyrpcinterface/v1/v1.go
+++ b/msrpc/tsgu/tsproxyrpcinterface/v1/v1.go
@@ -893,6 +893,9 @@ func (o *EndpointInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Port); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *EndpointInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -978,6 +981,9 @@ func (o *EndpointInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Port); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1433,6 +1439,9 @@ func (o *PacketVersionCaps) MarshalNDR(ctx context.Context, w ndr.Writer) error 
 	if err := w.WriteData(o.QuarantineCapabilities); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PacketVersionCaps) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1487,6 +1496,9 @@ func (o *PacketVersionCaps) UnmarshalNDR(ctx context.Context, w ndr.Reader) erro
 		return err
 	}
 	if err := w.ReadData(&o.QuarantineCapabilities); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -1680,6 +1692,9 @@ func (o *PacketQuarantineRequest) MarshalNDR(ctx context.Context, w ndr.Writer) 
 	if err := w.WriteData(o.DataLength); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PacketQuarantineRequest) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1757,6 +1772,9 @@ func (o *PacketQuarantineRequest) UnmarshalNDR(ctx context.Context, w ndr.Reader
 		return err
 	}
 	if err := w.ReadData(&o.DataLength); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2124,6 +2142,9 @@ func (o *PacketResponse) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PacketResponse) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2174,6 +2195,9 @@ func (o *PacketResponse) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		o.RedirectionFlags = &RedirectionFlags{}
 	}
 	if err := o.RedirectionFlags.UnmarshalNDR(ctx, w); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3452,6 +3476,9 @@ func (o *PacketReauth) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *PacketReauth) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3469,6 +3496,9 @@ func (o *PacketReauth) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	}
 	_swInitialPacket := uint32(o.PacketID)
 	if err := o.InitialPacket.UnmarshalUnionNDR(ctx, w, _swInitialPacket); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/w32t/w32t.go
+++ b/msrpc/w32t/w32t.go
@@ -163,6 +163,9 @@ func (o *NTPPeerInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.HostPollInterval); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *NTPPeerInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -216,6 +219,9 @@ func (o *NTPPeerInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.HostPollInterval); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil
@@ -2245,6 +2251,9 @@ func (o *ConfigurationDefault) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.FileLogFlagsFlag); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *ConfigurationDefault) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2290,6 +2299,9 @@ func (o *ConfigurationDefault) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 		return err
 	}
 	if err := w.ReadData(&o.FileLogFlagsFlag); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2964,6 +2976,9 @@ func (o *StatusInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 			return err
 		}
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *StatusInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3061,6 +3076,9 @@ func (o *StatusInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	})
 	_s_pEntries := func(ptr interface{}) { o.Entries = *ptr.(*[]*Entry) }
 	if err := w.ReadPointer(&o.Entries, _s_pEntries, _ptr_pEntries); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(8); err != nil {
 		return err
 	}
 	return nil

--- a/msrpc/wkst/wkssvc/v1/v1.go
+++ b/msrpc/wkst/wkssvc/v1/v1.go
@@ -1477,6 +1477,9 @@ func (o *StatWorkstation0) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.CurrentCommands); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *StatWorkstation0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1642,6 +1645,9 @@ func (o *StatWorkstation0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error
 	if err := w.ReadData(&o.CurrentCommands); err != nil {
 		return err
 	}
+	if err := w.ReadTrailingGap(8); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1739,6 +1745,9 @@ func (o *WorkstationInfo100) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.VerMinor); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *WorkstationInfo100) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -1772,6 +1781,9 @@ func (o *WorkstationInfo100) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.VerMinor); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2018,6 +2030,9 @@ func (o *WorkstationInfo102) MarshalNDR(ctx context.Context, w ndr.Writer) error
 	if err := w.WriteData(o.LoggedOnUsers); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *WorkstationInfo102) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2064,6 +2079,9 @@ func (o *WorkstationInfo102) UnmarshalNDR(ctx context.Context, w ndr.Reader) err
 		return err
 	}
 	if err := w.ReadData(&o.LoggedOnUsers); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -2786,6 +2804,9 @@ func (o *WorkstationTransportInfo0) MarshalNDR(ctx context.Context, w ndr.Writer
 	if err := w.WriteData(o.WANIsh); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *WorkstationTransportInfo0) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -2819,6 +2840,9 @@ func (o *WorkstationTransportInfo0) UnmarshalNDR(ctx context.Context, w ndr.Read
 		return err
 	}
 	if err := w.ReadData(&o.WANIsh); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3634,6 +3658,9 @@ func (o *UseInfo1) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.UseCount); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UseInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3680,6 +3707,9 @@ func (o *UseInfo1) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.UseCount); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil
@@ -3832,6 +3862,9 @@ func (o *UseInfo3) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Flags); err != nil {
 		return err
 	}
+	if err := w.WriteTrailingGap(9); err != nil {
+		return err
+	}
 	return nil
 }
 func (o *UseInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
@@ -3845,6 +3878,9 @@ func (o *UseInfo3) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 		return err
 	}
 	if err := w.ReadData(&o.Flags); err != nil {
+		return err
+	}
+	if err := w.ReadTrailingGap(9); err != nil {
 		return err
 	}
 	return nil

--- a/ndr/ndr.go
+++ b/ndr/ndr.go
@@ -91,6 +91,11 @@ type Reader interface {
 	// buffer.
 	ReadUnionAlign(int) error
 
+	// ReadTrailingGap function reads the trailing gap to align
+	// the last non-conformant and non-varying member to structure
+	// alignment.
+	ReadTrailingGap(int) error
+
 	// here go ReadX interface methods required to
 	// fullfill unmarshaling requirements.
 
@@ -140,6 +145,9 @@ type Writer interface {
 	// WriteUnionAlign function performs alignment of the union
 	// output buffer.
 	WriteUnionAlign(int) error
+
+	// WriteTrailingGap function writes the trailing gap.
+	WriteTrailingGap(int) error
 
 	// here go WriteX interface methods required to
 	// fullfill marshaling requirements.

--- a/ndr/ndr20.go
+++ b/ndr/ndr20.go
@@ -167,6 +167,11 @@ func (w *ndr20) WriteUnionAlign(sz int) error {
 	return w.err
 }
 
+func (w *ndr20) WriteTrailingGap(sz int) error {
+	// not used.
+	return w.err
+}
+
 // ReadAlign function read the alignment required for the data
 // of size `sz`.
 func (w *ndr20) ReadAlign(sz int) error {
@@ -183,6 +188,11 @@ func (w *ndr20) ReadAlign(sz int) error {
 }
 
 func (w *ndr20) ReadUnionAlign(sz int) error {
+	// not used.
+	return w.err
+}
+
+func (w *ndr20) ReadTrailingGap(sz int) error {
 	// not used.
 	return w.err
 }

--- a/ndr/ndr64.go
+++ b/ndr/ndr64.go
@@ -48,6 +48,10 @@ func (w *ndr64) WriteAlign(sz int) error {
 	return w.buf.FillMod(sz)
 }
 
+func (w *ndr64) WriteTrailingGap(sz int) error {
+	return w.WriteAlign(sz)
+}
+
 // WriteUnionAlign function writes the union alignment to the buffer.
 func (w *ndr64) WriteUnionAlign(sz int) error {
 	return w.WriteAlign(sz)
@@ -66,6 +70,10 @@ func (w *ndr64) ReadAlign(sz int) error {
 	}
 
 	return w.buf.SkipMod(sz)
+}
+
+func (w *ndr64) ReadTrailingGap(sz int) error {
+	return w.ReadAlign(sz)
 }
 
 // ReadUnionAlign function reads the union alignment from the buffer.


### PR DESCRIPTION
add trailing gap after last non-conformant / non-varying object for ndr64
set alignment for int3264 as 4.