### PR TITLE
feat: add fragmented bind/alter-context auth support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ rpc/y.out
 develop/.vagrant
 examples/testing
 test/
+.vimrc

--- a/config/flag/command_line.go
+++ b/config/flag/command_line.go
@@ -18,7 +18,9 @@ func BindFlags(c *config.Config, flagSet *flag.FlagSet) {
 
 	flagSet.DurationVar(&c.Timeout, "timeout", c.Timeout, "timeout")
 
-	flagSet.StringVar(&c.TrasnferEncoding, "transfer-encoding", c.TrasnferEncoding, "transfer encoding: ndr20, ndr64")
+	flagSet.StringVar(&c.TransferEncoding, "transfer-encoding", c.TransferEncoding, "transfer encoding: ndr20, ndr64")
+
+	flagSet.IntVar(&c.TransportXmitSize, "transport-xmit-size", c.TransportXmitSize, "transport xmit size")
 
 	flagSet.StringVar(&c.Credential.Password, "password", c.Credential.Password, "password to authenticate with")
 	flagSet.StringVar(&c.Credential.NTHash, "nthash", c.Credential.NTHash, "NT hash to authenticate with")

--- a/dcerpc/conn.go
+++ b/dcerpc/conn.go
@@ -25,11 +25,15 @@ type BufferedConn struct {
 	cur, total []byte
 }
 
-func (conn *BufferedConn) Resized(sz int) *BufferedConn {
-	if sz > len(conn.total) {
-		conn.total = make([]byte, sz)
+func resizeBuffer(buf []byte, sz int) []byte {
+	if sz > len(buf) {
+		return make([]byte, sz)
 	}
-	conn.cur, conn.total = nil, conn.total[:sz]
+	return buf[:sz]
+}
+
+func (conn *BufferedConn) Resized(sz int) *BufferedConn {
+	conn.cur, conn.total = nil, resizeBuffer(conn.total, sz)
 	return conn
 }
 

--- a/dcerpc/packet.go
+++ b/dcerpc/packet.go
@@ -38,6 +38,21 @@ type Packet struct {
 	start, end int
 }
 
+func (p *Packet) Unset(flag PacketFlag) {
+	p.Header.PacketFlags &^= flag
+}
+
+func (p *Packet) Set(flag PacketFlag) {
+	p.Header.PacketFlags |= flag
+}
+
+func (p *Packet) PDUHeaderSize() int {
+	if sizer := p.PDU.(interface{ Size() int }); sizer != nil {
+		return HeaderSize + sizer.Size() + MaxPad + SecurityTrailerSize
+	}
+	return 0
+}
+
 func (p *Packet) IsLastFrag() bool {
 	return p.Header.PacketFlags&PacketFlagLastFrag != 0
 }
@@ -332,7 +347,7 @@ func (c *transport) EncodePacket(ctx context.Context, pkt *Packet, raw []byte) e
 	pkt.raw, pkt.end = raw, len(raw)
 
 	// set packet rpc version.
-	pkt.Header.RPCVersion, pkt.Header.RPCVersionMinor = 5, 0
+	pkt.Header.RPCVersion = 5
 	// set packet drep.
 	pkt.Header.PacketDRep = c.settings.DataRepresentation
 	// set packet type.
@@ -364,14 +379,20 @@ func (c *transport) EncodePacket(ctx context.Context, pkt *Packet, raw []byte) e
 
 	// adjust stub buffer to include security trailer.
 	if pkt.Header.AuthLength > 0 {
-		pkt.end -= MaxPad + SecurityTrailerSize + int(pkt.Header.AuthLength)
+		sz := MaxPad + SecurityTrailerSize + int(pkt.Header.AuthLength)
+		if pkt.end -= sz; pkt.end <= 0 {
+			return fmt.Errorf("encode_packet: insufficient buffer size for security trailer (%d bytes)", sz)
+		}
 	}
 
 	// XXX: verification is computed for every fragment, however it's being
 	// written only for last fragment.
 	verifyLen := pkt.VerificationTrailer.Size()
 	if verifyLen > 0 {
-		pkt.end -= VerificationTrailerMaxPad + verifyLen /* VerificationMaxPad */
+		sz := VerificationTrailerMaxPad + verifyLen /* VerificationMaxPad */
+		if pkt.end -= sz; pkt.end <= 0 {
+			return fmt.Errorf("encode_packet: insufficient buffer size for verification trailer (%d bytes)", verifyLen)
+		}
 	}
 
 	w := c.Codec(raw, pkt.Header.PacketDRep)

--- a/dcerpc/pdu.go
+++ b/dcerpc/pdu.go
@@ -70,6 +70,10 @@ type Auth3 struct {
 	Pad [4]byte
 }
 
+func (pdu *Auth3) Size() int {
+	return 4
+}
+
 func (pdu *Auth3) MarshalZerologObject(e *zerolog.Event) {}
 
 // marshal function ...
@@ -99,6 +103,14 @@ type AlterContext struct {
 	MaxRecvFrag  uint16
 	AssocGroupID uint32
 	ContextList  []*Context
+}
+
+func (pdu *AlterContext) Size() int {
+	size := 8 + 4
+	for _, ctx := range pdu.ContextList {
+		size += ctx.Size()
+	}
+	return size
 }
 
 func (pdu *AlterContext) MarshalZerologObject(e *zerolog.Event) {}
@@ -199,6 +211,14 @@ type Bind struct {
 	MaxRecvFrag  uint16
 	AssocGroupID uint32
 	ContextList  []*Context
+}
+
+func (pdu *Bind) Size() int {
+	size := 8 + 4
+	for _, ctx := range pdu.ContextList {
+		size += ctx.Size()
+	}
+	return size
 }
 
 func (pdu *Bind) MarshalZerologObject(e *zerolog.Event) {}
@@ -305,6 +325,8 @@ func (pdu *BindNak) Error() string {
 		return "bind: authentication type was not recognized"
 	case InvalidChecksum:
 		return "bind: invalid checksum"
+	case ProtocolVersionNotSupported:
+		return "bind: protocol version not supported"
 	default:
 		return "bind: unknown error"
 	}

--- a/dcerpc/transport_conn.go
+++ b/dcerpc/transport_conn.go
@@ -112,7 +112,10 @@ func (c *call) WriteBuffer(ctx context.Context, hdr Header, p []byte) error {
 func (c *transport) WriteBuffer(ctx context.Context, hdr Header, p []byte) error {
 
 	if int(hdr.FragLength) > c.settings.MaxXmitFrag {
-		return ErrPacketTooLong
+		if hdr.PacketType != PacketTypeAlterContext {
+			// XXX: allow exceeding capacity for alter-context requests (as they may contain large krb tickets)
+			return ErrPacketTooLong
+		}
 	}
 
 	p = p[:hdr.FragLength]

--- a/dcerpc/types.go
+++ b/dcerpc/types.go
@@ -14,6 +14,10 @@ type SyntaxID struct {
 	IfVersionMinor uint16
 }
 
+func (v *SyntaxID) Size() int {
+	return 16 + 2 + 2
+}
+
 func (v *SyntaxID) Is(other *SyntaxID) bool {
 	if v == nil || other == nil {
 		return false
@@ -85,6 +89,14 @@ type Context struct {
 	TransferSyntaxes []*SyntaxID
 }
 
+func (c *Context) Size() int {
+	size := 4 + c.AbstractSyntax.Size()
+	for i := range c.TransferSyntaxes {
+		size += c.TransferSyntaxes[i].Size()
+	}
+	return size
+}
+
 // marshal function ...
 func (c *Context) WriteTo(ctx context.Context, w ndr.Writer) error {
 	w.WriteData(c.ContextID)
@@ -140,6 +152,7 @@ const (
 	AbstractSyntaxNotSupported           ProviderReason = 0x0001
 	ProposedTransferSyntaxesNotSupported ProviderReason = 0x0002
 	LocalLimitExceeded                   ProviderReason = 0x0003
+	ProtocolVersionNotSupported          ProviderReason = 0x0004
 	AuthTypeNotRecognized                ProviderReason = 0x0008
 	InvalidChecksum                      ProviderReason = 0x0009
 


### PR DESCRIPTION
* add fragmented bind/alter-context support for auth trailers exceeding max negotiated size. (see: https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm)

* add boundary checks for packet encoding.

See: https://github.com/oiweiwei/go-msrpc/issues/82