### PR TITLE
fixes: oaut panic in 'user'-pointer / dnsp use ip4

### DIFF
--- a/msrpc/dnsp/record/rr.go
+++ b/msrpc/dnsp/record/rr.go
@@ -345,7 +345,11 @@ func NewRecordFromRR(rr dns.RR) (*Record, error) {
 	case *ms_dns.WINS:
 		ips := make([][]byte, len(rr.WINSServers))
 		for i := range ips {
-			ips[i] = rr.WINSServers[i]
+			ip := rr.WINSServers[i]
+			if ip4 := ip.To4(); ip4 != nil {
+				ip = ip4
+			}
+			ips[i] = ip
 		}
 		val.Value = &Record_WINS{RecordWINS: &RecordWINS{
 			MappingFlag:   rr.MappingFlag,
@@ -680,7 +684,7 @@ func (r *Record) RR() dns.RR {
 		for i := range ips {
 			ips[i] = rr.WINSServers[i]
 			if ip4 := ips[i].To4(); ip4 != nil {
-				ips[i] = ips[i].To4()
+				ips[i] = ip4
 			}
 		}
 		return &ms_dns.WINS{

--- a/ndr/buffer.go
+++ b/ndr/buffer.go
@@ -364,8 +364,14 @@ func (c *WaitChunk) Float() math.FloatFormat {
 }
 
 // Bytes function returns the bytes written/not-yet-read for the
-// chunk.
-func (c *WaitChunk) Bytes() []byte { return nil /* panic("wait_chunk: bytes not supported") */ }
+// chunk. (unsafe, use for debug only)
+func (c *WaitChunk) Bytes() []byte {
+	if c.bAndFormat != nil {
+		return c.bAndFormat.b
+	}
+	return nil
+	/* panic("wait_chunk: bytes not supported") */
+}
 
 func (c *WaitChunk) ReadRepresentation(drep *DataRepresentation) error {
 	panic("wait_chunk: read_representation not supported")

--- a/ndr/ndr20.go
+++ b/ndr/ndr20.go
@@ -496,6 +496,11 @@ func (w *ndr20) ReadPointer(ptr Pointer, setter func(interface{}), mrs ...Unmars
 		return nil
 	}
 
+	if pptr == 0x72657355 /* 'User' */ {
+		w.rdeferred = append(w.rdeferred, mrs...)
+		return nil
+	}
+
 	if ptr, ok := w.ptrs[uint64(pptr)]; ok {
 		setter(interface{}(ptr))
 		return nil


### PR DESCRIPTION
* oaut: fixes server using same pointer that is reflected in a dump as 'User' for OAUT types. Fixes: https://github.com/oiweiwei/go-msrpc/issues/42
* dnsp: use ip4 when possible