### PR TITLE
Fixed issue with NTLMv2 authentication when using NTLM hash

### DIFF
--- a/ssp/ntlm/v2.go
+++ b/ssp/ntlm/v2.go
@@ -208,9 +208,9 @@ func (v2 *V2) NTOWF(ctx context.Context, cred Credential) ([]byte, error) {
 		err error
 	)
 
-	if cred, ok := cred.(credential.Password); ok {
+	if pw, ok := cred.(credential.Password); ok {
 
-		pass, err := utf16le.Encode(cred.Password())
+		pass, err := utf16le.Encode(pw.Password())
 		if err != nil {
 			return nil, fmt.Errorf("v2: ntowf: encode password: %w", err)
 		}


### PR DESCRIPTION
`cred` variable is overwritten within conditional in `github.com/oiweiwei/go-msrpc/ssp/ntlm`, `v2.go`, line 211.

![go-msrpc-ntowf-bug](https://github.com/user-attachments/assets/4c6c5913-624c-4722-874a-61975f9623af)

This caused NTLMv2 authentication to fail when provided an NT hash, with the following error:

`init security context: security provider: ntlm: init: authenticate: compute challenge response: v2: ntowf: invalid
 key/hash credential: nthash is emtpy`

