### PR TITLE
fix: add default pointer to fields labeled as unique and ptr

### DIFF
--- a/midl/scopes.go
+++ b/midl/scopes.go
@@ -219,18 +219,28 @@ string_loop:
 		}
 	}
 
+	ptrCount = 0
 	// put proper pointer dereference number.
 	// (go in reverse order).
 	// so that pointer(**ptr) -> 2, pointer(*ptr) -> 1
 	for i, pointer := len(scopes)-1, 1; i >= 0; i-- {
 		for j := len(scopes[i].Types) - 1; j >= 0; j-- {
 			if scopes[i].Types[j].Is(TypePointer) {
+				ptrCount++
 				scopes[i].Types[j].Pointer = pointer
 				pointer++
 			} else {
 				pointer = 1
 			}
 		}
+	}
+
+	if ptrCount == 0 && (f.Attrs.Pointer == PointerTypeUnique || f.Attrs.Pointer == PointerTypePtr) {
+		scopes[0].Types = append([]*ScopedType{{
+			Type:    &Type{Kind: TypePointer, Elem: scopes[0].Types[0].Type},
+			Pointer: 1,
+		}}, scopes[0].Types...)
+
 	}
 
 	return scopes

--- a/msrpc/dcom/iobjectexporter/v0/v0.go
+++ b/msrpc/dcom/iobjectexporter/v0/v0.go
@@ -692,52 +692,82 @@ func (o *xxx_ComplexPingOperation) MarshalNDRRequest(ctx context.Context, w ndr.
 			return err
 		}
 	}
-	// AddToSet {in} (1:{pointer=unique}[dim:0,size_is=cAddToSet])(2:{alias=OID}(uint64))
+	// AddToSet {in} (1:{pointer=unique}*(1)[dim:0,size_is=cAddToSet])(2:{alias=OID}(uint64))
 	{
-		dimSize1 := uint64(o.AddToSetCount)
-		if err := w.WriteSize(dimSize1); err != nil {
+		if o.AddToSet != nil || o.AddToSetCount > 0 {
+			_ptr_AddToSet := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+				dimSize1 := uint64(o.AddToSetCount)
+				if err := w.WriteSize(dimSize1); err != nil {
+					return err
+				}
+				sizeInfo := []uint64{
+					dimSize1,
+				}
+				for i1 := range o.AddToSet {
+					i1 := i1
+					if uint64(i1) >= sizeInfo[0] {
+						break
+					}
+					if err := w.WriteData(o.AddToSet[i1]); err != nil {
+						return err
+					}
+				}
+				for i1 := len(o.AddToSet); uint64(i1) < sizeInfo[0]; i1++ {
+					if err := w.WriteData(uint64(0)); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			if err := w.WritePointer(&o.AddToSet, _ptr_AddToSet); err != nil {
+				return err
+			}
+		} else {
+			if err := w.WritePointer(nil); err != nil {
+				return err
+			}
+		}
+		if err := w.WriteDeferred(); err != nil {
 			return err
-		}
-		sizeInfo := []uint64{
-			dimSize1,
-		}
-		for i1 := range o.AddToSet {
-			i1 := i1
-			if uint64(i1) >= sizeInfo[0] {
-				break
-			}
-			if err := w.WriteData(o.AddToSet[i1]); err != nil {
-				return err
-			}
-		}
-		for i1 := len(o.AddToSet); uint64(i1) < sizeInfo[0]; i1++ {
-			if err := w.WriteData(uint64(0)); err != nil {
-				return err
-			}
 		}
 	}
-	// DelFromSet {in} (1:{pointer=unique}[dim:0,size_is=cDelFromSet])(2:{alias=OID}(uint64))
+	// DelFromSet {in} (1:{pointer=unique}*(1)[dim:0,size_is=cDelFromSet])(2:{alias=OID}(uint64))
 	{
-		dimSize1 := uint64(o.DeleteFromSetCount)
-		if err := w.WriteSize(dimSize1); err != nil {
+		if o.DeleteFromSet != nil || o.DeleteFromSetCount > 0 {
+			_ptr_DelFromSet := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+				dimSize1 := uint64(o.DeleteFromSetCount)
+				if err := w.WriteSize(dimSize1); err != nil {
+					return err
+				}
+				sizeInfo := []uint64{
+					dimSize1,
+				}
+				for i1 := range o.DeleteFromSet {
+					i1 := i1
+					if uint64(i1) >= sizeInfo[0] {
+						break
+					}
+					if err := w.WriteData(o.DeleteFromSet[i1]); err != nil {
+						return err
+					}
+				}
+				for i1 := len(o.DeleteFromSet); uint64(i1) < sizeInfo[0]; i1++ {
+					if err := w.WriteData(uint64(0)); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			if err := w.WritePointer(&o.DeleteFromSet, _ptr_DelFromSet); err != nil {
+				return err
+			}
+		} else {
+			if err := w.WritePointer(nil); err != nil {
+				return err
+			}
+		}
+		if err := w.WriteDeferred(); err != nil {
 			return err
-		}
-		sizeInfo := []uint64{
-			dimSize1,
-		}
-		for i1 := range o.DeleteFromSet {
-			i1 := i1
-			if uint64(i1) >= sizeInfo[0] {
-				break
-			}
-			if err := w.WriteData(o.DeleteFromSet[i1]); err != nil {
-				return err
-			}
-		}
-		for i1 := len(o.DeleteFromSet); uint64(i1) < sizeInfo[0]; i1++ {
-			if err := w.WriteData(uint64(0)); err != nil {
-				return err
-			}
 		}
 	}
 	return nil
@@ -768,46 +798,66 @@ func (o *xxx_ComplexPingOperation) UnmarshalNDRRequest(ctx context.Context, w nd
 			return err
 		}
 	}
-	// AddToSet {in} (1:{pointer=unique}[dim:0,size_is=cAddToSet])(2:{alias=OID}(uint64))
+	// AddToSet {in} (1:{pointer=unique}*(1)[dim:0,size_is=cAddToSet])(2:{alias=OID}(uint64))
 	{
-		sizeInfo := []uint64{
-			0,
-		}
-		for sz1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
-				return err
+		_ptr_AddToSet := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+			sizeInfo := []uint64{
+				0,
 			}
-		}
-		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-			return fmt.Errorf("buffer overflow for size %d of array o.AddToSet", sizeInfo[0])
-		}
-		o.AddToSet = make([]uint64, sizeInfo[0])
-		for i1 := range o.AddToSet {
-			i1 := i1
-			if err := w.ReadData(&o.AddToSet[i1]); err != nil {
-				return err
+			for sz1 := range sizeInfo {
+				if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+					return err
+				}
 			}
+			if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+				return fmt.Errorf("buffer overflow for size %d of array o.AddToSet", sizeInfo[0])
+			}
+			o.AddToSet = make([]uint64, sizeInfo[0])
+			for i1 := range o.AddToSet {
+				i1 := i1
+				if err := w.ReadData(&o.AddToSet[i1]); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		_s_AddToSet := func(ptr interface{}) { o.AddToSet = *ptr.(*[]uint64) }
+		if err := w.ReadPointer(&o.AddToSet, _s_AddToSet, _ptr_AddToSet); err != nil {
+			return err
+		}
+		if err := w.ReadDeferred(); err != nil {
+			return err
 		}
 	}
-	// DelFromSet {in} (1:{pointer=unique}[dim:0,size_is=cDelFromSet])(2:{alias=OID}(uint64))
+	// DelFromSet {in} (1:{pointer=unique}*(1)[dim:0,size_is=cDelFromSet])(2:{alias=OID}(uint64))
 	{
-		sizeInfo := []uint64{
-			0,
-		}
-		for sz1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
-				return err
+		_ptr_DelFromSet := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+			sizeInfo := []uint64{
+				0,
 			}
-		}
-		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-			return fmt.Errorf("buffer overflow for size %d of array o.DeleteFromSet", sizeInfo[0])
-		}
-		o.DeleteFromSet = make([]uint64, sizeInfo[0])
-		for i1 := range o.DeleteFromSet {
-			i1 := i1
-			if err := w.ReadData(&o.DeleteFromSet[i1]); err != nil {
-				return err
+			for sz1 := range sizeInfo {
+				if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+					return err
+				}
 			}
+			if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+				return fmt.Errorf("buffer overflow for size %d of array o.DeleteFromSet", sizeInfo[0])
+			}
+			o.DeleteFromSet = make([]uint64, sizeInfo[0])
+			for i1 := range o.DeleteFromSet {
+				i1 := i1
+				if err := w.ReadData(&o.DeleteFromSet[i1]); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		_s_DelFromSet := func(ptr interface{}) { o.DeleteFromSet = *ptr.(*[]uint64) }
+		if err := w.ReadPointer(&o.DeleteFromSet, _s_DelFromSet, _ptr_DelFromSet); err != nil {
+			return err
+		}
+		if err := w.ReadDeferred(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/msrpc/mqmp/qmcomm/v1/v1.go
+++ b/msrpc/mqmp/qmcomm/v1/v1.go
@@ -7398,56 +7398,83 @@ func (o *xxx_SetObjectPropertiesOperation) MarshalNDRRequest(ctx context.Context
 			return err
 		}
 	}
-	// aProp {in} (1:{pointer=unique}[dim:0,size_is=cp])(2:{alias=DWORD}(uint32))
+	// aProp {in} (1:{pointer=unique}*(1)[dim:0,size_is=cp])(2:{alias=DWORD}(uint32))
 	{
-		dimSize1 := uint64(o.CreatePartition)
-		if err := w.WriteSize(dimSize1); err != nil {
+		if o.Property != nil || o.CreatePartition > 0 {
+			_ptr_aProp := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+				dimSize1 := uint64(o.CreatePartition)
+				if err := w.WriteSize(dimSize1); err != nil {
+					return err
+				}
+				sizeInfo := []uint64{
+					dimSize1,
+				}
+				for i1 := range o.Property {
+					i1 := i1
+					if uint64(i1) >= sizeInfo[0] {
+						break
+					}
+					if err := w.WriteData(o.Property[i1]); err != nil {
+						return err
+					}
+				}
+				for i1 := len(o.Property); uint64(i1) < sizeInfo[0]; i1++ {
+					if err := w.WriteData(uint32(0)); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			if err := w.WritePointer(&o.Property, _ptr_aProp); err != nil {
+				return err
+			}
+		} else {
+			if err := w.WritePointer(nil); err != nil {
+				return err
+			}
+		}
+		if err := w.WriteDeferred(); err != nil {
 			return err
-		}
-		sizeInfo := []uint64{
-			dimSize1,
-		}
-		for i1 := range o.Property {
-			i1 := i1
-			if uint64(i1) >= sizeInfo[0] {
-				break
-			}
-			if err := w.WriteData(o.Property[i1]); err != nil {
-				return err
-			}
-		}
-		for i1 := len(o.Property); uint64(i1) < sizeInfo[0]; i1++ {
-			if err := w.WriteData(uint32(0)); err != nil {
-				return err
-			}
 		}
 	}
-	// apVar {in} (1:{pointer=unique}[dim:0,size_is=cp])(2:{alias=PROPVARIANT}(struct))
+	// apVar {in} (1:{pointer=unique}*(1)[dim:0,size_is=cp])(2:{alias=PROPVARIANT}(struct))
 	{
-		dimSize1 := uint64(o.CreatePartition)
-		if err := w.WriteSize(dimSize1); err != nil {
-			return err
-		}
-		sizeInfo := []uint64{
-			dimSize1,
-		}
-		for i1 := range o.Var {
-			i1 := i1
-			if uint64(i1) >= sizeInfo[0] {
-				break
-			}
-			if o.Var[i1] != nil {
-				if err := o.Var[i1].MarshalNDR(ctx, w); err != nil {
+		if o.Var != nil || o.CreatePartition > 0 {
+			_ptr_apVar := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+				dimSize1 := uint64(o.CreatePartition)
+				if err := w.WriteSize(dimSize1); err != nil {
 					return err
 				}
-			} else {
-				if err := (&mqmq.PropertyVariant{}).MarshalNDR(ctx, w); err != nil {
-					return err
+				sizeInfo := []uint64{
+					dimSize1,
 				}
+				for i1 := range o.Var {
+					i1 := i1
+					if uint64(i1) >= sizeInfo[0] {
+						break
+					}
+					if o.Var[i1] != nil {
+						if err := o.Var[i1].MarshalNDR(ctx, w); err != nil {
+							return err
+						}
+					} else {
+						if err := (&mqmq.PropertyVariant{}).MarshalNDR(ctx, w); err != nil {
+							return err
+						}
+					}
+				}
+				for i1 := len(o.Var); uint64(i1) < sizeInfo[0]; i1++ {
+					if err := (&mqmq.PropertyVariant{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			if err := w.WritePointer(&o.Var, _ptr_apVar); err != nil {
+				return err
 			}
-		}
-		for i1 := len(o.Var); uint64(i1) < sizeInfo[0]; i1++ {
-			if err := (&mqmq.PropertyVariant{}).MarshalNDR(ctx, w); err != nil {
+		} else {
+			if err := w.WritePointer(nil); err != nil {
 				return err
 			}
 		}
@@ -7477,49 +7504,66 @@ func (o *xxx_SetObjectPropertiesOperation) UnmarshalNDRRequest(ctx context.Conte
 			return err
 		}
 	}
-	// aProp {in} (1:{pointer=unique}[dim:0,size_is=cp])(2:{alias=DWORD}(uint32))
+	// aProp {in} (1:{pointer=unique}*(1)[dim:0,size_is=cp])(2:{alias=DWORD}(uint32))
 	{
-		sizeInfo := []uint64{
-			0,
-		}
-		for sz1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
-				return err
+		_ptr_aProp := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+			sizeInfo := []uint64{
+				0,
 			}
-		}
-		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-			return fmt.Errorf("buffer overflow for size %d of array o.Property", sizeInfo[0])
-		}
-		o.Property = make([]uint32, sizeInfo[0])
-		for i1 := range o.Property {
-			i1 := i1
-			if err := w.ReadData(&o.Property[i1]); err != nil {
-				return err
+			for sz1 := range sizeInfo {
+				if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+					return err
+				}
 			}
+			if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+				return fmt.Errorf("buffer overflow for size %d of array o.Property", sizeInfo[0])
+			}
+			o.Property = make([]uint32, sizeInfo[0])
+			for i1 := range o.Property {
+				i1 := i1
+				if err := w.ReadData(&o.Property[i1]); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		_s_aProp := func(ptr interface{}) { o.Property = *ptr.(*[]uint32) }
+		if err := w.ReadPointer(&o.Property, _s_aProp, _ptr_aProp); err != nil {
+			return err
+		}
+		if err := w.ReadDeferred(); err != nil {
+			return err
 		}
 	}
-	// apVar {in} (1:{pointer=unique}[dim:0,size_is=cp])(2:{alias=PROPVARIANT}(struct))
+	// apVar {in} (1:{pointer=unique}*(1)[dim:0,size_is=cp])(2:{alias=PROPVARIANT}(struct))
 	{
-		sizeInfo := []uint64{
-			0,
-		}
-		for sz1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
-				return err
+		_ptr_apVar := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+			sizeInfo := []uint64{
+				0,
 			}
-		}
-		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-			return fmt.Errorf("buffer overflow for size %d of array o.Var", sizeInfo[0])
-		}
-		o.Var = make([]*mqmq.PropertyVariant, sizeInfo[0])
-		for i1 := range o.Var {
-			i1 := i1
-			if o.Var[i1] == nil {
-				o.Var[i1] = &mqmq.PropertyVariant{}
+			for sz1 := range sizeInfo {
+				if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+					return err
+				}
 			}
-			if err := o.Var[i1].UnmarshalNDR(ctx, w); err != nil {
-				return err
+			if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+				return fmt.Errorf("buffer overflow for size %d of array o.Var", sizeInfo[0])
 			}
+			o.Var = make([]*mqmq.PropertyVariant, sizeInfo[0])
+			for i1 := range o.Var {
+				i1 := i1
+				if o.Var[i1] == nil {
+					o.Var[i1] = &mqmq.PropertyVariant{}
+				}
+				if err := o.Var[i1].UnmarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		_s_apVar := func(ptr interface{}) { o.Var = *ptr.(*[]*mqmq.PropertyVariant) }
+		if err := w.ReadPointer(&o.Var, _s_apVar, _ptr_apVar); err != nil {
+			return err
 		}
 		if err := w.ReadDeferred(); err != nil {
 			return err

--- a/msrpc/par/iremotewinspool/v1/v1.go
+++ b/msrpc/par/iremotewinspool/v1/v1.go
@@ -12055,26 +12055,9 @@ func (o *BIDIRequestContainer) xxx_PreparePayload(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (o *BIDIRequestContainer) NDRSizeInfo() []uint64 {
-	dimSize1 := uint64(o.Count)
-	return []uint64{
-		dimSize1,
-	}
-}
 func (o *BIDIRequestContainer) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
-	}
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for sz1 := range sizeInfo {
-			if err := w.WriteSize(sizeInfo[sz1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
 	}
 	if err := w.WriteAlign(9); err != nil {
 		return err
@@ -12088,42 +12071,48 @@ func (o *BIDIRequestContainer) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
-	if err := w.WriteTrailingGap(9); err != nil {
-		return err
-	}
-	for i1 := range o.Data {
-		i1 := i1
-		if uint64(i1) >= sizeInfo[0] {
-			break
-		}
-		if o.Data[i1] != nil {
-			if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+	if o.Data != nil || o.Count > 0 {
+		_ptr_aData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+			dimSize1 := uint64(o.Count)
+			if err := w.WriteSize(dimSize1); err != nil {
 				return err
 			}
-		} else {
-			if err := (&BIDIRequestData{}).MarshalNDR(ctx, w); err != nil {
-				return err
+			sizeInfo := []uint64{
+				dimSize1,
 			}
+			for i1 := range o.Data {
+				i1 := i1
+				if uint64(i1) >= sizeInfo[0] {
+					break
+				}
+				if o.Data[i1] != nil {
+					if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				} else {
+					if err := (&BIDIRequestData{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+			}
+			for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
+				if err := (&BIDIRequestData{}).MarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err := w.WritePointer(&o.Data, _ptr_aData); err != nil {
+			return err
 		}
-	}
-	for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
-		if err := (&BIDIRequestData{}).MarshalNDR(ctx, w); err != nil {
+	} else {
+		if err := w.WritePointer(nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 func (o *BIDIRequestContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for i1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[i1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
 	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
@@ -12136,25 +12125,37 @@ func (o *BIDIRequestContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 	if err := w.ReadData(&o.Count); err != nil {
 		return err
 	}
-	if err := w.ReadTrailingGap(9); err != nil {
+	_ptr_aData := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+		sizeInfo := []uint64{
+			0,
+		}
+		for sz1 := range sizeInfo {
+			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+				return err
+			}
+		}
+		// XXX: for opaque unmarshaling
+		if o.Count > 0 && sizeInfo[0] == 0 {
+			sizeInfo[0] = uint64(o.Count)
+		}
+		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+			return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
+		}
+		o.Data = make([]*BIDIRequestData, sizeInfo[0])
+		for i1 := range o.Data {
+			i1 := i1
+			if o.Data[i1] == nil {
+				o.Data[i1] = &BIDIRequestData{}
+			}
+			if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	_s_aData := func(ptr interface{}) { o.Data = *ptr.(*[]*BIDIRequestData) }
+	if err := w.ReadPointer(&o.Data, _s_aData, _ptr_aData); err != nil {
 		return err
-	}
-	// XXX: for opaque unmarshaling
-	if o.Count > 0 && sizeInfo[0] == 0 {
-		sizeInfo[0] = uint64(o.Count)
-	}
-	if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-		return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
-	}
-	o.Data = make([]*BIDIRequestData, sizeInfo[0])
-	for i1 := range o.Data {
-		i1 := i1
-		if o.Data[i1] == nil {
-			o.Data[i1] = &BIDIRequestData{}
-		}
-		if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -12179,26 +12180,9 @@ func (o *BIDIResponseContainer) xxx_PreparePayload(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (o *BIDIResponseContainer) NDRSizeInfo() []uint64 {
-	dimSize1 := uint64(o.Count)
-	return []uint64{
-		dimSize1,
-	}
-}
 func (o *BIDIResponseContainer) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
-	}
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for sz1 := range sizeInfo {
-			if err := w.WriteSize(sizeInfo[sz1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
 	}
 	if err := w.WriteAlign(9); err != nil {
 		return err
@@ -12212,42 +12196,48 @@ func (o *BIDIResponseContainer) MarshalNDR(ctx context.Context, w ndr.Writer) er
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
-	if err := w.WriteTrailingGap(9); err != nil {
-		return err
-	}
-	for i1 := range o.Data {
-		i1 := i1
-		if uint64(i1) >= sizeInfo[0] {
-			break
-		}
-		if o.Data[i1] != nil {
-			if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+	if o.Data != nil || o.Count > 0 {
+		_ptr_aData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+			dimSize1 := uint64(o.Count)
+			if err := w.WriteSize(dimSize1); err != nil {
 				return err
 			}
-		} else {
-			if err := (&BIDIResponseData{}).MarshalNDR(ctx, w); err != nil {
-				return err
+			sizeInfo := []uint64{
+				dimSize1,
 			}
+			for i1 := range o.Data {
+				i1 := i1
+				if uint64(i1) >= sizeInfo[0] {
+					break
+				}
+				if o.Data[i1] != nil {
+					if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				} else {
+					if err := (&BIDIResponseData{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+			}
+			for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
+				if err := (&BIDIResponseData{}).MarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err := w.WritePointer(&o.Data, _ptr_aData); err != nil {
+			return err
 		}
-	}
-	for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
-		if err := (&BIDIResponseData{}).MarshalNDR(ctx, w); err != nil {
+	} else {
+		if err := w.WritePointer(nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 func (o *BIDIResponseContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for i1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[i1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
 	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
@@ -12260,25 +12250,37 @@ func (o *BIDIResponseContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 	if err := w.ReadData(&o.Count); err != nil {
 		return err
 	}
-	if err := w.ReadTrailingGap(9); err != nil {
+	_ptr_aData := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+		sizeInfo := []uint64{
+			0,
+		}
+		for sz1 := range sizeInfo {
+			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+				return err
+			}
+		}
+		// XXX: for opaque unmarshaling
+		if o.Count > 0 && sizeInfo[0] == 0 {
+			sizeInfo[0] = uint64(o.Count)
+		}
+		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+			return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
+		}
+		o.Data = make([]*BIDIResponseData, sizeInfo[0])
+		for i1 := range o.Data {
+			i1 := i1
+			if o.Data[i1] == nil {
+				o.Data[i1] = &BIDIResponseData{}
+			}
+			if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	_s_aData := func(ptr interface{}) { o.Data = *ptr.(*[]*BIDIResponseData) }
+	if err := w.ReadPointer(&o.Data, _s_aData, _ptr_aData); err != nil {
 		return err
-	}
-	// XXX: for opaque unmarshaling
-	if o.Count > 0 && sizeInfo[0] == 0 {
-		sizeInfo[0] = uint64(o.Count)
-	}
-	if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-		return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
-	}
-	o.Data = make([]*BIDIResponseData, sizeInfo[0])
-	for i1 := range o.Data {
-		i1 := i1
-		if o.Data[i1] == nil {
-			o.Data[i1] = &BIDIResponseData{}
-		}
-		if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -13609,26 +13611,9 @@ func (o *V2NotifyInfo) xxx_PreparePayload(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (o *V2NotifyInfo) NDRSizeInfo() []uint64 {
-	dimSize1 := uint64(o.Count)
-	return []uint64{
-		dimSize1,
-	}
-}
 func (o *V2NotifyInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
-	}
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for sz1 := range sizeInfo {
-			if err := w.WriteSize(sizeInfo[sz1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
 	}
 	if err := w.WriteAlign(9); err != nil {
 		return err
@@ -13642,42 +13627,48 @@ func (o *V2NotifyInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
-	if err := w.WriteTrailingGap(9); err != nil {
-		return err
-	}
-	for i1 := range o.Data {
-		i1 := i1
-		if uint64(i1) >= sizeInfo[0] {
-			break
-		}
-		if o.Data[i1] != nil {
-			if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+	if o.Data != nil || o.Count > 0 {
+		_ptr_aData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+			dimSize1 := uint64(o.Count)
+			if err := w.WriteSize(dimSize1); err != nil {
 				return err
 			}
-		} else {
-			if err := (&V2NotifyInfoData{}).MarshalNDR(ctx, w); err != nil {
-				return err
+			sizeInfo := []uint64{
+				dimSize1,
 			}
+			for i1 := range o.Data {
+				i1 := i1
+				if uint64(i1) >= sizeInfo[0] {
+					break
+				}
+				if o.Data[i1] != nil {
+					if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				} else {
+					if err := (&V2NotifyInfoData{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+			}
+			for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
+				if err := (&V2NotifyInfoData{}).MarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err := w.WritePointer(&o.Data, _ptr_aData); err != nil {
+			return err
 		}
-	}
-	for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
-		if err := (&V2NotifyInfoData{}).MarshalNDR(ctx, w); err != nil {
+	} else {
+		if err := w.WritePointer(nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 func (o *V2NotifyInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for i1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[i1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
 	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
@@ -13690,25 +13681,37 @@ func (o *V2NotifyInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.Count); err != nil {
 		return err
 	}
-	if err := w.ReadTrailingGap(9); err != nil {
+	_ptr_aData := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+		sizeInfo := []uint64{
+			0,
+		}
+		for sz1 := range sizeInfo {
+			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+				return err
+			}
+		}
+		// XXX: for opaque unmarshaling
+		if o.Count > 0 && sizeInfo[0] == 0 {
+			sizeInfo[0] = uint64(o.Count)
+		}
+		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+			return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
+		}
+		o.Data = make([]*V2NotifyInfoData, sizeInfo[0])
+		for i1 := range o.Data {
+			i1 := i1
+			if o.Data[i1] == nil {
+				o.Data[i1] = &V2NotifyInfoData{}
+			}
+			if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	_s_aData := func(ptr interface{}) { o.Data = *ptr.(*[]*V2NotifyInfoData) }
+	if err := w.ReadPointer(&o.Data, _s_aData, _ptr_aData); err != nil {
 		return err
-	}
-	// XXX: for opaque unmarshaling
-	if o.Count > 0 && sizeInfo[0] == 0 {
-		sizeInfo[0] = uint64(o.Count)
-	}
-	if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-		return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
-	}
-	o.Data = make([]*V2NotifyInfoData, sizeInfo[0])
-	for i1 := range o.Data {
-		i1 := i1
-		if o.Data[i1] == nil {
-			o.Data[i1] = &V2NotifyInfoData{}
-		}
-		if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -14953,94 +14956,95 @@ func (o *BranchOfficeJobDataContainer) xxx_PreparePayload(ctx context.Context) e
 	}
 	return nil
 }
-
-func (o *BranchOfficeJobDataContainer) NDRSizeInfo() []uint64 {
-	dimSize1 := uint64(o.JobDataEntriesCount)
-	return []uint64{
-		dimSize1,
-	}
-}
 func (o *BranchOfficeJobDataContainer) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for sz1 := range sizeInfo {
-			if err := w.WriteSize(sizeInfo[sz1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
-	if err := w.WriteAlign(8); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(o.JobDataEntriesCount); err != nil {
 		return err
 	}
-	if err := w.WriteTrailingGap(8); err != nil {
-		return err
-	}
-	for i1 := range o.JobData {
-		i1 := i1
-		if uint64(i1) >= sizeInfo[0] {
-			break
-		}
-		if o.JobData[i1] != nil {
-			if err := o.JobData[i1].MarshalNDR(ctx, w); err != nil {
+	if o.JobData != nil || o.JobDataEntriesCount > 0 {
+		_ptr_JobData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+			dimSize1 := uint64(o.JobDataEntriesCount)
+			if err := w.WriteSize(dimSize1); err != nil {
 				return err
 			}
-		} else {
-			if err := (&BranchOfficeJobData{}).MarshalNDR(ctx, w); err != nil {
-				return err
+			sizeInfo := []uint64{
+				dimSize1,
 			}
+			for i1 := range o.JobData {
+				i1 := i1
+				if uint64(i1) >= sizeInfo[0] {
+					break
+				}
+				if o.JobData[i1] != nil {
+					if err := o.JobData[i1].MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				} else {
+					if err := (&BranchOfficeJobData{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+			}
+			for i1 := len(o.JobData); uint64(i1) < sizeInfo[0]; i1++ {
+				if err := (&BranchOfficeJobData{}).MarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err := w.WritePointer(&o.JobData, _ptr_JobData); err != nil {
+			return err
 		}
-	}
-	for i1 := len(o.JobData); uint64(i1) < sizeInfo[0]; i1++ {
-		if err := (&BranchOfficeJobData{}).MarshalNDR(ctx, w); err != nil {
+	} else {
+		if err := w.WritePointer(nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 func (o *BranchOfficeJobDataContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for i1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[i1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
-	if err := w.ReadAlign(8); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData(&o.JobDataEntriesCount); err != nil {
 		return err
 	}
-	if err := w.ReadTrailingGap(8); err != nil {
+	_ptr_JobData := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+		sizeInfo := []uint64{
+			0,
+		}
+		for sz1 := range sizeInfo {
+			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+				return err
+			}
+		}
+		// XXX: for opaque unmarshaling
+		if o.JobDataEntriesCount > 0 && sizeInfo[0] == 0 {
+			sizeInfo[0] = uint64(o.JobDataEntriesCount)
+		}
+		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+			return fmt.Errorf("buffer overflow for size %d of array o.JobData", sizeInfo[0])
+		}
+		o.JobData = make([]*BranchOfficeJobData, sizeInfo[0])
+		for i1 := range o.JobData {
+			i1 := i1
+			if o.JobData[i1] == nil {
+				o.JobData[i1] = &BranchOfficeJobData{}
+			}
+			if err := o.JobData[i1].UnmarshalNDR(ctx, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	_s_JobData := func(ptr interface{}) { o.JobData = *ptr.(*[]*BranchOfficeJobData) }
+	if err := w.ReadPointer(&o.JobData, _s_JobData, _ptr_JobData); err != nil {
 		return err
-	}
-	// XXX: for opaque unmarshaling
-	if o.JobDataEntriesCount > 0 && sizeInfo[0] == 0 {
-		sizeInfo[0] = uint64(o.JobDataEntriesCount)
-	}
-	if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-		return fmt.Errorf("buffer overflow for size %d of array o.JobData", sizeInfo[0])
-	}
-	o.JobData = make([]*BranchOfficeJobData, sizeInfo[0])
-	for i1 := range o.JobData {
-		i1 := i1
-		if o.JobData[i1] == nil {
-			o.JobData[i1] = &BranchOfficeJobData{}
-		}
-		if err := o.JobData[i1].UnmarshalNDR(ctx, w); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/msrpc/rprn/winspool/v1/v1.go
+++ b/msrpc/rprn/winspool/v1/v1.go
@@ -12699,26 +12699,9 @@ func (o *BIDIRequestContainer) xxx_PreparePayload(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (o *BIDIRequestContainer) NDRSizeInfo() []uint64 {
-	dimSize1 := uint64(o.Count)
-	return []uint64{
-		dimSize1,
-	}
-}
 func (o *BIDIRequestContainer) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
-	}
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for sz1 := range sizeInfo {
-			if err := w.WriteSize(sizeInfo[sz1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
 	}
 	if err := w.WriteAlign(9); err != nil {
 		return err
@@ -12732,42 +12715,48 @@ func (o *BIDIRequestContainer) MarshalNDR(ctx context.Context, w ndr.Writer) err
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
-	if err := w.WriteTrailingGap(9); err != nil {
-		return err
-	}
-	for i1 := range o.Data {
-		i1 := i1
-		if uint64(i1) >= sizeInfo[0] {
-			break
-		}
-		if o.Data[i1] != nil {
-			if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+	if o.Data != nil || o.Count > 0 {
+		_ptr_aData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+			dimSize1 := uint64(o.Count)
+			if err := w.WriteSize(dimSize1); err != nil {
 				return err
 			}
-		} else {
-			if err := (&BIDIRequestData{}).MarshalNDR(ctx, w); err != nil {
-				return err
+			sizeInfo := []uint64{
+				dimSize1,
 			}
+			for i1 := range o.Data {
+				i1 := i1
+				if uint64(i1) >= sizeInfo[0] {
+					break
+				}
+				if o.Data[i1] != nil {
+					if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				} else {
+					if err := (&BIDIRequestData{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+			}
+			for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
+				if err := (&BIDIRequestData{}).MarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err := w.WritePointer(&o.Data, _ptr_aData); err != nil {
+			return err
 		}
-	}
-	for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
-		if err := (&BIDIRequestData{}).MarshalNDR(ctx, w); err != nil {
+	} else {
+		if err := w.WritePointer(nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 func (o *BIDIRequestContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for i1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[i1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
 	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
@@ -12780,25 +12769,37 @@ func (o *BIDIRequestContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) e
 	if err := w.ReadData(&o.Count); err != nil {
 		return err
 	}
-	if err := w.ReadTrailingGap(9); err != nil {
+	_ptr_aData := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+		sizeInfo := []uint64{
+			0,
+		}
+		for sz1 := range sizeInfo {
+			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+				return err
+			}
+		}
+		// XXX: for opaque unmarshaling
+		if o.Count > 0 && sizeInfo[0] == 0 {
+			sizeInfo[0] = uint64(o.Count)
+		}
+		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+			return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
+		}
+		o.Data = make([]*BIDIRequestData, sizeInfo[0])
+		for i1 := range o.Data {
+			i1 := i1
+			if o.Data[i1] == nil {
+				o.Data[i1] = &BIDIRequestData{}
+			}
+			if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	_s_aData := func(ptr interface{}) { o.Data = *ptr.(*[]*BIDIRequestData) }
+	if err := w.ReadPointer(&o.Data, _s_aData, _ptr_aData); err != nil {
 		return err
-	}
-	// XXX: for opaque unmarshaling
-	if o.Count > 0 && sizeInfo[0] == 0 {
-		sizeInfo[0] = uint64(o.Count)
-	}
-	if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-		return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
-	}
-	o.Data = make([]*BIDIRequestData, sizeInfo[0])
-	for i1 := range o.Data {
-		i1 := i1
-		if o.Data[i1] == nil {
-			o.Data[i1] = &BIDIRequestData{}
-		}
-		if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -12834,26 +12835,9 @@ func (o *BIDIResponseContainer) xxx_PreparePayload(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (o *BIDIResponseContainer) NDRSizeInfo() []uint64 {
-	dimSize1 := uint64(o.Count)
-	return []uint64{
-		dimSize1,
-	}
-}
 func (o *BIDIResponseContainer) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
-	}
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for sz1 := range sizeInfo {
-			if err := w.WriteSize(sizeInfo[sz1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
 	}
 	if err := w.WriteAlign(9); err != nil {
 		return err
@@ -12867,42 +12851,48 @@ func (o *BIDIResponseContainer) MarshalNDR(ctx context.Context, w ndr.Writer) er
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
-	if err := w.WriteTrailingGap(9); err != nil {
-		return err
-	}
-	for i1 := range o.Data {
-		i1 := i1
-		if uint64(i1) >= sizeInfo[0] {
-			break
-		}
-		if o.Data[i1] != nil {
-			if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+	if o.Data != nil || o.Count > 0 {
+		_ptr_aData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+			dimSize1 := uint64(o.Count)
+			if err := w.WriteSize(dimSize1); err != nil {
 				return err
 			}
-		} else {
-			if err := (&BIDIResponseData{}).MarshalNDR(ctx, w); err != nil {
-				return err
+			sizeInfo := []uint64{
+				dimSize1,
 			}
+			for i1 := range o.Data {
+				i1 := i1
+				if uint64(i1) >= sizeInfo[0] {
+					break
+				}
+				if o.Data[i1] != nil {
+					if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				} else {
+					if err := (&BIDIResponseData{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+			}
+			for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
+				if err := (&BIDIResponseData{}).MarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err := w.WritePointer(&o.Data, _ptr_aData); err != nil {
+			return err
 		}
-	}
-	for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
-		if err := (&BIDIResponseData{}).MarshalNDR(ctx, w); err != nil {
+	} else {
+		if err := w.WritePointer(nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 func (o *BIDIResponseContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for i1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[i1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
 	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
@@ -12915,25 +12905,37 @@ func (o *BIDIResponseContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) 
 	if err := w.ReadData(&o.Count); err != nil {
 		return err
 	}
-	if err := w.ReadTrailingGap(9); err != nil {
+	_ptr_aData := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+		sizeInfo := []uint64{
+			0,
+		}
+		for sz1 := range sizeInfo {
+			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+				return err
+			}
+		}
+		// XXX: for opaque unmarshaling
+		if o.Count > 0 && sizeInfo[0] == 0 {
+			sizeInfo[0] = uint64(o.Count)
+		}
+		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+			return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
+		}
+		o.Data = make([]*BIDIResponseData, sizeInfo[0])
+		for i1 := range o.Data {
+			i1 := i1
+			if o.Data[i1] == nil {
+				o.Data[i1] = &BIDIResponseData{}
+			}
+			if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	_s_aData := func(ptr interface{}) { o.Data = *ptr.(*[]*BIDIResponseData) }
+	if err := w.ReadPointer(&o.Data, _s_aData, _ptr_aData); err != nil {
 		return err
-	}
-	// XXX: for opaque unmarshaling
-	if o.Count > 0 && sizeInfo[0] == 0 {
-		sizeInfo[0] = uint64(o.Count)
-	}
-	if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-		return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
-	}
-	o.Data = make([]*BIDIResponseData, sizeInfo[0])
-	for i1 := range o.Data {
-		i1 := i1
-		if o.Data[i1] == nil {
-			o.Data[i1] = &BIDIResponseData{}
-		}
-		if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -14392,26 +14394,9 @@ func (o *V2NotifyInfo) xxx_PreparePayload(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (o *V2NotifyInfo) NDRSizeInfo() []uint64 {
-	dimSize1 := uint64(o.Count)
-	return []uint64{
-		dimSize1,
-	}
-}
 func (o *V2NotifyInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
-	}
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for sz1 := range sizeInfo {
-			if err := w.WriteSize(sizeInfo[sz1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
 	}
 	if err := w.WriteAlign(9); err != nil {
 		return err
@@ -14425,42 +14410,48 @@ func (o *V2NotifyInfo) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := w.WriteData(o.Count); err != nil {
 		return err
 	}
-	if err := w.WriteTrailingGap(9); err != nil {
-		return err
-	}
-	for i1 := range o.Data {
-		i1 := i1
-		if uint64(i1) >= sizeInfo[0] {
-			break
-		}
-		if o.Data[i1] != nil {
-			if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+	if o.Data != nil || o.Count > 0 {
+		_ptr_aData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+			dimSize1 := uint64(o.Count)
+			if err := w.WriteSize(dimSize1); err != nil {
 				return err
 			}
-		} else {
-			if err := (&V2NotifyInfoData{}).MarshalNDR(ctx, w); err != nil {
-				return err
+			sizeInfo := []uint64{
+				dimSize1,
 			}
+			for i1 := range o.Data {
+				i1 := i1
+				if uint64(i1) >= sizeInfo[0] {
+					break
+				}
+				if o.Data[i1] != nil {
+					if err := o.Data[i1].MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				} else {
+					if err := (&V2NotifyInfoData{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+			}
+			for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
+				if err := (&V2NotifyInfoData{}).MarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err := w.WritePointer(&o.Data, _ptr_aData); err != nil {
+			return err
 		}
-	}
-	for i1 := len(o.Data); uint64(i1) < sizeInfo[0]; i1++ {
-		if err := (&V2NotifyInfoData{}).MarshalNDR(ctx, w); err != nil {
+	} else {
+		if err := w.WritePointer(nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 func (o *V2NotifyInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for i1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[i1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
 	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
@@ -14473,25 +14464,37 @@ func (o *V2NotifyInfo) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
 	if err := w.ReadData(&o.Count); err != nil {
 		return err
 	}
-	if err := w.ReadTrailingGap(9); err != nil {
+	_ptr_aData := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+		sizeInfo := []uint64{
+			0,
+		}
+		for sz1 := range sizeInfo {
+			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+				return err
+			}
+		}
+		// XXX: for opaque unmarshaling
+		if o.Count > 0 && sizeInfo[0] == 0 {
+			sizeInfo[0] = uint64(o.Count)
+		}
+		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+			return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
+		}
+		o.Data = make([]*V2NotifyInfoData, sizeInfo[0])
+		for i1 := range o.Data {
+			i1 := i1
+			if o.Data[i1] == nil {
+				o.Data[i1] = &V2NotifyInfoData{}
+			}
+			if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	_s_aData := func(ptr interface{}) { o.Data = *ptr.(*[]*V2NotifyInfoData) }
+	if err := w.ReadPointer(&o.Data, _s_aData, _ptr_aData); err != nil {
 		return err
-	}
-	// XXX: for opaque unmarshaling
-	if o.Count > 0 && sizeInfo[0] == 0 {
-		sizeInfo[0] = uint64(o.Count)
-	}
-	if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-		return fmt.Errorf("buffer overflow for size %d of array o.Data", sizeInfo[0])
-	}
-	o.Data = make([]*V2NotifyInfoData, sizeInfo[0])
-	for i1 := range o.Data {
-		i1 := i1
-		if o.Data[i1] == nil {
-			o.Data[i1] = &V2NotifyInfoData{}
-		}
-		if err := o.Data[i1].UnmarshalNDR(ctx, w); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -16623,94 +16626,95 @@ func (o *BranchOfficeJobDataContainer) xxx_PreparePayload(ctx context.Context) e
 	}
 	return nil
 }
-
-func (o *BranchOfficeJobDataContainer) NDRSizeInfo() []uint64 {
-	dimSize1 := uint64(o.JobDataEntriesCount)
-	return []uint64{
-		dimSize1,
-	}
-}
 func (o *BranchOfficeJobDataContainer) MarshalNDR(ctx context.Context, w ndr.Writer) error {
 	if err := o.xxx_PreparePayload(ctx); err != nil {
 		return err
 	}
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for sz1 := range sizeInfo {
-			if err := w.WriteSize(sizeInfo[sz1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
-	if err := w.WriteAlign(8); err != nil {
+	if err := w.WriteAlign(9); err != nil {
 		return err
 	}
 	if err := w.WriteData(o.JobDataEntriesCount); err != nil {
 		return err
 	}
-	if err := w.WriteTrailingGap(8); err != nil {
-		return err
-	}
-	for i1 := range o.JobData {
-		i1 := i1
-		if uint64(i1) >= sizeInfo[0] {
-			break
-		}
-		if o.JobData[i1] != nil {
-			if err := o.JobData[i1].MarshalNDR(ctx, w); err != nil {
+	if o.JobData != nil || o.JobDataEntriesCount > 0 {
+		_ptr_JobData := ndr.MarshalNDRFunc(func(ctx context.Context, w ndr.Writer) error {
+			dimSize1 := uint64(o.JobDataEntriesCount)
+			if err := w.WriteSize(dimSize1); err != nil {
 				return err
 			}
-		} else {
-			if err := (&BranchOfficeJobData{}).MarshalNDR(ctx, w); err != nil {
-				return err
+			sizeInfo := []uint64{
+				dimSize1,
 			}
+			for i1 := range o.JobData {
+				i1 := i1
+				if uint64(i1) >= sizeInfo[0] {
+					break
+				}
+				if o.JobData[i1] != nil {
+					if err := o.JobData[i1].MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				} else {
+					if err := (&BranchOfficeJobData{}).MarshalNDR(ctx, w); err != nil {
+						return err
+					}
+				}
+			}
+			for i1 := len(o.JobData); uint64(i1) < sizeInfo[0]; i1++ {
+				if err := (&BranchOfficeJobData{}).MarshalNDR(ctx, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err := w.WritePointer(&o.JobData, _ptr_JobData); err != nil {
+			return err
 		}
-	}
-	for i1 := len(o.JobData); uint64(i1) < sizeInfo[0]; i1++ {
-		if err := (&BranchOfficeJobData{}).MarshalNDR(ctx, w); err != nil {
+	} else {
+		if err := w.WritePointer(nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 func (o *BranchOfficeJobDataContainer) UnmarshalNDR(ctx context.Context, w ndr.Reader) error {
-	sizeInfo, ok := ctx.Value(ndr.SizeInfo).([]uint64)
-	if !ok {
-		sizeInfo = o.NDRSizeInfo()
-		for i1 := range sizeInfo {
-			if err := w.ReadSize(&sizeInfo[i1]); err != nil {
-				return err
-			}
-		}
-		ctx = context.WithValue(ctx, ndr.SizeInfo, sizeInfo)
-	}
-	if err := w.ReadAlign(8); err != nil {
+	if err := w.ReadAlign(9); err != nil {
 		return err
 	}
 	if err := w.ReadData(&o.JobDataEntriesCount); err != nil {
 		return err
 	}
-	if err := w.ReadTrailingGap(8); err != nil {
+	_ptr_JobData := ndr.UnmarshalNDRFunc(func(ctx context.Context, w ndr.Reader) error {
+		sizeInfo := []uint64{
+			0,
+		}
+		for sz1 := range sizeInfo {
+			if err := w.ReadSize(&sizeInfo[sz1]); err != nil {
+				return err
+			}
+		}
+		// XXX: for opaque unmarshaling
+		if o.JobDataEntriesCount > 0 && sizeInfo[0] == 0 {
+			sizeInfo[0] = uint64(o.JobDataEntriesCount)
+		}
+		if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
+			return fmt.Errorf("buffer overflow for size %d of array o.JobData", sizeInfo[0])
+		}
+		o.JobData = make([]*BranchOfficeJobData, sizeInfo[0])
+		for i1 := range o.JobData {
+			i1 := i1
+			if o.JobData[i1] == nil {
+				o.JobData[i1] = &BranchOfficeJobData{}
+			}
+			if err := o.JobData[i1].UnmarshalNDR(ctx, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	_s_JobData := func(ptr interface{}) { o.JobData = *ptr.(*[]*BranchOfficeJobData) }
+	if err := w.ReadPointer(&o.JobData, _s_JobData, _ptr_JobData); err != nil {
 		return err
-	}
-	// XXX: for opaque unmarshaling
-	if o.JobDataEntriesCount > 0 && sizeInfo[0] == 0 {
-		sizeInfo[0] = uint64(o.JobDataEntriesCount)
-	}
-	if sizeInfo[0] > uint64(w.Len()) /* sanity-check */ {
-		return fmt.Errorf("buffer overflow for size %d of array o.JobData", sizeInfo[0])
-	}
-	o.JobData = make([]*BranchOfficeJobData, sizeInfo[0])
-	for i1 := range o.JobData {
-		i1 := i1
-		if o.JobData[i1] == nil {
-			o.JobData[i1] = &BranchOfficeJobData{}
-		}
-		if err := o.JobData[i1].UnmarshalNDR(ctx, w); err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
dcom.idl for complex ping operations says:

```
[idempotent] error_status_t ComplexPing
    (
[in]       handle_t        hRpc,
[in, out]  SETID          *pSetId,
[in]       unsigned short  SequenceNum,
[in]       unsigned short  cAddToSet,
[in]       unsigned short  cDelFromSet,
[in, unique, size_is(cAddToSet)]   OID AddToSet[],
[in, unique, size_is(cDelFromSet)] OID DelFromSet[],
[out]      unsigned short *pPingBackoffFactor      
    );
```

though, no pointer is implied, it is clear that unique pointer property must be applied to the object (that is `[]` is equal to `*`)