### PR TITLE
fix: ssp: krb5 authentication and spnego

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/testing
 test/
 vendor/
 .vimrc
+.exrc

--- a/dcerpc/pdu.go
+++ b/dcerpc/pdu.go
@@ -499,6 +499,7 @@ func (pdu *Response) MarshalZerologObject(e *zerolog.Event) {
 func (pdu *Response) WriteTo(ctx context.Context, w ndr.Writer) error {
 	w.WriteData(pdu.AllocHint)
 	w.WriteData(pdu.ContextID)
+	w.WriteData(pdu.CancelCount)
 	w.WriteData((uint8)(0)) // pad.
 	return w.Err()
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/oiweiwei/go-math v1.0.0
 	github.com/oiweiwei/go-oem v1.0.0
 	github.com/oiweiwei/go-smb2.fork v1.0.2
-	github.com/oiweiwei/gokrb5.fork/v9 v9.0.6
+	github.com/oiweiwei/gokrb5.fork/v9 v9.0.7
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.1
 	golang.org/x/crypto v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/oiweiwei/go-oem v1.0.0 h1:77MJnres0RkNadz7oPEfsbUmZxw1XfYtl8yaxfm8bMM
 github.com/oiweiwei/go-oem v1.0.0/go.mod h1:+QzsBHKmIIYsYk6Cx+vmjBNSymazlroCVurNRzsgyIg=
 github.com/oiweiwei/go-smb2.fork v1.0.2 h1:rHCaJhX37yNg7U/R7WeoSqlZQxudu/rSxFbA4xtpK2M=
 github.com/oiweiwei/go-smb2.fork v1.0.2/go.mod h1:h0CzLVvGAmq39izdYVHKyI5cLv6aHdbQAMKEe4dz4N8=
-github.com/oiweiwei/gokrb5.fork/v9 v9.0.6 h1:ZMXO5OtzPPSqZ7KPgknVuvHE5iAbSXq5JLgzrkiXknM=
-github.com/oiweiwei/gokrb5.fork/v9 v9.0.6/go.mod h1:KEnkAYUYqZ5VwzxLFbv3JHlRhCvdFahjrdjjssMJJkI=
+github.com/oiweiwei/gokrb5.fork/v9 v9.0.7 h1:m5sNMe7ogxSQnL0SiOVNEdhc7VY/rUzbtBtFEsc2+vw=
+github.com/oiweiwei/gokrb5.fork/v9 v9.0.7/go.mod h1:KEnkAYUYqZ5VwzxLFbv3JHlRhCvdFahjrdjjssMJJkI=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
 github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=

--- a/ssp/krb5/authentifier.go
+++ b/ssp/krb5/authentifier.go
@@ -308,6 +308,10 @@ func (a *Authentifier) VerifyAPRequest(ctx context.Context, b []byte) ([]byte, e
 
 	encPart := messages.NewEncAPRepPart(a.APReq.Authenticator.SeqNumber)
 	encPart.Subkey = a.SessionKey
+	// RFC-4120: The timestamp and microsecond fields used in the reply MUST be
+	// the client's timestamp and microsecond fields (as provided in authenticator).
+	encPart.Cusec = a.APReq.Authenticator.Cusec
+	encPart.CTime = a.APReq.Authenticator.CTime
 
 	ap, err := messages.NewAPRep(a.SessionKey, encPart)
 	if err != nil {
@@ -319,11 +323,11 @@ func (a *Authentifier) VerifyAPRequest(ctx context.Context, b []byte) ([]byte, e
 		return nil, fmt.Errorf("krb5: verify apreq: aprep: marshal: %w", err)
 	}
 
+	a.APRep = &ap
+
 	if err := a.makeSecurityService(ctx); err != nil {
 		return nil, fmt.Errorf("krb5: accept: make security service: %w", err)
 	}
-
-	a.APRep = &ap
 
 	return b, nil
 }

--- a/ssp/spnego/authentifier.go
+++ b/ssp/spnego/authentifier.go
@@ -59,7 +59,8 @@ func (a *Authentifier) Negotiate(ctx context.Context) ([]byte, error) {
 func (a *Authentifier) Reject(ctx context.Context) ([]byte, error) {
 
 	resp := &NegTokenResp{
-		State: Reject,
+		State:    Reject,
+		IsTarget: true,
 	}
 
 	b, err := resp.Marshal(ctx)
@@ -108,8 +109,6 @@ func (a *Authentifier) ServerRespond(ctx context.Context, b []byte) ([]byte, err
 		return b, nil
 	}
 
-	var resp = new(NegTokenResp)
-
 	if a.IsNegTokenInit(ctx, b) {
 
 		init := &NegTokenInit{}
@@ -133,10 +132,11 @@ func (a *Authentifier) ServerRespond(ctx context.Context, b []byte) ([]byte, err
 			return nil, fmt.Errorf("spnego: init: mechanism accept: %w", err)
 		}
 
-		resp = &NegTokenResp{
+		resp := &NegTokenResp{
 			SupportedMech: (asn1.ObjectIdentifier)(a.Mechanism.Type()),
 			ResponseToken: tok.Payload,
 			State:         AcceptIncomplete,
+			IsTarget:      true,
 		}
 
 		if gssapi.IsComplete(ctx) {
@@ -159,6 +159,8 @@ func (a *Authentifier) ServerRespond(ctx context.Context, b []byte) ([]byte, err
 		return b, nil
 	}
 
+	var resp = new(NegTokenResp)
+
 	if err := resp.Unmarshal(ctx, b); err != nil {
 		return nil, fmt.Errorf("spnego: init: unmarshal neg token resp: %w", err)
 	}
@@ -174,6 +176,7 @@ func (a *Authentifier) ServerRespond(ctx context.Context, b []byte) ([]byte, err
 		SupportedMech: (asn1.ObjectIdentifier)(a.Mechanism.Type()),
 		ResponseToken: mechTok.Payload,
 		State:         AcceptIncomplete,
+		IsTarget:      true,
 	}
 
 	if a.Config.RequireMechanismListMIC {

--- a/ssp/spnego/spnego.go
+++ b/ssp/spnego/spnego.go
@@ -265,6 +265,8 @@ type NegTokenResp struct {
 	// This field, if present, contains an MIC token for the mechanism
 	// list in the initial negotiation message.
 	MechListMIC []byte
+	// IsTarget indicates whether the token is from the target or the initiator.
+	IsTarget bool
 }
 
 // Marshal function marshals the negotiate token response.
@@ -277,7 +279,7 @@ func (tok *NegTokenResp) Marshal(ctx context.Context) ([]byte, error) {
 		// NegTokenResp ::= SEQUENCE
 		b.AddASN1(cb_asn1.SEQUENCE, func(b *cb.Builder) {
 			// [0] ENUMERATED [...] OPTIONAL
-			if tok.State != 0 {
+			if tok.IsTarget {
 				b.AddASN1(cb_asn1.Tag(0).ContextSpecific().Constructed(), func(b *cb.Builder) {
 					b.AddASN1Enum(int64(tok.State))
 				})
@@ -285,9 +287,7 @@ func (tok *NegTokenResp) Marshal(ctx context.Context) ([]byte, error) {
 			// [1] MechType OPTIONAL
 			if tok.SupportedMech != nil {
 				b.AddASN1(cb_asn1.Tag(1).ContextSpecific().Constructed(), func(b *cb.Builder) {
-					b.AddASN1(cb_asn1.SEQUENCE, func(b *cb.Builder) {
-						b.AddASN1ObjectIdentifier(tok.SupportedMech)
-					})
+					b.AddASN1ObjectIdentifier(tok.SupportedMech)
 				})
 			}
 			// [2] OCTET STRING OPTIONAL
@@ -335,13 +335,7 @@ func (tok *NegTokenResp) Unmarshal(ctx context.Context, b []byte) error {
 	// [1] MechType OPTIONAL
 	if s.ReadOptionalASN1(&tag, &present, cb_asn1.Tag(1).ContextSpecific().Constructed()) {
 		if present {
-			if tag.ReadOptionalASN1(&tag, &present, cb_asn1.SEQUENCE) {
-				if present {
-					tag.ReadASN1ObjectIdentifier((*asn1.ObjectIdentifier)(&tok.SupportedMech))
-				}
-			} else {
-				return fmt.Errorf("neg_token_resp: unmarshal: mech_type sequence read error")
-			}
+			tag.ReadASN1ObjectIdentifier((*asn1.ObjectIdentifier)(&tok.SupportedMech))
 		}
 	} else {
 		return fmt.Errorf("neg_token_resp: unmarshal: mech_type read error")


### PR DESCRIPTION
 * use is_target for server-initiated spnego responses to marshal state

 * update gokrb5.fork to include correct APRep marshal/unmarshal

 * fix cusec rendering for server response

 * dcerpc: fix response marshaling
 
 fixes for: https://github.com/oiweiwei/go-msrpc/issues/163 https://github.com/oiweiwei/go-msrpc/issues/162 https://github.com/oiweiwei/go-msrpc/issues/161 https://github.com/oiweiwei/go-msrpc/issues/160 https://github.com/oiweiwei/go-msrpc/issues/159