### PR TITLE
fix: dnsp: fix nodename as its an arbitrary string

### DIFF
--- a/msrpc/dnsp/record/rr.go
+++ b/msrpc/dnsp/record/rr.go
@@ -22,11 +22,7 @@ func (o *NodeName) MarshalJSON() ([]byte, error) {
 }
 
 func (o *NodeName) String() string {
-	n := string(o.DNSName)
-	if n == "" {
-		return "."
-	}
-	return n
+	return string(o.DNSName)
 }
 
 func (o *NodeText) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
don't remember exactly why it seemed to be a good idea to return dot. as per DNS_RPC_NAME docs, it can be arbitrary string.

https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/3fd41adc-c69e-407b-979e-721251403132

https://github.com/oiweiwei/go-msrpc/issues/56